### PR TITLE
Move service interface loading into its own class

### DIFF
--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -1,17 +1,8 @@
 package latis.server
 
-import java.io.File
-import java.net.URLClassLoader
-
-import scala.reflect.runtime.{ universe => ru }
-
 import cats.effect.ExitCode
 import cats.effect.IO
 import cats.effect.IOApp
-import cats.implicits._
-import coursier._
-import coursier.cache.FileCache
-import coursier.interop.cats._
 import org.http4s.HttpRoutes
 import org.http4s.implicits._
 import org.http4s.server.Router
@@ -21,54 +12,14 @@ import pureconfig.module.catseffect._
 
 object Latis3Server extends IOApp {
 
-  // Make Coursier use cats-effect IO.
-  val cache: FileCache[IO] = FileCache()
+  val loader: ServiceInterfaceLoader =
+    new ServiceInterfaceLoader()
 
   val getServerConf: IO[ServerConf] =
     loadConfigF[IO, ServerConf]("latis")
 
   val getServiceConf: IO[ServiceConf] =
     loadConfigF[IO, ServiceConf]("latis")
-
-  def loadService(cl: URLClassLoader, spec: ServiceSpec): IO[ServiceInterface] =
-    IO {
-      val constructor = {
-        val m = ru.runtimeMirror(cl)
-        val clss = m.staticClass(spec.clss)
-        val cm = m.reflectClass(clss)
-        val ctor = clss.toType.decl(ru.termNames.CONSTRUCTOR).asMethod
-        cm.reflectConstructor(ctor)
-      }
-      constructor().asInstanceOf[ServiceInterface]
-    }
-
-  def fetchServiceArtifacts(conf: ServiceConf): IO[List[File]] = {
-    val dependencies: List[Dependency] =
-      conf.services.map {
-        case ServiceSpec(name, version, _, _) =>
-          val nameM = ModuleName(s"${name}_2.12")
-          Dependency.of(Module(org"io.latis-data", nameM), version)
-      }
-
-    Fetch(cache).withDependencies(dependencies).io.map(_.toList)
-  }
-
-  def getClassLoader(paths: List[File]): IO[URLClassLoader] =
-    IO {
-      new URLClassLoader(
-        paths.map(_.toURI().toURL()).toArray,
-        Thread.currentThread().getContextClassLoader()
-      )
-    }
-
-  def loadServices(conf: ServiceConf): IO[List[(ServiceSpec, ServiceInterface)]] =
-    for {
-      artifacts <- fetchServiceArtifacts(conf)
-      cl        <- getClassLoader(artifacts)
-      services  <- conf.services.traverse { spec =>
-        loadService(cl, spec).map((spec, _))
-      }
-    } yield services
 
   def constructRoutes(services: List[(ServiceSpec, ServiceInterface)]): HttpRoutes[IO] = {
     val routes: List[(String, HttpRoutes[IO])] = services.map {
@@ -94,7 +45,7 @@ object Latis3Server extends IOApp {
     for {
       serverConf  <- getServerConf
       serviceConf <- getServiceConf
-      services    <- loadServices(serviceConf)
+      services    <- loader.loadServices(serviceConf)
       routes       = constructRoutes(services)
       _           <- startServer(routes, serverConf)
     } yield ExitCode.Success

--- a/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
+++ b/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
@@ -1,0 +1,69 @@
+package latis.server
+
+import java.io.File
+import java.net.URLClassLoader
+
+import scala.reflect.runtime.{ universe => ru }
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.implicits._
+import coursier._
+import coursier.cache.FileCache
+import coursier.interop.cats._
+
+final class ServiceInterfaceLoader(implicit cs: ContextShift[IO]) {
+
+  // Make Coursier use cats-effect IO.
+  val cache: FileCache[IO] = FileCache()
+
+  /**
+   * Load service interfaces described in the service interface
+   * configuration.
+   *
+   * This method downloads the service interface artifact (and its
+   * dependencies) and constructs an instance of the service
+   * interface.
+   *
+   * This only needs to be called once on server initialization.
+   */
+  def loadServices(conf: ServiceConf): IO[List[(ServiceSpec, ServiceInterface)]] =
+    for {
+      artifacts <- fetchServiceArtifacts(conf)
+      cl        <- makeClassLoader(artifacts)
+      services  <- conf.services.traverse { spec =>
+        loadService(cl, spec).map((spec, _))
+      }
+    } yield services
+
+  private def loadService(cl: URLClassLoader, spec: ServiceSpec): IO[ServiceInterface] =
+    IO {
+      val constructor = {
+        val m = ru.runtimeMirror(cl)
+        val clss = m.staticClass(spec.clss)
+        val cm = m.reflectClass(clss)
+        val ctor = clss.toType.decl(ru.termNames.CONSTRUCTOR).asMethod
+        cm.reflectConstructor(ctor)
+      }
+      constructor().asInstanceOf[ServiceInterface]
+    }
+
+  private def fetchServiceArtifacts(conf: ServiceConf): IO[List[File]] = {
+    val dependencies: List[Dependency] =
+      conf.services.map {
+        case ServiceSpec(name, version, _, _) =>
+          val nameM = ModuleName(s"${name}_2.12")
+          Dependency.of(Module(org"io.latis-data", nameM), version)
+      }
+
+    Fetch(cache).withDependencies(dependencies).io.map(_.toList)
+  }
+
+  private def makeClassLoader(paths: List[File]): IO[URLClassLoader] =
+    IO {
+      new URLClassLoader(
+        paths.map(_.toURI().toURL()).toArray,
+        Thread.currentThread().getContextClassLoader()
+      )
+    }
+}


### PR DESCRIPTION
This cleans up the main server code by moving the stuff responsible for loading service interfaces into a `ServiceInterfaceLoader` class.

`ServiceInterfaceLoader` is a class instead of an object because we need a `ContextShift` to derive a `coursier.util.Sync` instance for `IO`. We get the `ContextShift` provided by `IOApp` through the implicit constructor argument.

In the future, the `ServiceInterfaceLoader` constructor will likely require a configuration object that will control things like the cache location and what resolvers to use.