### PR TITLE
Flesh out DAP 2 service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val core = project
   )
 
 lazy val `dap2-service` = project
+  .dependsOn(core)
   .dependsOn(`service-interface`)
   .settings(commonSettings)
   .settings(

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -8,7 +8,7 @@ import org.http4s._
 import org.http4s.dsl.Http4sDsl
 
 import latis.server.ServiceInterface
-import latis.util.dap2.ConstraintParser
+import latis.util.dap2.parser.ConstraintParser
 
 class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
 

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -2,35 +2,82 @@ package latis.service.dap2
 
 import java.net.URLDecoder
 
+import scala.util.Try
+
 import cats.effect._
 import cats.implicits._
-import org.http4s._
+import org.http4s.HttpRoutes
+import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
 
+import latis.input.DatasetResolver
+import latis.model.Dataset
+import latis.ops
+import latis.ops.UnaryOperation
+import latis.output.Encoder
+import latis.output.TextEncoder
 import latis.server.ServiceInterface
+import latis.service.dap2.error._
 import latis.util.dap2.parser.ConstraintParser
+import latis.util.dap2.parser.ast
 
+/**
+ * A service interface implementing the DAP 2 specification.
+ */
 class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
 
   override def routes: HttpRoutes[IO] =
     HttpRoutes.of {
-      // I don't know how to get both the dataset and the constraint
-      // expression through the http4s DSL, so I use the DSL to handle
-      // the routing and get the query myself.
-      case req @ GET -> Root =>
-        val uri = req.uri.renderString
-
-        // TODO: This is just for demonstration purposes.
-        uri.split('?').toList match {
-          case ds :: ce :: Nil
-              if ds.nonEmpty && ce.nonEmpty =>
-            val ceDec = URLDecoder.decode(ce, "UTF-8")
-            ConstraintParser.parse(ceDec) match {
-              case Left(msg) => BadRequest(msg)
-              case Right(_)  => Ok(ceDec)
-            }
-          case ds :: Nil => Ok(ds)
-          case _ => BadRequest()
+      case req @ GET -> Root / id ~ ext =>
+        (for {
+          dataset  <- IO.fromEither(getDataset(id))
+          ops      <- IO.fromEither(getOperations(req.queryString))
+          result    = ops.foldLeft(dataset)((ds, op) => op(ds))
+          encoder  <- IO.fromEither(getEncoder(ext))
+          response <- Ok(encoder.encode(result))
+        } yield response).handleErrorWith {
+          case err: Dap2Error => handleDap2Error(err)
+          case _              => InternalServerError()
         }
+    }
+
+  private def getDataset(id: String): Either[Dap2Error, Dataset] =
+    Try(DatasetResolver.getDataset(id))
+      .toEither
+      .leftMap(_ => DatasetResolutionFailure(s"Failed to resolve dataset: $id"))
+
+  private def getOperations(query: String): Either[Dap2Error, List[UnaryOperation]] = {
+    val ce = URLDecoder.decode(query, "UTF-8")
+
+    ConstraintParser.parse(ce)
+      .leftMap(ParseFailure(_))
+      .flatMap { cexprs: ast.ConstraintExpression =>
+        cexprs.exprs.traverse {
+          case ast.Projection(vs)      => Right(ops.Projection(vs:_*))
+          case ast.Selection(n, op, v) => Right(ops.Selection(n, ast.prettyOp(op), v))
+          // TODO: Here we may need to dynamically construct an
+          // instance of an operation based on the query string and
+          // server/interface configuration.
+          case ast.Operation(n, _)  => Left(UnknownOperation(s"Unknown operation: $n"))
+        }
+      }
+  }
+
+  private def getEncoder(ext: String): Either[Dap2Error, Encoder[IO, String]] =
+    ext match {
+      case ""    => getEncoder("html")
+      case "txt" => Right(TextEncoder)
+      // TODO: Here we may need to dynamically construct an instance
+      // of an encoder based on the extension and server/interface
+      // configuration.
+      case _     => Left(UnknownExtension(s"Unknown extension: $ext"))
+    }
+
+  private def handleDap2Error(err: Dap2Error): IO[Response[IO]] =
+    err match {
+      case DatasetResolutionFailure(msg) => NotFound(msg)
+      case ParseFailure(msg)             => BadRequest(msg)
+      case UnknownExtension(msg)         => NotFound(msg)
+      case UnknownOperation(msg)         => BadRequest(msg)
     }
 }

--- a/dap2-service/src/main/scala/latis/service/dap2/error/error.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/error/error.scala
@@ -1,0 +1,7 @@
+package latis.service.dap2.error
+
+sealed trait Dap2Error extends Exception
+final case class DatasetResolutionFailure(msg: String) extends Dap2Error
+final case class ParseFailure(msg: String) extends Dap2Error
+final case class UnknownExtension(msg: String) extends Dap2Error
+final case class UnknownOperation(msg: String) extends Dap2Error

--- a/dap2-service/src/main/scala/latis/util/dap2/parser/ast.scala
+++ b/dap2-service/src/main/scala/latis/util/dap2/parser/ast.scala
@@ -42,23 +42,29 @@ object ast {
    * @param expr constraint expression to pretty print
    */
   def pretty(expr: ConstraintExpression): String = {
-    def prettyOp(op: SelectionOp): String = op match {
-      case Gt        => ">"
-      case Lt        => "<"
-      case Eq        => "="
-      case GtEq      => ">="
-      case LtEq      => "<="
-      case EqEq      => "=="
-      case NeEq      => "!="
-      case Tilde     => "~"
-      case EqTilde   => "=~"
-      case NeEqTilde => "!=~"
-    }
 
     expr.exprs.map {
       case Projection(n)       => n.mkString(",")
       case Selection(n, op, v) => s"$n${prettyOp(op)}$v"
       case Operation(n, args)  => s"$n(${args.mkString(",")})"
     }.mkString("&")
+  }
+
+  /**
+   * Pretty print a selection operator.
+   *
+   * @param op selection operator to pretty print
+   */
+  def prettyOp(op: SelectionOp): String = op match {
+    case Gt        => ">"
+    case Lt        => "<"
+    case Eq        => "="
+    case GtEq      => ">="
+    case LtEq      => "<="
+    case EqEq      => "=="
+    case NeEq      => "!="
+    case Tilde     => "~"
+    case EqTilde   => "=~"
+    case NeEqTilde => "!=~"
   }
 }

--- a/dap2-service/src/main/scala/latis/util/dap2/parser/ast.scala
+++ b/dap2-service/src/main/scala/latis/util/dap2/parser/ast.scala
@@ -1,0 +1,64 @@
+package latis.util.dap2.parser
+
+/**
+ * Module for the DAP 2 constraint expression AST.
+ */
+object ast {
+
+  sealed abstract trait CExpr
+
+  final case class Projection(
+    names: List[String]
+  ) extends CExpr
+
+  final case class Selection(
+    name: String, op: SelectionOp, value: String
+  ) extends CExpr
+
+  final case class Operation(
+    name: String, args: List[String]
+  ) extends CExpr
+
+  sealed abstract trait SelectionOp
+  final case object Gt extends SelectionOp
+  final case object Lt extends SelectionOp
+  final case object Eq extends SelectionOp
+  final case object GtEq extends SelectionOp
+  final case object LtEq extends SelectionOp
+  final case object EqEq extends SelectionOp
+  final case object NeEq extends SelectionOp
+  final case object Tilde extends SelectionOp
+  final case object EqTilde extends SelectionOp
+  final case object NeEqTilde extends SelectionOp
+
+  /**
+   * Wrapper for DAP 2 constraint expressions.
+   */
+  final case class ConstraintExpression(exprs: List[CExpr]) extends AnyVal
+
+  /**
+   * Pretty print a constraint expression.
+   *
+   * @param expr constraint expression to pretty print
+   */
+  def pretty(expr: ConstraintExpression): String = {
+    def prettyOp(op: SelectionOp): String = op match {
+      case Gt        => ">"
+      case Lt        => "<"
+      case Eq        => "="
+      case GtEq      => ">="
+      case LtEq      => "<="
+      case EqEq      => "=="
+      case NeEq      => "!="
+      case Tilde     => "~"
+      case EqTilde   => "=~"
+      case NeEqTilde => "!=~"
+    }
+
+    expr.exprs.map {
+      case Projection(n)       => n.mkString(",")
+      case Selection(n, op, v) => s"$n${prettyOp(op)}$v"
+      case Operation(n, args)  => s"$n(${args.mkString(",")})"
+    }.mkString("&")
+  }
+}

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
@@ -1,4 +1,4 @@
-package latis.util.dap2
+package latis.util.dap2.parser
 
 import org.scalacheck._
 import org.scalacheck.ScalacheckShapeless._

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
@@ -1,8 +1,9 @@
-package latis.util.dap2
+package latis.util.dap2.parser
 
 import org.junit._, Assert._
 import org.scalatest.junit.JUnitSuite
-import latis.util.dap2.ast._
+
+import ast._
 
 class TestConstraintParser extends JUnitSuite {
 


### PR DESCRIPTION
With these changes we can use the DAP 2 service to request cached datasets, but we're limited to the ASCII output. We only support selections and projections, though projections don't seem to work.

Some things to think about for the future:
- `DatasetResolver` should probably be something we construct and give to the services.
- How do we share common errors between services?
    - Datasets that can't be found, unsupported operations and formats, etc.
- How do services get encoders and operations dynamically?
- There's no logging here.