### PR TITLE
Fix model projection logic

### DIFF
--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -33,7 +33,7 @@ case class Projection(vids: String*) extends MapOperation {
       }
     case Function(d, r) => (applyToVariable(d), applyToVariable(r)) match {
       case (Some(d), Some(r)) => Some(Function(d, r))
-      case _ => ???
+      case _ => throw new UnsupportedOperationException("Both domain and range portions must be projected.")
     }
   }
   

--- a/core/src/test/scala/latis/ops/TestProjection.scala
+++ b/core/src/test/scala/latis/ops/TestProjection.scala
@@ -1,0 +1,21 @@
+package latis.ops
+
+import org.junit.Assert._
+import org.junit.Ignore
+import org.junit.Test
+import org.scalatest.junit.JUnitSuite
+import latis.model._
+
+class TestProjection {
+  
+  @Test
+  def tuple() = {
+    val model = Tuple(Scalar("a"), Scalar("b"), Scalar("c"))
+    val proj = Projection("a", "b")
+    proj.applyToModel(model) match {
+      case Tuple(a: Scalar, b: Scalar) =>
+        assertEquals("a", a.id)
+        assertEquals("b", b.id)
+    }
+  }
+}


### PR DESCRIPTION
This may be the first nail in the coffin of `DataType` extending `Traversable`. I also smell a recursion scheme.

We'll need to beef this up soon with support for Index as a non-projected domain variable place-holder and the other TODOs, but it should be sufficient to support HAPI.