### PR TITLE
Add circe dependencies and fix TextAdapter.seekingDataMarker()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.12.8"
 
-val circeVersion = "0.11.1"
 val coursierVersion   = "2.0.0-RC3-2"
 val fs2Version        = "1.0.2"
 val http4sVersion     = "0.20.10"
@@ -13,10 +12,7 @@ lazy val commonSettings = compilerFlags ++ Seq(
     "org.typelevel" %% "cats-effect"   % "1.1.0",
     "co.fs2"        %% "fs2-core"      % fs2Version,
     "co.fs2"        %% "fs2-io"        % fs2Version,
-    "com.typesafe"   % "config"        % "1.3.4",
-    "io.circe"      %% "circe-core"    % circeVersion,
-    "io.circe"      %% "circe-generic" % circeVersion,
-    "io.circe"      %% "circe-parser"  % circeVersion
+    "com.typesafe"   % "config"        % "1.3.4"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,11 @@ val pureconfigVersion = "0.10.1"
 
 lazy val commonSettings = compilerFlags ++ Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-core"     % "1.5.0",
-    "org.typelevel" %% "cats-effect"   % "1.1.0",
-    "co.fs2"        %% "fs2-core"      % fs2Version,
-    "co.fs2"        %% "fs2-io"        % fs2Version,
-    "com.typesafe"   % "config"        % "1.3.4"
+    "org.typelevel" %% "cats-core"   % "1.5.0",
+    "org.typelevel" %% "cats-effect" % "1.1.0",
+    "co.fs2"        %% "fs2-core"    % fs2Version,
+    "co.fs2"        %% "fs2-io"      % fs2Version,
+    "com.typesafe"   % "config"      % "1.3.4"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.12.8"
 
+val circeVersion = "0.11.1"
 val coursierVersion   = "2.0.0-RC3-2"
 val fs2Version        = "1.0.2"
 val http4sVersion     = "0.20.10"
@@ -8,11 +9,14 @@ val pureconfigVersion = "0.10.1"
 
 lazy val commonSettings = compilerFlags ++ Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-core"   % "1.5.0",
-    "org.typelevel" %% "cats-effect" % "1.1.0",
-    "co.fs2"        %% "fs2-core"    % fs2Version,
-    "co.fs2"        %% "fs2-io"      % fs2Version,
-    "com.typesafe"   % "config"      % "1.3.4"
+    "org.typelevel" %% "cats-core"     % "1.5.0",
+    "org.typelevel" %% "cats-effect"   % "1.1.0",
+    "co.fs2"        %% "fs2-core"      % fs2Version,
+    "co.fs2"        %% "fs2-io"        % fs2Version,
+    "com.typesafe"   % "config"        % "1.3.4",
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion
   )
 )
 

--- a/core/src/main/scala/latis/input/TextAdapter.scala
+++ b/core/src/main/scala/latis/input/TextAdapter.scala
@@ -39,7 +39,7 @@ class TextAdapter(model: DataType, config: TextAdapter.Config = new TextAdapter.
    */
   private def seekToDataMarker(marker: Option[String]): Pipe[IO, String, String] = marker match {
     case Some(m) => _.dropWhile(! _.matches(m)).drop(1)
-    case None => s: Stream[IO, String] => s
+    case None => identity
   }
 
   

--- a/core/src/main/scala/latis/input/TextAdapter.scala
+++ b/core/src/main/scala/latis/input/TextAdapter.scala
@@ -49,10 +49,10 @@ class TextAdapter(model: DataType, config: TextAdapter.Config = new TextAdapter.
     var foundDataMarker = false
     config.dataMarker match {
       case Some(marker) => {
-        //a little gymnastics to also skip the line with the marker
-        val seeking = ! foundDataMarker
+        //a little gymnastics to also skip the line with the marker (TODO: the line with the marker isn't getting skipped...)
+        //val seeking = ! foundDataMarker
         if (line.matches(marker)) foundDataMarker = true
-        seeking
+        !foundDataMarker //seeking
       }
       case None => false //no marker defined so we are not seeking
     }


### PR DESCRIPTION
While working on my `HapiJsonAdapter` in the latis3-hapi project, I realized `TextAdapter.seekingDataMarker()` didn't work.

The first problem is that `seeking` isn’t doing what the author thought. It gets set to the `!` of `foundDataMarker` (true) but then its value never updates (because it’s a val). So there’s no way for this function to stop returning true. When I changed the line below the `if` that says `seeking` to `!foundDataMarker` the function started doing what it’s supposed to.
However, it doesn’t actually skip the line with the marker like the comment says. The line containing the data marker still gets passed to `parseRecord` for processing, which I think isn’t what was intended. I don’t think this function ever did what it was designed to do. Who knows who wrote it? I left the old code commented out because there might still be a good idea there, I just don't understand it.

I also added circe to our sbt build because that's our preferred JSON library. It's not actually being used yet though, so what do people think about adding the dependencies? Would it be better not to to keep this project lean?