### PR TITLE
Latis 817

### DIFF
--- a/core/src/main/scala/latis/model/DataType.scala
+++ b/core/src/main/scala/latis/model/DataType.scala
@@ -2,6 +2,7 @@ package latis.model
 
 import latis.metadata._
 import latis.data._
+import latis.data.Data._
 import scala.collection.TraversableLike
 import scala.collection.mutable.Builder
 import scala.collection.mutable.Stack
@@ -199,7 +200,7 @@ class Scalar(val metadata: Metadata) extends DataType {
     //TODO: deal with parse errors
     //TODO: use enumeration, ADT, fdml schema
     //case Some("boolean")    => value.toBoolean
-    case Some("char")       => value.head
+//    case Some("char")       => value.head
     case Some("short")      => value.toShort
     case Some("int")        => value.toInt
     case Some("long")       => value.toLong
@@ -212,6 +213,16 @@ class Scalar(val metadata: Metadata) extends DataType {
     //TODO: class, e.g. latis.time.Time?
     case Some(s) => ??? //unsupported type s
     case None => ??? //type not defined
+  }
+
+  def formatValue(data: Data): String = data match {
+    case v: ShortValue => v.asString
+    case v: IntValue => v.asString
+    case v: LongValue => v.asString
+    case v: FloatValue => v.asString
+    case v: DoubleValue => v.asString
+    case v: StringValue => v.asString
+    case _ => throw new RuntimeException("Not a valid Scalar data value.")
   }
   
   override def toString: String = id

--- a/core/src/main/scala/latis/output/CsvEncoder.scala
+++ b/core/src/main/scala/latis/output/CsvEncoder.scala
@@ -1,0 +1,43 @@
+package latis.output
+
+import scala.util.Properties.lineSeparator
+import cats.effect.IO
+import fs2.Stream
+import latis.data.Data
+import latis.data.Sample
+import latis.model.DataType
+import latis.model.Dataset
+import latis.model.Function
+import latis.model.Scalar
+import latis.ops.Uncurry
+
+class CsvEncoder extends Encoder[IO, String] {
+
+  /**
+   * Encodes the Stream of Samples from the given Dataset as a Stream
+   * of Strings with comma separated values.
+   * @param dataset dataset to encode
+   */
+  override def encode(dataset: Dataset): Stream[IO, String] = {
+    val uncurriedDataset = Uncurry()(dataset)
+    // Encode each Sample as a String in the Stream
+    uncurriedDataset.data.streamSamples
+      .map(encodeSample(uncurriedDataset.model, _) + lineSeparator)
+  }
+
+  /**
+   * Encodes a single Sample to a String of comma separated values.
+   */
+  def encodeSample(model: DataType, sample: Sample): String = {
+    (model, sample) match {
+      case (Function(domain, range), Sample(ds, rs)) => {
+        val scalars = domain.getScalars ++ range.getScalars
+        val datas = ds ++ rs
+        (scalars zip datas).map {
+          case (s: Scalar, d: Data) =>
+            s.formatValue(d)
+        }.mkString(",")
+      }
+    }
+  }
+}

--- a/core/src/main/scala/latis/output/TextEncoder.scala
+++ b/core/src/main/scala/latis/output/TextEncoder.scala
@@ -9,7 +9,7 @@ import latis.data._
 import latis.model._
 import latis.util.StreamUtils
 
-object TextEncoder extends Encoder[IO, String] {
+class TextEncoder extends Encoder[IO, String] {
   
   /**
    * Track the level of Function nesting so we can indent.

--- a/core/src/main/scala/latis/output/TextWriter.scala
+++ b/core/src/main/scala/latis/output/TextWriter.scala
@@ -7,12 +7,12 @@ import cats.effect.IO
 import fs2._
 
 case class TextWriter(out: OutputStream) {
-  
+
   def write(dataset: Dataset): Unit =
-    TextEncoder.encode(dataset)
-               .through(text.utf8Encode)
-               .through(OutputStreamWriter.unsafeFromOutputStream[IO](out).write)
-               .compile.drain.unsafeRunSync()
+    new TextEncoder().encode(dataset)
+      .through(text.utf8Encode)
+      .through(OutputStreamWriter.unsafeFromOutputStream[IO](out).write)
+      .compile.drain.unsafeRunSync()
 
 }
 

--- a/core/src/test/scala/latis/output/CsvEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/CsvEncoderSpec.scala
@@ -1,0 +1,25 @@
+package latis.output
+
+import scala.util.Properties.lineSeparator
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import latis.model.Dataset
+
+class CsvEncoderSpec extends FlatSpec {
+
+  /**
+   * Instance of CsvEncoder for testing.
+   */
+  val enc = new CsvEncoder
+  val ds: Dataset = Dataset.fromName("data")
+  val expectedCsv = List(
+    "0,1,1.1,a",
+    "1,2,2.2,b",
+    "2,4,3.3,c"
+  ).map(_ + lineSeparator)
+
+  "A CSV encoder" should "encode a dataset to CSV" in {
+    val csvList = enc.encode(ds).compile.toList.unsafeRunSync()
+    csvList should be (expectedCsv)
+  }
+}

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -66,7 +66,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
   private def getEncoder(ext: String): Either[Dap2Error, Encoder[IO, String]] =
     ext match {
       case ""    => getEncoder("html")
-      case "txt" => Right(TextEncoder)
+      case "txt" => Right(new TextEncoder)
       // TODO: Here we may need to dynamically construct an instance
       // of an encoder based on the extension and server/interface
       // configuration.


### PR DESCRIPTION
Adding `CsvEncoder` with tests.

I made `TextEncoder` extensible because I was going to have `CsvEncoder` extend it, but it turns out we want to refactor `TextEncoder` to have different return types, so I left the change to `TextEncoder` and make `CsvEncoder` extend `Encoder` for now.