### PR TITLE
Dataset resolver order

### DIFF
--- a/core/src/main/resources/META-INF/services/latis.input.DatasetResolver
+++ b/core/src/main/resources/META-INF/services/latis.input.DatasetResolver
@@ -1,2 +1,2 @@
-latis.input.FdmlDatasetResolver
 latis.util.CacheManager
+latis.input.FdmlDatasetResolver

--- a/core/src/main/resources/META-INF/services/latis.input.DatasetResolver
+++ b/core/src/main/resources/META-INF/services/latis.input.DatasetResolver
@@ -1,2 +1,1 @@
-latis.util.CacheManager
 latis.input.FdmlDatasetResolver

--- a/core/src/main/scala/latis/dataset/AbstractDataset.scala
+++ b/core/src/main/scala/latis/dataset/AbstractDataset.scala
@@ -5,7 +5,7 @@ import latis.model.DataType
 import latis.ops.UnaryOperation
 
 /**
- * Defines metadata and model operations for a Dataset.
+ * Defines the base capabilities for a Dataset.
  */
 abstract class AbstractDataset(
   _metadata: Metadata,

--- a/core/src/main/scala/latis/dataset/Dataset.scala
+++ b/core/src/main/scala/latis/dataset/Dataset.scala
@@ -46,7 +46,7 @@ trait Dataset extends MetadataLike {
    * Causes the data source to be read and released
    * and existing Operations to be applied.
    */
-  def unsafeForce: TappedDataset = ??? //TODO: MemoizedDataset?
+  def unsafeForce(): MemoizedDataset
   
   /**
    * Puts a copy of this Dataset into the CacheManager.

--- a/core/src/main/scala/latis/dataset/MemoizedDataset.scala
+++ b/core/src/main/scala/latis/dataset/MemoizedDataset.scala
@@ -1,0 +1,19 @@
+package latis.dataset
+
+import latis.metadata.Metadata
+import latis.model.DataType
+import latis.data.MemoizedFunction
+import latis.ops.UnaryOperation
+
+/**
+ * Defines a Dataset whose data is not connected 
+ * to an external data resource. 
+ */
+class MemoizedDataset(
+  metadata: Metadata,
+  model: DataType,
+  data: MemoizedFunction,
+  operations: Seq[UnaryOperation] = Seq.empty
+) extends TappedDataset(metadata, model, data, operations) {
+  
+}

--- a/core/src/main/scala/latis/dataset/MemoizedDataset.scala
+++ b/core/src/main/scala/latis/dataset/MemoizedDataset.scala
@@ -10,10 +10,14 @@ import latis.ops.UnaryOperation
  * to an external data resource. 
  */
 class MemoizedDataset(
-  metadata: Metadata,
-  model: DataType,
-  data: MemoizedFunction,
+  _metadata: Metadata,
+  _model: DataType,
+  _data: MemoizedFunction,
   operations: Seq[UnaryOperation] = Seq.empty
-) extends TappedDataset(metadata, model, data, operations) {
-  
+) extends TappedDataset(_metadata, _model, _data, operations) {
+
+  /**
+   * Returns the data as a MemoizedFunction.
+   */
+  override def data: MemoizedFunction = _data
 }

--- a/core/src/main/scala/latis/dataset/TappedDataset.scala
+++ b/core/src/main/scala/latis/dataset/TappedDataset.scala
@@ -22,9 +22,14 @@ import latis.data.SampledFunction
 class TappedDataset(
   _metadata: Metadata,
   _model: DataType,
-  val data: SampledFunction,
+  _data: SampledFunction,
   operations: Seq[UnaryOperation] = Seq.empty
 ) extends AbstractDataset(_metadata, _model, operations) {
+
+  /**
+   * Returns the data as a SampledFunction.
+   */
+  def data: SampledFunction = _data
 
   /**
    * Returns a copy of this Dataset with the given Operation 

--- a/core/src/main/scala/latis/input/DatasetResolver.scala
+++ b/core/src/main/scala/latis/input/DatasetResolver.scala
@@ -7,6 +7,7 @@ import scala.util.Properties
 import scala.util.Try
 
 import latis.dataset.Dataset
+import latis.util.CacheManager
 import latis.util.FileUtils
 import latis.util.LatisConfig
 
@@ -22,7 +23,7 @@ trait DatasetResolver {
   /**
    * Optionally return the Dataset with the given identifier.
    * If the DatasetResolver implementation does not support the given Dataset
-   * return Null. A failure to read the data could result in an empty Dataset
+   * return None. A failure to read the data could result in an empty Dataset
    * as opposed to None.
    */
   def getDataset(id: String): Option[Dataset]
@@ -33,16 +34,22 @@ trait DatasetResolver {
 object DatasetResolver {
   
   /**
-   * Find the DatasetResolver that can provide the requested dataset by name
-   * among the DatasetResolver registered in META-INF/services/ of jar files 
-   * in the classpath.
-   * If the Dataset is not found among any resolver throw a RuntimeException.
+   * Finds a Dataset with the given identifier.
+   * 
+   * If the identified Dataset does not exist in the cache,
+   * this will find the DatasetResolver that can provide it.
+   * If the Dataset is not found among any resolver throw a 
+   * RuntimeException.
    */
   def getDataset(id: String): Dataset = {
+    //TODO: return Option, Either?
+    // could throw ServiceConfigurationError
+    CacheManager.getDataset(id).getOrElse {
     ServiceLoader.load(classOf[DatasetResolver]).asScala
       .flatMap(_.getDataset(id)).headOption.getOrElse {
         throw new RuntimeException(s"Failed to resolve dataset: $id")
       }
+    }
   }
 
 
@@ -50,6 +57,7 @@ object DatasetResolver {
    * Find all datasets and return their IDs.
    */
   def getDatasetIds: Try[Seq[String]] = {
+    //TODO: ask all DatasetResolvers to provide a list/catalog?
     val suffix = ".fdml"
     val searchPathFromConfig =
       LatisConfig.getOrElse("latis.fdml.dir", Properties.userDir)

--- a/core/src/main/scala/latis/util/CacheManager.scala
+++ b/core/src/main/scala/latis/util/CacheManager.scala
@@ -2,22 +2,6 @@ package latis.util
 
 import scala.collection._
 import latis.dataset.Dataset
-import latis.input.DatasetResolver
-
-/**
- * Manage a cache to hold instances of a Dataset in a Map with
- * the dataset identifier as the key.
- */
-class CacheManager extends DatasetResolver {
-
-  /**
-   * This method is used by the DatasetResolver ServiceLoader to determine
-   * if this can provide the requested Dataset.
-   */
-  def getDataset(id: String): Option[Dataset] = CacheManager.cache.get(id)
-
-}
-
 
 /**
  * Companion object where we encapsulate the single instance and

--- a/core/src/test/scala/latis/input/DatasetResolverSpec.scala
+++ b/core/src/test/scala/latis/input/DatasetResolverSpec.scala
@@ -1,0 +1,50 @@
+package latis.input
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+import latis.metadata.Metadata
+import latis.data._
+import latis.model._
+import latis.dataset._
+import latis.output.TextWriter
+import latis.util.CacheManager
+
+class DatasetResolverSpec extends FlatSpec {
+  
+  val dataset = {
+    val md = Metadata("data")
+    // Note, there is an fdml dataset with the same name
+    // but different structure.
+        
+    val model = Function(
+      Scalar(Metadata("id" -> "myDomain", "type" -> "int")),
+      Scalar(Metadata("id" -> "myRange", "type" -> "int"))
+    )
+    
+    val data = {
+      val samples = List(
+        Sample(DomainData(Data(1)), RangeData(Data(2)))
+      )
+      SampledFunction(samples)
+    }
+
+    new TappedDataset(md, model, data)
+  }
+  
+  dataset.cache()
+  
+  "The DatasetResolver" should "find a cached dataset before all others" in {
+    Dataset.fromName("data").model match {
+      case Function(d, _) =>
+        d.id should be ("myDomain")
+    }
+  }
+  
+  it should "find a dataset if not cached" in {
+    CacheManager.removeDataset("data")
+    Dataset.fromName("data").model match {
+      case Function(d, _) =>
+        d.id should be ("a")
+    }
+  }
+}

--- a/core/src/test/scala/latis/input/DatasetResolverSpec.scala
+++ b/core/src/test/scala/latis/input/DatasetResolverSpec.scala
@@ -31,17 +31,17 @@ class DatasetResolverSpec extends FlatSpec {
     new TappedDataset(md, model, data)
   }
   
-  dataset.cache()
   
   "The DatasetResolver" should "find a cached dataset before all others" in {
+    dataset.cache()
     Dataset.fromName("data").model match {
       case Function(d, _) =>
         d.id should be ("myDomain")
     }
+    CacheManager.removeDataset("data")
   }
   
   it should "find a dataset if not cached" in {
-    CacheManager.removeDataset("data")
     Dataset.fromName("data").model match {
       case Function(d, _) =>
         d.id should be ("a")


### PR DESCRIPTION
Checking the order meant that we needed to be able to cache in the first place. I needed to reimplement `unsafeForce` with the new Dataset package.

I played with the order of service providers in `src/main/resources/META-INF/services/latis.input.DatasetResolver` and confirmed that listing CacheManager first seems to work, but we can't count on that when we have multiple jars providing resolvers. I ended up hard-coding the `CacheManager` in the resolution code.