### PR TITLE
Move encoder implicits to package

### DIFF
--- a/core/src/main/scala/latis/output/JsonEncoder.scala
+++ b/core/src/main/scala/latis/output/JsonEncoder.scala
@@ -2,12 +2,9 @@ package latis.output
 
 import cats.effect.IO
 import fs2.Stream
-import io.circe.{Encoder => CEncoder}
 import io.circe.Json
 import io.circe.syntax._
 
-import latis.data._
-import latis.data.Data._
 import latis.dataset._
 import latis.ops.Uncurry
 
@@ -22,25 +19,4 @@ class JsonEncoder extends Encoder[IO, Json] {
     // Encode each Sample as a String in the Stream
     uncurriedDataset.samples.map(_.asJson)
   }
-
-  /** Instance of io.circe.Encoder for Sample. */
-  implicit val encodeSample: CEncoder[Sample] = new CEncoder[Sample] {
-    final def apply(s: Sample): Json = s match {
-      case Sample(ds, rs) => (ds ++ rs).asJson
-    }
-  }
-
-  /** Instance of io.circe.Encoder for Data. */
-  implicit val encodeData: CEncoder[Data] = new CEncoder[Data] {
-    final def apply(value: Data): Json = value match {
-      case x: ShortValue  => x.value.asJson
-      case x: IntValue    => x.value.asJson
-      case x: LongValue   => x.value.asJson
-      case x: FloatValue  => x.value.asJson
-      case x: DoubleValue => x.value.asJson
-      case x: StringValue => x.value.asJson
-      case x              => x.toString.asJson
-    }
-  }
-
 }

--- a/core/src/main/scala/latis/output/package.scala
+++ b/core/src/main/scala/latis/output/package.scala
@@ -1,0 +1,31 @@
+package latis
+
+import io.circe.Json
+import io.circe.{Encoder => CEncoder}
+import io.circe.syntax._
+import latis.data._
+import latis.data.Data._
+
+package object output {
+
+  /** Instance of io.circe.Encoder for Sample. */
+  implicit val encodeSample: CEncoder[Sample] = new CEncoder[Sample] {
+    final def apply(s: Sample): Json = s match {
+      case Sample(ds, rs) => (ds ++ rs).asJson
+    }
+  }
+
+  /** Instance of io.circe.Encoder for Data. */
+  implicit val encodeData: CEncoder[Data] = new CEncoder[Data] {
+    final def apply(value: Data): Json = value match {
+      case x: ShortValue  => x.value.asJson
+      case x: IntValue    => x.value.asJson
+      case x: LongValue   => x.value.asJson
+      case x: FloatValue  => x.value.asJson
+      case x: DoubleValue => x.value.asJson
+      case x: StringValue => x.value.asJson
+      case x              => x.toString.asJson
+    }
+  }
+
+}

--- a/core/src/test/scala/latis/output/JsonEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/JsonEncoderSpec.scala
@@ -30,8 +30,7 @@ class JsonEncoderSpec extends FlatSpec {
   }
 
   "A JSON encoder" should "encode a Sample to JSON" in {
-    val sample = Sample(DomainData(0), RangeData(1, 1.1, "a"))
-      .asJson
+    val sample = Sample(DomainData(0), RangeData(1, 1.1, "a")).asJson
     val expected = Json.arr(0.asJson, 1.asJson, 1.1.asJson, "a".asJson)
 
     sample should be(expected)

--- a/core/src/test/scala/latis/output/JsonEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/JsonEncoderSpec.scala
@@ -31,7 +31,7 @@ class JsonEncoderSpec extends FlatSpec {
 
   "A JSON encoder" should "encode a Sample to JSON" in {
     val sample = Sample(DomainData(0), RangeData(1, 1.1, "a"))
-      .asJson(enc.encodeSample)
+      .asJson
     val expected = Json.arr(0.asJson, 1.asJson, 1.1.asJson, "a".asJson)
 
     sample should be(expected)


### PR DESCRIPTION
This branch was supposed to be for a another json encoder that returns a stream in which each element can be read as a complete json, and not just part of a json object. It turns out, the existing json encoder already does that, so this PR just moves the implicit encoders to output/package.scala so circe is no longer a dependency of latis core.