### PR TITLE
Various version updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / organization := "io.latis-data"
-ThisBuild / scalaVersion := "2.12.8"
+ThisBuild / scalaVersion := "2.12.11"
 
 val coursierVersion   = "2.0.0-RC5-2"
 val fs2Version        = "1.0.2"
@@ -86,7 +86,7 @@ lazy val core = project
       "io.circe"               %% "circe-core"          % "0.12.3",
       "org.scodec"             %% "scodec-core"         % "1.10.3",
       "org.scodec"             %% "scodec-stream"       % "1.2.0",
-      "org.scala-lang"          % "scala-reflect"       % "2.12.8",
+      "org.scala-lang"          % "scala-reflect"       % scalaVersion.value,
       "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
       "org.tpolecat"           %% "atto-core"           % "0.7.0",
       "junit"                   % "junit"               % "4.12"  % Test

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val compilerFlags = Seq(
   )
 )
 
-val artifactory = "http://web-artifacts.lasp.colorado.edu/artifactory/"
+val artifactory = "https://web-artifacts.lasp.colorado.edu/artifactory/"
 lazy val publishSettings = Seq(
   publishTo := {
     if (isSnapshot.value) {

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,24 @@
 ThisBuild / organization := "io.latis-data"
 ThisBuild / scalaVersion := "2.12.11"
 
-val coursierVersion   = "2.0.0-RC5-2"
-val fs2Version        = "1.0.2"
-val http4sVersion     = "0.20.13"
-val pureconfigVersion = "0.12.1"
+val attoVersion       = "0.7.2"
+val catsVersion       = "2.1.1"
+val catsEffectVersion = "2.1.3"
+val coursierVersion   = "2.0.0-RC6-13"
+val fs2Version        = "2.3.0"
+val http4sVersion     = "0.21.3"
+val junitVersion      = "4.13"
+val netcdfVersion     = "5.3.1"
+val pureconfigVersion = "0.12.3"
 
 lazy val commonSettings = compilerFlags ++ Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-core"   % "1.5.0",
-    "org.typelevel" %% "cats-effect" % "1.1.0",
+    "org.typelevel" %% "cats-core"   % catsVersion,
+    "org.typelevel" %% "cats-effect" % catsEffectVersion,
     "co.fs2"        %% "fs2-core"    % fs2Version,
     "co.fs2"        %% "fs2-io"      % fs2Version,
-    "com.typesafe"   % "config"      % "1.3.4",
-    "org.scalatest" %% "scalatest"   % "3.0.5" % Test
+    "com.typesafe"   % "config"      % "1.4.0",
+    "org.scalatest" %% "scalatest"   % "3.0.8" % Test
   )
 )
 
@@ -82,14 +87,14 @@ lazy val core = project
   .settings(
     name := "latis3-core",
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-xml"           % "1.0.6",
-      "io.circe"               %% "circe-core"          % "0.12.3",
-      "org.scodec"             %% "scodec-core"         % "1.10.3",
-      "org.scodec"             %% "scodec-stream"       % "1.2.0",
       "org.scala-lang"          % "scala-reflect"       % scalaVersion.value,
+      "org.scala-lang.modules" %% "scala-xml"           % "1.3.0",
+      "io.circe"               %% "circe-core"          % "0.13.0",
+      "org.scodec"             %% "scodec-core"         % "1.11.7",
+      "org.scodec"             %% "scodec-stream"       % "2.0.0",
       "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
-      "org.tpolecat"           %% "atto-core"           % "0.7.0",
-      "junit"                   % "junit"               % "4.12"  % Test
+      "org.tpolecat"           %% "atto-core"           % attoVersion,
+      "junit"                   % "junit"               % junitVersion  % Test
     )
   )
 
@@ -109,10 +114,10 @@ lazy val `dap2-service` = project
     libraryDependencies ++= Seq(
       "org.http4s"     %% "http4s-core" % http4sVersion % Provided,
       "org.http4s"     %% "http4s-dsl"  % http4sVersion % Provided,
-      "org.tpolecat"   %% "atto-core"   % "0.7.0",
-      "org.scalacheck" %% "scalacheck"  % "1.13.5" % Test,
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % Test,
-      "junit"           % "junit"       % "4.12"  % Test
+      "org.tpolecat"   %% "atto-core"   % attoVersion,
+      "org.scalacheck" %% "scalacheck"  % "1.14.3" % Test,
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % Test,
+      "junit"           % "junit"       % junitVersion  % Test
     )
   )
 
@@ -142,8 +147,8 @@ lazy val `service-interface` = project
     name := "latis3-service-interface",
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-core" % http4sVersion,
-      "org.typelevel" %% "cats-core"   % "1.5.0",
-      "org.typelevel" %% "cats-effect" % "1.1.0"
+      "org.typelevel" %% "cats-core"   % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion
     )
   )
 
@@ -153,9 +158,9 @@ lazy val netcdf = project
   .settings(
     name := "latis3-netcdf",
     libraryDependencies ++= Seq(
-      "edu.ucar"            % "cdm-core"         % "5.3.1",
-      "edu.ucar"            % "httpservices"     % "5.3.1",
-      "edu.ucar"            % "netcdf4"          % "5.3.1",
+      "edu.ucar"            % "cdm-core"         % netcdfVersion,
+      "edu.ucar"            % "httpservices"     % netcdfVersion,
+      "edu.ucar"            % "netcdf4"          % netcdfVersion,
     ),
     resolvers ++= Seq(
       "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases"

--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,7 @@ lazy val core = project
       "io.circe"               %% "circe-core"          % "0.12.3",
       "org.scodec"             %% "scodec-core"         % "1.10.3",
       "org.scodec"             %% "scodec-stream"       % "1.2.0",
+      "org.scala-lang"          % "scala-reflect"       % "2.12.8",
       "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
       "org.tpolecat"           %% "atto-core"           % "0.7.0",
       "junit"                   % "junit"               % "4.12"  % Test

--- a/core/src/main/scala/latis/input/FileStreamSource.scala
+++ b/core/src/main/scala/latis/input/FileStreamSource.scala
@@ -9,7 +9,7 @@ import fs2.Stream
 
 import latis.util.LatisException
 import latis.util.NetUtils
-import latis.util.StreamUtils.blockingExecutionContext
+import latis.util.StreamUtils.blocker
 import latis.util.StreamUtils.contextShift
 
 /**
@@ -34,7 +34,7 @@ class FileStreamSource extends StreamSource {
         case Right(u) =>
           val fis: IO[InputStream] = IO(u.toURL.openStream) //TODO: handle exception, wrap as LatisException
           val chunkSize: Int = 4096 //TODO: tune? config option?
-          Option(readInputStream[IO](fis, chunkSize, blockingExecutionContext))
+          Option(readInputStream[IO](fis, chunkSize, blocker))
       }
 
 }

--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -5,8 +5,7 @@ import fs2.Stream
 import scodec._
 import scodec.Codec
 import scodec.bits._
-import scodec.codecs.implicits._
-import scodec.stream.{StreamEncoder, encode => sEncode}
+import scodec.stream.StreamEncoder
 import scodec.{Encoder => SEncoder}
 import latis.data.Data._
 import latis.data._
@@ -28,7 +27,7 @@ class BinaryEncoder extends Encoder[IO, BitVector] {
 
   /** Instance of scodec.stream.StreamEncoder for Sample. */
   def sampleStreamEncoder(model: DataType): StreamEncoder[Sample] =
-    sEncode.many(sampleEncoder(model))
+    StreamEncoder.many(sampleEncoder(model))
 
   def sampleEncoder(model: DataType): SEncoder[Sample] = new SEncoder[(DomainData, RangeData)] {
     def encode(sample: (DomainData, RangeData)): Attempt[BitVector] =

--- a/core/src/main/scala/latis/output/OutputStreamWriter.scala
+++ b/core/src/main/scala/latis/output/OutputStreamWriter.scala
@@ -2,9 +2,8 @@ package latis.output
 
 import java.io.OutputStream
 
-import scala.concurrent.ExecutionContext
-
 import cats.Applicative
+import cats.effect.Blocker
 import cats.effect.ContextShift
 import cats.effect.Sync
 import cats.implicits._
@@ -17,11 +16,11 @@ import latis.util.StreamUtils
  */
 class OutputStreamWriter[F[_]: ContextShift: Sync](
   outputStream: F[OutputStream],
-  blockingEC: ExecutionContext
+  blocker: Blocker
 ) extends Writer[F, Byte] {
 
   override val write: Pipe[F, Byte, Unit] =
-    fs2.io.writeOutputStream(outputStream, blockingEC)
+    fs2.io.writeOutputStream(outputStream, blocker)
 }
 
 object OutputStreamWriter {
@@ -35,5 +34,5 @@ object OutputStreamWriter {
   def unsafeFromOutputStream[F[_]: Applicative: ContextShift: Sync](
     os: OutputStream
   ): OutputStreamWriter[F] =
-    new OutputStreamWriter(os.pure[F], StreamUtils.blockingExecutionContext)
+    new OutputStreamWriter(os.pure[F], StreamUtils.blocker)
 }

--- a/core/src/main/scala/latis/util/StreamUtils.scala
+++ b/core/src/main/scala/latis/util/StreamUtils.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
 
+import cats.effect.Blocker
 import cats.effect.ContextShift
 import cats.effect.IO
 import fs2.Stream
@@ -14,11 +15,10 @@ import fs2.Stream
 object StreamUtils {
 
   /**
-   * Provide a single blocking ExecutionContext for use with
-   * fs2.io.readInputStream (e.g. UrlStreamSource).
+   * An execution context for blocking operations.
    */
-  val blockingExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool)
+  val blocker: Blocker =
+    Blocker.liftExecutorService(Executors.newCachedThreadPool())
 
   /**
    * Provide an implicit ContextShift for use with

--- a/core/src/test/scala/latis/data/TestSample.scala
+++ b/core/src/test/scala/latis/data/TestSample.scala
@@ -2,7 +2,7 @@ package latis.data
 
 import org.junit._
 import org.junit.Assert._
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 class TestSample extends JUnitSuite {
   

--- a/core/src/test/scala/latis/input/TestFdmlReader.scala
+++ b/core/src/test/scala/latis/input/TestFdmlReader.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import org.junit._
 import org.junit.Assert._
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 import latis.data._
 import latis.dataset.Dataset

--- a/core/src/test/scala/latis/metadata/TestMetadata.scala
+++ b/core/src/test/scala/latis/metadata/TestMetadata.scala
@@ -2,7 +2,7 @@ package latis.metadata
 
 import org.junit._
 import org.junit.Assert._
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 class TestMetadata extends JUnitSuite {
   

--- a/core/src/test/scala/latis/ops/TestPivot.scala
+++ b/core/src/test/scala/latis/ops/TestPivot.scala
@@ -2,7 +2,7 @@ package latis.ops
 
 import org.junit._
 import org.junit.Assert._
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 import latis.data._
 
 class TestPivot extends JUnitSuite {

--- a/core/src/test/scala/latis/ops/TestProjection.scala
+++ b/core/src/test/scala/latis/ops/TestProjection.scala
@@ -3,7 +3,7 @@ package latis.ops
 import org.junit.Assert._
 import org.junit.Ignore
 import org.junit.Test
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 import latis.metadata.Metadata
 import latis.model._

--- a/core/src/test/scala/latis/util/TestPropertiesLike.scala
+++ b/core/src/test/scala/latis/util/TestPropertiesLike.scala
@@ -2,7 +2,7 @@ package latis.util
 
 import org.junit._
 import org.junit.Assert._
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 class TestPropertiesLike extends JUnitSuite {
   

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
@@ -1,7 +1,7 @@
 package latis.util.dap2.parser
 
 import org.junit._, Assert._
-import org.scalatest.junit.JUnitSuite
+import org.scalatestplus.junit.JUnitSuite
 
 import ast._
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")

--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -9,7 +9,7 @@ import org.http4s.server.Router
 import org.http4s.server.blaze._
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
-import pureconfig.module.catseffect._
+import pureconfig.module.catseffect.syntax._
 
 object Latis3Server extends IOApp {
 


### PR DESCRIPTION
We've fallen far behind on the version of nearly everything we're using, including SBT and Scala itself. This PR updates (almost) everything and fixes whatever was necessary for the updates.

I have some notes on the last commit, but I'll copy them here for convenience:

> Note that there are still eviction warnings about cats, cats-effect,
> and fs2. These are okay because the newer versions being selected are
> compatible with the older versions required by some dependencies.
> 
> I did not update scalatest to the latest version because there was
> significant migration required. I'm also using a deprecated method
> from pureconfig-cats-effect because more thought is required on how we
> make and share execution contexts.
> 
> Some brief notes on the changes I did make:
> 
> - ScalaTest moved the JUnit integration into a separate package, so
>   the tests using JUnit have been updated accordingly.
> 
> - Cats Effect introduced a Blocker type that represents a blocking
>   execution context. I've replaced our usage of blocking execution
>   contexts with Blocker.
> 
> - The pureconfig-cats-effect and scodec-stream APIs changed slightly.