### PR TITLE
Use new BooleanData trait in unit tests

### DIFF
--- a/core/src/main/scala/latis/data/Data.scala
+++ b/core/src/main/scala/latis/data/Data.scala
@@ -120,6 +120,17 @@ object NullData extends Datum with Serializable {
 }
 
 /**
+ * BooleanData is a type of Data whose value is represented as a Boolean.
+ */
+trait BooleanData extends Any with Datum {
+  def asBoolean: Boolean
+}
+object BooleanData {
+  // Extract a Boolean from a BooleanData
+  def unapply(data: BooleanData): Option[Boolean] = Option(data.asBoolean)
+}
+
+/**
  * Define a base trait for all numeric data.
  * Implementers of Number must be able to provide values as various
  * primitive numeric types.
@@ -212,8 +223,9 @@ object Data {
   //Note, these are value classes
   //Note, these are implicit so we can construct DomainData from primitive types
 
-  implicit class BooleanValue(val value: Boolean) extends AnyVal with Datum with Serializable {
+  implicit class BooleanValue(val value: Boolean) extends AnyVal with BooleanData with Serializable {
     def asString: String = value.toString
+    def asBoolean: Boolean = value
     override def toString = s"BooleanValue($value)"
   }
 

--- a/python/src/test/scala/latis/AnomalyDataSpec.scala
+++ b/python/src/test/scala/latis/AnomalyDataSpec.scala
@@ -28,12 +28,11 @@ class AnomalyDataSpec extends FlatSpec {
     //TextWriter().write(ds)
 
     StreamUtils.unsafeHead(ds.samples) match {
-      //TODO: Need a Data trait to match on Booleans?
-      case Sample(DomainData(Number(t)), RangeData(Real(f), Real(rm), o: Data.BooleanValue)) =>
+      case Sample(DomainData(Number(t)), RangeData(Real(f), Real(rm), BooleanData(o))) =>
         t should be (1)
         f should be (0.841470985)
         rm should be (0.9432600027000001)
-        o.value should be (false)
+        o should be (false)
     }
 
   }
@@ -46,12 +45,11 @@ class AnomalyDataSpec extends FlatSpec {
     //TextWriter().write(ds)
 
     StreamUtils.unsafeHead(ds.samples) match {
-      //TODO: Need a Data trait to match on Booleans?
-      case Sample(DomainData(Number(t)), RangeData(Real(f), Real(a), o: Data.BooleanValue)) =>
+      case Sample(DomainData(Number(t)), RangeData(Real(f), Real(a), BooleanData(o))) =>
         t should be (1)
         f should be (0.841470985)
         a should be (0.5363466169117648)
-        o.value should be (false)
+        o should be (false)
     }
 
   }


### PR DESCRIPTION
This PR adds a new `BooleanData` trait to `Data.scala`. I tried naming the trait just "Boolean" but it wouldn't let me overload that name, so I went with "BooleanData". 

This buys us the ability to extract a `Boolean` value from a `BooleanValue` with pattern matching.