### PR TITLE
Add support and test for multi-D data

### DIFF
--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -25,7 +25,6 @@ import latis.util.LatisException
  * Makes a [[https://www.unidata.ucar.edu/software/netcdf/ NetCDF4]] file from a [[latis.dataset.Dataset]].
  *
  * This encoder assumes:
- *   - the dataset is uncurried
  *   - the dataset is sorted so that the first domain variable changes slowest
  *
  * Throws a `LatisExeption` if the dataset includes any of the following types:

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -24,7 +24,9 @@ import latis.util.LatisException
 /**
  * Makes a [[https://www.unidata.ucar.edu/software/netcdf/ NetCDF4]] file from a [[latis.dataset.Dataset]].
  *
- * This encoder assumes the dataset is uncurried.
+ * This encoder assumes:
+ *   - the dataset is uncurried
+ *   - the dataset is sorted so that the first domain variable changes slowest
  *
  * Throws a `LatisExeption` if the dataset includes any of the following types:
  *   - `Boolean`
@@ -142,28 +144,28 @@ object NetcdfEncoder {
       case (s, a) =>
         s.valueType match {
           case ByteValueType =>
-            val b = a.asInstanceOf[Array[Byte]].distinct;
+            val b = a.asInstanceOf[Array[Byte]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case CharValueType =>
-            val b = a.asInstanceOf[Array[Char]].distinct;
+            val b = a.asInstanceOf[Array[Char]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case ShortValueType =>
-            val b = a.asInstanceOf[Array[Short]].distinct;
+            val b = a.asInstanceOf[Array[Short]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case IntValueType =>
-            val b = a.asInstanceOf[Array[Int]].distinct;
+            val b = a.asInstanceOf[Array[Int]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case LongValueType =>
-            val b = a.asInstanceOf[Array[Long]].distinct;
+            val b = a.asInstanceOf[Array[Long]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case FloatValueType =>
-            val b = a.asInstanceOf[Array[Float]].distinct;
+            val b = a.asInstanceOf[Array[Float]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case DoubleValueType =>
-            val b = a.asInstanceOf[Array[Double]].distinct;
+            val b = a.asInstanceOf[Array[Double]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case StringValueType =>
-            val b = a.asInstanceOf[Array[String]].distinct;
+            val b = a.asInstanceOf[Array[String]].distinct
             NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
           case t => throw LatisException(s"Unsupported type: $t")
         }
@@ -216,14 +218,5 @@ object NetcdfEncoder {
       case "string" => NcDataType.STRING
       // Boolean is not supported by netCDF3
       case t => throw LatisException(s"Unsupported type: $t")
-    }
-
-  private def addVariablesFromScalars(
-    file: NetcdfFileWriter,
-    dim: Dimension,
-    ss: Seq[Scalar]
-  ): Seq[Variable] =
-    ss.map { s =>
-      file.addVariable(s.id, scalarToNetcdfDataType(s), dim.getShortName)
     }
 }

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -5,8 +5,8 @@ import java.io.File
 import cats.effect.IO
 import cats.effect.Resource
 import fs2.Stream
-import ucar.ma2.{DataType => NcDataType}
 import ucar.ma2.{Array => NcArray}
+import ucar.ma2.{DataType => NcDataType}
 import ucar.nc2.Dimension
 import ucar.nc2.NetcdfFileWriter
 import ucar.nc2.NetcdfFileWriter.Version.netcdf4
@@ -16,8 +16,8 @@ import latis.data.Data
 import latis.data.Data._
 import latis.data.Sample
 import latis.dataset.Dataset
-import latis.model._
 import latis.model.DataType
+import latis.model._
 import latis.ops.Uncurry
 import latis.util.LatisException
 
@@ -61,20 +61,29 @@ class NetcdfEncoder(file: File) extends Encoder[IO, File] {
     model: DataType,
     datasetList: Vector[Sample]
   ): Unit = model match {
-    case Function(domain: Scalar, range) =>
-      // add metadata (dimension(s) and variables)
-      val dim                 = file.addDimension(domain.id, datasetList.length)
-      val scalars             = domain +: range.getScalars
-      val vars: Seq[Variable] = addVariablesFromScalars(file, dim, scalars)
-      file.create() // create file and write metadata
+    case Function(domain, range) =>
+      val dScalars = domain.getScalars
+      val rScalars = range.getScalars
+      val scalars  = dScalars ++ rScalars
+      val acc: Accumulator =
+        accumulate(scalarsToAccumulator(scalars, datasetList.length), scalars, datasetList)
 
+      val dArrs = domainAccumulatorToNcArray(acc, dScalars)
+      val shape = dArrs.map(_.getSize.toInt).toArray
+      val rArrs = accumulatorToNcArray(acc.slice(dScalars.length, acc.length), rScalars, shape)
+
+      // add dimensions
+      dScalars.zip(shape).foreach { case (s, dim) => file.addDimension(s.id, dim) }
+      // add variables
+      val dimNames = dScalars.map(_.id).mkString(" ")
+      val dVars    = dScalars.map(s => file.addVariable(s.id, scalarToNetcdfDataType(s), s.id))
+      val rVars    = rScalars.map(s => file.addVariable(s.id, scalarToNetcdfDataType(s), dimNames))
+      file.create() // create file and write metadata
       // write data
-      val acc: Accumulator   = scalarsToAccumulator(scalars, datasetList.length)
-      val data: Seq[NcArray] = accumulate(acc, scalars, datasetList)
-      vars.zip(data).foreach { case (v, d) => file.write(v, d) }
+      (dVars ++ rVars).zip(dArrs ++ rArrs).foreach { case (v, a) => file.write(v, a) }
     case _ =>
       throw LatisException(
-        "dataset must be a function of a scalar to either a scalar or tuple of scalars"
+        "dataset must be a function where domain and range are scalars or tuples of scalars"
       )
   }
 }
@@ -85,11 +94,13 @@ object NetcdfEncoder {
 
   private type Accumulator = List[Any]
 
-  private def accumulate(acc: Accumulator, ss: Seq[Scalar], data: Seq[Sample]): Seq[NcArray] = {
+  private def accumulate(acc: Accumulator, ss: Seq[Scalar], data: Seq[Sample]): Accumulator = {
     for (i <- data.indices) yield {
       data(i) match {
-        case Sample(d, rs) =>
-          val vals: Array[Data] = (d ++ rs).toArray
+        // for each sample (row), add the domain and range values to the arrays
+        // (columns) in the accumulator.
+        case Sample(d, r) =>
+          val vals: Array[Data] = (d ++ r).toArray
           (vals, ss, acc).zipped.toList.foreach {
             case (v, s, a) =>
               s.valueType match {
@@ -113,12 +124,57 @@ object NetcdfEncoder {
           }
         case _ =>
           throw LatisException(
-            "dataset must be a function of a scalar to either a scalar or tuple of scalars"
+            "dataset must be a function where domain and range are scalars or tuples of scalars"
           )
       }
     }
-    val shape: Array[Int] = Array(data.length)
-    ss.zip(acc).map {
+    acc
+  }
+
+  /**
+   * Removes duplicate values from the input accumulator before converting to a
+   * NetCDF Array.
+   *
+   * Expects at least one input argument to be domain only.
+   */
+  private def domainAccumulatorToNcArray(acc: Accumulator, scalars: Seq[Scalar]): Seq[NcArray] =
+    scalars.zip(acc).map {
+      case (s, a) =>
+        s.valueType match {
+          case ByteValueType =>
+            val b = a.asInstanceOf[Array[Byte]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case CharValueType =>
+            val b = a.asInstanceOf[Array[Char]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case ShortValueType =>
+            val b = a.asInstanceOf[Array[Short]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case IntValueType =>
+            val b = a.asInstanceOf[Array[Int]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case LongValueType =>
+            val b = a.asInstanceOf[Array[Long]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case FloatValueType =>
+            val b = a.asInstanceOf[Array[Float]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case DoubleValueType =>
+            val b = a.asInstanceOf[Array[Double]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case StringValueType =>
+            val b = a.asInstanceOf[Array[String]].distinct;
+            NcArray.factory(scalarToNetcdfDataType(s), Array(b.length), b)
+          case t => throw LatisException(s"Unsupported type: $t")
+        }
+    }
+
+  private def accumulatorToNcArray(
+    acc: Accumulator,
+    scalars: Seq[Scalar],
+    shape: Array[Int]
+  ): Seq[NcArray] =
+    scalars.zip(acc).map {
       case (s, a) =>
         s.valueType match {
           case ByteValueType   => NcArray.factory(scalarToNetcdfDataType(s), shape, a)
@@ -132,7 +188,6 @@ object NetcdfEncoder {
           case t               => throw LatisException(s"Unsupported type: $t")
         }
     }
-  }
 
   private def scalarsToAccumulator(ss: Seq[Scalar], length: Int): Accumulator =
     ss.map(_.valueType)

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -204,15 +204,15 @@ object NetcdfEncoder {
       .toList
 
   private def scalarToNetcdfDataType(s: Scalar): NcDataType =
-    s.metadata.getProperty("type", "").toLowerCase match {
-      case "byte"   => NcDataType.BYTE
-      case "char"   => NcDataType.CHAR
-      case "short"  => NcDataType.SHORT
-      case "int"    => NcDataType.INT
-      case "long"   => NcDataType.LONG
-      case "float"  => NcDataType.FLOAT
-      case "double" => NcDataType.DOUBLE
-      case "string" => NcDataType.STRING
+    s.valueType match {
+      case ByteValueType   => NcDataType.BYTE
+      case CharValueType   => NcDataType.CHAR
+      case ShortValueType  => NcDataType.SHORT
+      case IntValueType    => NcDataType.INT
+      case LongValueType   => NcDataType.LONG
+      case FloatValueType  => NcDataType.FLOAT
+      case DoubleValueType => NcDataType.DOUBLE
+      case StringValueType => NcDataType.STRING
       // Boolean is not supported by netCDF4
       case t => throw LatisException(s"Unsupported type: $t")
     }

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -14,6 +14,7 @@ import ucar.nc2.Variable
 
 import latis.data.Data
 import latis.data.Data._
+import latis.data.Datum
 import latis.data.Sample
 import latis.dataset.Dataset
 import latis.model.DataType
@@ -72,7 +73,7 @@ class NetcdfEncoder(file: File) extends Encoder[IO, File] {
 
       val dArrs = domainAccumulatorToNcArray(acc, dScalars)
       val shape = dArrs.map(_.getSize.toInt).toArray
-      val rArrs = accumulatorToNcArray(acc.slice(dScalars.length, acc.length), rScalars, shape)
+      val rArrs = accumulatorToNcArray(acc.drop(dScalars.length), rScalars, shape)
 
       // add dimensions
       dScalars.zip(shape).foreach { case (s, dim) => file.addDimension(s.id, dim) }
@@ -212,7 +213,7 @@ object NetcdfEncoder {
       case "float"  => NcDataType.FLOAT
       case "double" => NcDataType.DOUBLE
       case "string" => NcDataType.STRING
-      // Boolean is not supported by netCDF3
+      // Boolean is not supported by netCDF4
       case t => throw LatisException(s"Unsupported type: $t")
     }
 }

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -25,6 +25,7 @@ import latis.util.LatisException
  * Makes a [[https://www.unidata.ucar.edu/software/netcdf/ NetCDF4]] file from a [[latis.dataset.Dataset]].
  *
  * This encoder assumes:
+ *   - the dataset is Cartesian with no missing values
  *   - the dataset is sorted so that the first domain variable changes slowest
  *
  * Throws a `LatisExeption` if the dataset includes any of the following types:
@@ -123,10 +124,6 @@ object NetcdfEncoder {
                 case t => throw LatisException(s"Unsupported type: $t")
               }
           }
-        case _ =>
-          throw LatisException(
-            "dataset must be a function where domain and range are scalars or tuples of scalars"
-          )
       }
     }
     acc

--- a/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
+++ b/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
@@ -64,6 +64,31 @@ class NetcdfEncoderSpec extends FlatSpec {
       file.delete()
     }
   }
+
+  it should "encode a 2-D dataset to NetCDF" in {
+    val enc          = NetcdfEncoder(new File("test3.nc"))
+    val expectedTime = Array(1, 2, 3)
+    val expectedWavelength = Array(430.1, 538.5)
+    val expectedFlag = Array[Byte](0, 0, 0, -1, 0, 0)
+    val expectedFlux = Array(1.0, 2.5, 1.2, 5.1e-2, 0.9, 2.1)
+
+    val file   = enc.encode(time_series_2D).compile.toList.unsafeRunSync().head
+    val ncFile = NetcdfFile.open(file.getAbsolutePath)
+    try {
+      val arrs    = ncFile.readArrays(ncFile.getVariables)
+      val timeArr = arrs.get(0).getDataAsByteBuffer.asIntBuffer
+      val wavelengthArr = arrs.get(1).getDataAsByteBuffer.asDoubleBuffer
+      val flagArr = arrs.get(2).getDataAsByteBuffer
+      val fluxArr = arrs.get(3).getDataAsByteBuffer.asDoubleBuffer
+      timeArr should be(IntBuffer.wrap(expectedTime))
+      wavelengthArr should be(DoubleBuffer.wrap(expectedWavelength))
+      flagArr should be(ByteBuffer.wrap(expectedFlag))
+      fluxArr should be(DoubleBuffer.wrap(expectedFlux))
+    } finally {
+      ncFile.close()
+      file.delete()
+    }
+  }
 }
 
 object NetcdfEncoderSpec {
@@ -100,6 +125,32 @@ object NetcdfEncoderSpec {
         Scalar(Metadata("flux") + ("type" -> "double")),
         Scalar(Metadata("long") + ("type" -> "long")),
         Scalar(Metadata("str") + ("type"  -> "string"))
+      )
+    )
+    val data = SampledFunction(samples)
+
+    new MemoizedDataset(md, model, data)
+  }
+
+  private val time_series_2D: MemoizedDataset = {
+    val samples = Seq(
+      Sample(DomainData(1, 430.1), RangeData(0: Byte, 1.0)),
+      Sample(DomainData(1, 538.5), RangeData(0: Byte, 2.5)),
+      Sample(DomainData(2, 430.1), RangeData(0: Byte, 1.2)),
+      Sample(DomainData(2, 538.5), RangeData(-1: Byte, 5.1e-2)),
+      Sample(DomainData(3, 430.1), RangeData(0: Byte, 0.9)),
+      Sample(DomainData(3, 538.5), RangeData(0: Byte, 2.1))
+    )
+
+    val md = Metadata("time_series_2D")
+    val model = Function(
+      Tuple(
+        Scalar(Metadata("time") + ("type" -> "int")),
+        Scalar(Metadata("wavelength") + ("type"  -> "double"))
+      ),
+      Tuple(
+        Scalar(Metadata("flag") + ("type" -> "byte")),
+        Scalar(Metadata("flux") + ("type" -> "double"))
       )
     )
     val data = SampledFunction(samples)

--- a/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
+++ b/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
@@ -91,7 +91,7 @@ class NetcdfEncoderSpec extends FlatSpec {
   }
 
   it should "encode a 3-D dataset to NetCDF" in {
-    val enc          = NetcdfEncoder(new File("test3.nc"))
+    val enc          = NetcdfEncoder(new File("test4.nc"))
     val expectedTime = Array(1, 2)
     val expectedWavelength = Array(430.1, 538.5)
     val expectedAnother = Array(1.1, 2.2)

--- a/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
+++ b/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
@@ -158,12 +158,18 @@ object NetcdfEncoderSpec {
 
   private val time_series_2D: MemoizedDataset = {
     val samples = Seq(
-      Sample(DomainData(1, 430.1), RangeData(0: Byte, 1.0)),
-      Sample(DomainData(1, 538.5), RangeData(0: Byte, 2.5)),
-      Sample(DomainData(2, 430.1), RangeData(0: Byte, 1.2)),
-      Sample(DomainData(2, 538.5), RangeData(-1: Byte, 5.1e-2)),
-      Sample(DomainData(3, 430.1), RangeData(0: Byte, 0.9)),
-      Sample(DomainData(3, 538.5), RangeData(0: Byte, 2.1))
+      Sample(DomainData(1), RangeData(SampledFunction(Seq(
+        Sample(DomainData(430.1), RangeData(0: Byte, 1.0)),
+        Sample(DomainData(538.5), RangeData(0: Byte, 2.5))
+      )))),
+      Sample(DomainData(2), RangeData(SampledFunction(Seq(
+        Sample(DomainData(430.1), RangeData(0: Byte, 1.2)),
+        Sample(DomainData(538.5), RangeData(-1: Byte, 5.1e-2))
+      )))),
+      Sample(DomainData(3), RangeData(SampledFunction(Seq(
+        Sample(DomainData(430.1), RangeData(0: Byte, 0.9)),
+        Sample(DomainData(538.5), RangeData(0: Byte, 2.1))
+      ))))
     )
 
     val md = Metadata("time_series_2D")


### PR DESCRIPTION
I think the code looks pretty ugly, but we talked about cleaning this up in the next ticket (LATIS-847). It works with the given 2-D test, and should work work for even more dimensions. I would like to add a test for a higher dimension dataset, but I'm trying to get this PR in before sprint close by the skin of my teeth.

I split the `Accumulate` function into two parts. The first is still `Accumulate`, the second is `domainAccumulatorToNcArray` for domain variables, and `AccumulatorToNcArray` for the range. The point of this is so duplicate values in the domain can be removed before converting them to NetCDF Arrays and written to  file.