### PR TITLE
Cross-build Scala 2.12 and 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: scala
+scala:
+  - 2.12.11
+  - 2.13.3
 
 cache:
   directories:

--- a/core/src/main/scala/latis/ops/Uncurry.scala
+++ b/core/src/main/scala/latis/ops/Uncurry.scala
@@ -41,12 +41,12 @@ case class Uncurry() extends FlatMapOperation {
     // Reconstruct the model from the new domain and range types
     val rtype = rs.length match {
       case 1 => rs.head
-      case _ => Tuple(rs)
+      case _ => Tuple(rs.toSeq)
     }
     ds.length match {
       case 0 => rtype
       case 1 => Function(ds.head, rtype)
-      case _ => Function(Tuple(ds), rtype)
+      case _ => Function(Tuple(ds.toSeq), rtype)
       //TODO: flatten domain, Traversable builder not working
     }
   }

--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -2,11 +2,10 @@ package latis.output
 
 import cats.effect.IO
 import fs2.Stream
-import scodec._
+import scodec.{Encoder => SEncoder, _}
 import scodec.Codec
 import scodec.bits._
 import scodec.stream.StreamEncoder
-import scodec.{Encoder => SEncoder}
 import latis.data.Data._
 import latis.data._
 import latis.dataset._

--- a/core/src/main/scala/latis/util/DefaultDatumOrdering.scala
+++ b/core/src/main/scala/latis/util/DefaultDatumOrdering.scala
@@ -20,7 +20,7 @@ object DefaultDatumOrdering extends PartialOrdering[Datum] {
   def tryCompare(x: Datum, y: Datum): Option[Int] = (x, y) match {
     case (Number(d1), Number(d2)) =>
       if (d1.isNaN || d2.isNaN) None
-      else Some(Double.compare(d1, d2))
+      else Some(Ordering[Double].compare(d1, d2))
     case (Text(s1), Text(s2)) =>
       Some(String.compare(s1, s2))
     // Make NullDatum larger than any other


### PR DESCRIPTION
(I accidentally exploded #72. This is a new PR that's the same, just against `master`.)

These changes enable building LaTiS 3 for both Scala 2.12 and 2.13.

Take a look at the [SBT docs on cross-building](https://www.scala-sbt.org/1.x/docs/Cross-Build.html), because things will be different. Specifically, running a task (like `compile`) will only run it for 2.13. You need to say `+compile` to run it for all versions. It will be interesting to see how this works with IDEs.

There were [several changes between 2.12 and 2.13](https://github.com/scala/scala/releases/tag/v2.13.0), but we only seemed to hit a few of them:

- `BinaryEncoder`: There was a change in the shadowing behavior of imports in 2.13, so the wildcard import was shadowing our own `Encoder` type even though we renamed `scodec.Encoder` in a later import statement. It looks like renaming and importing a wildcard in the same expression works, though. (See the spec on [import clauses](https://scala-lang.org/files/archive/spec/2.13/04-basic-declarations-and-definitions.html#import-clauses).)

- `Uncurry`: Varargs use `Seq`, which is now immutable, so the collections we pass to methods using varargs [must also be immutable](https://docs.scala-lang.org/overviews/core/collections-migration-213.html#scalaseq-varargs-and-scalaindexedseq-migration). I just added `.toSeq`, we could do whatever makes sense. (They were `ArrayBuffer`s, but they don't need to be.)

- `DefaultDatumOrdering`: There are now two orderings for `Double`, [`IeeeOrdering`](https://www.scala-lang.org/api/current/scala/math/Ordering$$Double$$IeeeOrdering.html) and [`TotalOrdering`](https://www.scala-lang.org/api/current/scala/math/Ordering$$Double$$TotalOrdering.html). The behavior in 2.12 is consistent with `IeeeOrdering`, but the default in 2.13 is `TotalOrdering`. ~~I didn't think very hard about this one and just made two version-specific copies of the file. We could probably come up with something better with some more thought.~~ By getting `Ordering[Double]` implicitly, I think we get the right ordering for each version.

There were some [changes to the compiler flags](https://docs.scala-lang.org/overviews/compiler-options/index.html) as well.

I've also updated the Travis build to build and test for both versions of Scala.

I can't say that publishing will work, but I couldn't say that it would work before either. That's something we'll need to test when we get there.