### PR TITLE
Add metadata to NetCDF encoder

### DIFF
--- a/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
+++ b/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
@@ -1,18 +1,15 @@
 package latis.output
 
 import java.io.File
-import java.nio.ByteBuffer
 import java.nio.DoubleBuffer
 import java.nio.IntBuffer
-import java.nio.LongBuffer
-import scala.collection.JavaConverters._
-import ucar.ma2.{DataType => NcDataType}
+
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
+import ucar.ma2.{DataType => NcDataType}
 import ucar.nc2.NetcdfFile
 
 import latis.data._
-import latis.dataset.Dataset
 import latis.dataset.MemoizedDataset
 import latis.metadata.Metadata
 import latis.model._
@@ -21,7 +18,7 @@ class NetcdfEncoderSpec extends FlatSpec {
   import NetcdfEncoderSpec._
 
   "A NetCDF encoder" should "encode a 1-D dataset with a single range variable to NetCDF" in {
-    val enc          = NetcdfEncoder(new File("test1.nc"))
+    val enc          = NetcdfEncoder(File.createTempFile("netcdf_test", ".nc", null))
     val expectedTime = Array(1, 2, 3)
     val expectedFlux = Array(1.0, 2.5, 5.1e-2)
 
@@ -40,7 +37,7 @@ class NetcdfEncoderSpec extends FlatSpec {
   }
 
   it should "encode a 1-D dataset with multiple range variables to NetCDF" in {
-    val enc          = NetcdfEncoder(new File("test2.nc"))
+    val enc          = NetcdfEncoder(File.createTempFile("netcdf_test", ".nc", null))
     val expectedTime = Array(1, 2, 3)
     val expectedFlag = Array[Byte](0, 0, -1)
     val expectedFlux = Array(1.0, 2.5, 5.1e-2)
@@ -50,11 +47,11 @@ class NetcdfEncoderSpec extends FlatSpec {
     val file   = enc.encode(time_series_1D_multi_range).compile.toList.unsafeRunSync().head
     val ncFile = NetcdfFile.open(file.getAbsolutePath)
     try {
-      ncFile.readSection("time").get1DJavaArray(NcDataType.INT) should be (expectedTime)
-      ncFile.readSection("flag").get1DJavaArray(NcDataType.BYTE) should be (expectedFlag)
-      ncFile.readSection("flux").get1DJavaArray(NcDataType.DOUBLE) should be (expectedFlux)
-      ncFile.readSection("long").get1DJavaArray(NcDataType.LONG) should be (expectedLong)
-      ncFile.readSection("str").get1DJavaArray(NcDataType.STRING) should be (expectedStr)
+      ncFile.readSection("time").get1DJavaArray(NcDataType.INT) should be(expectedTime)
+      ncFile.readSection("flag").get1DJavaArray(NcDataType.BYTE) should be(expectedFlag)
+      ncFile.readSection("flux").get1DJavaArray(NcDataType.DOUBLE) should be(expectedFlux)
+      ncFile.readSection("long").get1DJavaArray(NcDataType.LONG) should be(expectedLong)
+      ncFile.readSection("str").get1DJavaArray(NcDataType.STRING) should be(expectedStr)
     } finally {
       ncFile.close()
       file.delete()
@@ -62,19 +59,21 @@ class NetcdfEncoderSpec extends FlatSpec {
   }
 
   it should "encode a 2-D dataset to NetCDF" in {
-    val enc          = NetcdfEncoder(new File("test3.nc"))
-    val expectedTime = Array(1, 2, 3)
+    val enc                = NetcdfEncoder(File.createTempFile("netcdf_test", ".nc", null))
+    val expectedTime       = Array(1, 2, 3)
     val expectedWavelength = Array(430.1, 538.5)
-    val expectedFlag = Array[Byte](0, 0, 0, -1, 0, 0)
-    val expectedFlux = Array(1.0, 2.5, 1.2, 5.1e-2, 0.9, 2.1)
+    val expectedFlag       = Array[Byte](0, 0, 0, -1, 0, 0)
+    val expectedFlux       = Array(1.0, 2.5, 1.2, 5.1e-2, 0.9, 2.1)
 
     val file   = enc.encode(time_series_2D).compile.toList.unsafeRunSync().head
     val ncFile = NetcdfFile.open(file.getAbsolutePath)
     try {
-      ncFile.readSection("time").get1DJavaArray(NcDataType.INT) should be (expectedTime)
-      ncFile.readSection("wavelength").get1DJavaArray(NcDataType.DOUBLE) should be (expectedWavelength)
-      ncFile.readSection("flag").get1DJavaArray(NcDataType.BYTE) should be (expectedFlag)
-      ncFile.readSection("flux").get1DJavaArray(NcDataType.DOUBLE) should be (expectedFlux)
+      ncFile.readSection("time").get1DJavaArray(NcDataType.INT) should be(expectedTime)
+      ncFile.readSection("wavelength").get1DJavaArray(NcDataType.DOUBLE) should be(
+        expectedWavelength
+      )
+      ncFile.readSection("flag").get1DJavaArray(NcDataType.BYTE) should be(expectedFlag)
+      ncFile.readSection("flux").get1DJavaArray(NcDataType.DOUBLE) should be(expectedFlux)
     } finally {
       ncFile.close()
       file.delete()
@@ -82,19 +81,21 @@ class NetcdfEncoderSpec extends FlatSpec {
   }
 
   it should "encode a 3-D dataset to NetCDF" in {
-    val enc          = NetcdfEncoder(new File("test4.nc"))
-    val expectedTime = Array(1, 2)
+    val enc                = NetcdfEncoder(File.createTempFile("netcdf_test", ".nc", null))
+    val expectedTime       = Array(1, 2)
     val expectedWavelength = Array(430.1, 538.5)
-    val expectedAnother = Array(1.1, 2.2)
-    val expectedFlux = Array(1.0, 2.5, 1.2, 5.1e-2, 0.9, 2.1, 0.9, 2.1)
+    val expectedAnother    = Array(1.1, 2.2)
+    val expectedFlux       = Array(1.0, 2.5, 1.2, 5.1e-2, 0.9, 2.1, 0.9, 2.1)
 
     val file   = enc.encode(time_series_3D).compile.toList.unsafeRunSync().head
     val ncFile = NetcdfFile.open(file.getAbsolutePath)
     try {
-      ncFile.readSection("time").get1DJavaArray(NcDataType.INT) should be (expectedTime)
-      ncFile.readSection("wavelength").get1DJavaArray(NcDataType.DOUBLE) should be (expectedWavelength)
-      ncFile.readSection("another").get1DJavaArray(NcDataType.DOUBLE) should be (expectedAnother)
-      ncFile.readSection("flux").get1DJavaArray(NcDataType.DOUBLE) should be (expectedFlux)
+      ncFile.readSection("time").get1DJavaArray(NcDataType.INT) should be(expectedTime)
+      ncFile.readSection("wavelength").get1DJavaArray(NcDataType.DOUBLE) should be(
+        expectedWavelength
+      )
+      ncFile.readSection("another").get1DJavaArray(NcDataType.DOUBLE) should be(expectedAnother)
+      ncFile.readSection("flux").get1DJavaArray(NcDataType.DOUBLE) should be(expectedFlux)
     } finally {
       ncFile.close()
       file.delete()
@@ -102,14 +103,14 @@ class NetcdfEncoderSpec extends FlatSpec {
   }
 
   it should "include global metadata in the file" in {
-    val enc = NetcdfEncoder(new File("test5.nc"))
+    val enc              = NetcdfEncoder(File.createTempFile("netcdf_test", ".nc", null))
     val expectedMetadata = Metadata("dataset_with_metadata") + ("globalFoo" -> "globalBar") + ("history" -> "Uncurry()")
 
     val file   = enc.encode(dataset_with_metadata).compile.toList.unsafeRunSync().head
     val ncFile = NetcdfFile.open(file.getAbsolutePath)
     try {
       expectedMetadata.properties.foreach {
-        case (k, v) => ncFile.findGlobalAttribute(k).getStringValue should be (v)
+        case (k, v) => ncFile.findGlobalAttribute(k).getStringValue should be(v)
       }
     } finally {
       ncFile.close()
@@ -118,7 +119,7 @@ class NetcdfEncoderSpec extends FlatSpec {
   }
 
   it should "include variable metadata in the file" in {
-    val enc = NetcdfEncoder(new File("test6.nc"))
+    val enc                  = NetcdfEncoder(File.createTempFile("netcdf_test", ".nc", null))
     val expectedTimeMetadata = Metadata("time") + ("type" -> "int") + ("scalarFoo" -> "scalarBar")
     val expectedFluxMetadata = Metadata("flux") + ("type" -> "double") + ("Foo" -> "Bar")
 
@@ -127,11 +128,11 @@ class NetcdfEncoderSpec extends FlatSpec {
     try {
       val timeVar = ncFile.findVariable("time")
       expectedTimeMetadata.properties.foreach {
-        case (k, v) => timeVar.findAttribute(k).getStringValue should be (v)
+        case (k, v) => timeVar.findAttribute(k).getStringValue should be(v)
       }
       val fluxVar = ncFile.findVariable("flux")
       expectedFluxMetadata.properties.foreach {
-        case (k, v) => fluxVar.findAttribute(k).getStringValue should be (v)
+        case (k, v) => fluxVar.findAttribute(k).getStringValue should be(v)
       }
     } finally {
       ncFile.close()
@@ -183,25 +184,46 @@ object NetcdfEncoderSpec {
 
   private val time_series_2D: MemoizedDataset = {
     val samples = Seq(
-      Sample(DomainData(1), RangeData(SampledFunction(Seq(
-        Sample(DomainData(430.1), RangeData(0: Byte, 1.0)),
-        Sample(DomainData(538.5), RangeData(0: Byte, 2.5))
-      )))),
-      Sample(DomainData(2), RangeData(SampledFunction(Seq(
-        Sample(DomainData(430.1), RangeData(0: Byte, 1.2)),
-        Sample(DomainData(538.5), RangeData(-1: Byte, 5.1e-2))
-      )))),
-      Sample(DomainData(3), RangeData(SampledFunction(Seq(
-        Sample(DomainData(430.1), RangeData(0: Byte, 0.9)),
-        Sample(DomainData(538.5), RangeData(0: Byte, 2.1))
-      ))))
+      Sample(
+        DomainData(1),
+        RangeData(
+          SampledFunction(
+            Seq(
+              Sample(DomainData(430.1), RangeData(0: Byte, 1.0)),
+              Sample(DomainData(538.5), RangeData(0: Byte, 2.5))
+            )
+          )
+        )
+      ),
+      Sample(
+        DomainData(2),
+        RangeData(
+          SampledFunction(
+            Seq(
+              Sample(DomainData(430.1), RangeData(0: Byte, 1.2)),
+              Sample(DomainData(538.5), RangeData(-1: Byte, 5.1e-2))
+            )
+          )
+        )
+      ),
+      Sample(
+        DomainData(3),
+        RangeData(
+          SampledFunction(
+            Seq(
+              Sample(DomainData(430.1), RangeData(0: Byte, 0.9)),
+              Sample(DomainData(538.5), RangeData(0: Byte, 2.1))
+            )
+          )
+        )
+      )
     )
 
     val md = Metadata("time_series_2D")
     val model = Function(
       Scalar(Metadata("time") + ("type" -> "int")),
       Function(
-        Scalar(Metadata("wavelength") + ("type"  -> "double")),
+        Scalar(Metadata("wavelength") + ("type" -> "double")),
         Tuple(
           Scalar(Metadata("flag") + ("type" -> "byte")),
           Scalar(Metadata("flux") + ("type" -> "double"))
@@ -228,11 +250,11 @@ object NetcdfEncoderSpec {
     val md = Metadata("time_series_3D")
     val model = Function(
       Tuple(
-        Scalar(Metadata("time") + ("type" -> "int")),
-        Scalar(Metadata("wavelength") + ("type"  -> "double")),
-        Scalar(Metadata("another") + ("type"  -> "double"))
+        Scalar(Metadata("time") + ("type"       -> "int")),
+        Scalar(Metadata("wavelength") + ("type" -> "double")),
+        Scalar(Metadata("another") + ("type"    -> "double"))
       ),
-        Scalar(Metadata("flux") + ("type" -> "double"))
+      Scalar(Metadata("flux") + ("type" -> "double"))
     )
     val data = SampledFunction(samples)
 
@@ -247,7 +269,7 @@ object NetcdfEncoderSpec {
     val md = Metadata("dataset_with_metadata") + ("globalFoo" -> "globalBar")
     val model = Function(
       Scalar(Metadata("time") + ("type" -> "int") + ("scalarFoo" -> "scalarBar")),
-      Scalar(Metadata("flux") + ("type" -> "double") + ("Foo" -> "Bar"))
+      Scalar(Metadata("flux") + ("type" -> "double") + ("Foo"    -> "Bar"))
     )
     val data = SampledFunction(samples)
 


### PR DESCRIPTION
This PR adds metadata to the NetCDF encoder, as the title implies, but also includes a small refactor of a couple things.

`datasetToNetcdf` now returns `IO[Unit]` instead of `Unit`. This involved wrapping every operation on NetcdfFileWriter in a helper function that returns `IO[Unit]`, and then calling those in a for comprehension.

the unit tests now use temp files.