### PR TITLE
Add constructor for NetcdfAdapter

### DIFF
--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -101,7 +101,7 @@ case class NetcdfAdapter(
 }
 
 //TODO: move some of this to NetcdfUtils?
-object NetcdfAdapter {
+object NetcdfAdapter extends AdapterFactory {
   /**
    * Constructor used by the AdapterFactory.
    */

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -102,6 +102,11 @@ case class NetcdfAdapter(
 
 //TODO: move some of this to NetcdfUtils?
 object NetcdfAdapter {
+  /**
+   * Constructor used by the AdapterFactory.
+   */
+  def apply(model: DataType, config: AdapterConfig): NetcdfAdapter =
+    new NetcdfAdapter(model, NetcdfAdapter.Config(config.properties: _*))
 
   /**
    * Defines a NetcdfAdapter specific configuration with type-safe accessors for


### PR DESCRIPTION
It appears that the NetcdfAdapter won't work from the AdapterFactory without an `apply` method, so this PR is to add that.