### PR TITLE
Add file list adapter

### DIFF
--- a/core/src/main/scala/latis/input/FileListAdapter.scala
+++ b/core/src/main/scala/latis/input/FileListAdapter.scala
@@ -1,0 +1,235 @@
+package latis.input
+
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.util.matching.Regex
+
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.implicits._
+import fs2.Stream
+import fs2.io.file
+
+import latis.data.Data
+import latis.data.RangeData
+import latis.data.Sample
+import latis.model.DataType
+import latis.model.Function
+import latis.model.Scalar
+import latis.util.ConfigLike
+import latis.util.LatisException
+import latis.util.NetUtils
+import latis.util.StreamUtils
+import FileListAdapter.FileInfo
+
+/**
+ * An adapter for creating datasets from directory listings.
+ *
+ * This adapter produces datasets of the form `(s,,1,,, ..., s,,N,,) →
+ * uri` or `(s,,1,,, ..., s,,N,,) → (uri, size)` given a regular
+ * expression with `N` capture groups. This regular expression is
+ * recursively applied to the paths of files within the directory
+ * given to [[getData]]. The groups are used to populate the
+ * corresponding scalars. Paths that do not match or have too few
+ * groups are silently ignored.
+ *
+ * The scalars `s,,1,,, ..., s,,N,,` are mapped to capture groups in
+ * the given regular expression using the `columns` configuration key.
+ * The scalars must be able to parse the string returned by the
+ * associated capture group. If the `columns` configuration key is
+ * unspecified, a direct mapping (first scalar is mapped to first
+ * capture group, and so on) is assumed.
+ *
+ * The `columns` configuration key is a string of zero-indexed indices
+ * corresponding to capture groups separated by semicolons (`;`). The
+ * `N`th index specifies the capture group to be mapped to the scalar
+ * `s,,N,,`. Multiple capture groups can be mapped to a single scalar
+ * by separating their indices with a comma (`,`). These groups are
+ * joined with a space before being mapped to the corresponding
+ * scalar. For example, `1;0;2` will map the second capture group to
+ * the first scalar, the first capture group to the second scalar, and
+ * the third capture group to the third scalar. `2;0,1` will map the
+ * third capture group to the first scalar, and map the first and
+ * second capture groups joined with a space to the second scalar.
+ *
+ * The scalar `uri` will be a file URI to a file contained within the
+ * directory given in [[getData]] or its subdirectories with a path
+ * matching the regular expression. The ID must be `uri` and the type
+ * must be `text`. If the `baseDir` configuration key is set to a file
+ * URI, this URI will be relative to `baseDir`. This scalar is
+ * expected to be present in the model.
+ *
+ * The scalar `size` will be the size of the corresponding file in
+ * bytes. The ID must be `size` and the type must be `long`. This
+ * scalar may be omitted from the model, in which case the size of
+ * each file will not be computed.
+ */
+class FileListAdapter(
+  model: DataType,
+  config: FileListAdapter.Config
+) extends StreamingAdapter[FileInfo] {
+
+  implicit private val cs: ContextShift[IO] = StreamUtils.contextShift
+
+  override def recordStream(uri: URI): Stream[IO, FileInfo] =
+    for {
+      root  <- Stream.fromEither[IO](NetUtils.getFilePath(uri))
+      files <- listFiles(root)
+    } yield files
+
+  override def parseRecord(info: FileInfo): Option[Sample] =
+    for {
+      (ds, rs) <- model match {
+        case Function(d, r) => (d.getScalars, r.getScalars).some
+        case _              => None
+      }
+      dv      = extractValues(info.path)
+      _      <- (ds.length == dv.length).guard[Option]
+      domain <- ds.zip(dv).traverse(p => p._1.parseValue(p._2)).toOption
+      range  <- makeRange(rs, info.path, info.size).toOption
+    } yield Sample(domain, range)
+
+  /**
+   * Produces a Stream of paths, optionally with the corresponding
+   * file size, for every file in the directory pointed to by `path`
+   * and its subdirectories.
+   *
+   * The size is only computed if there is a variable named "size" in
+   * the model.
+   */
+  private def listFiles(path: Path): Stream[IO, FileInfo] = {
+    val files: Stream[IO, Path] =
+      file.walk[IO](StreamUtils.blocker, path).filter(Files.isRegularFile(_))
+
+    // Get the size if there is a variable named "size."
+    model match {
+      case Function(_, rs) if rs.findVariable("size").isDefined =>
+        files.evalMap { p =>
+          file.size[IO](StreamUtils.blocker, p).map(s => FileInfo(p, s.some))
+        }
+      case _ => files.map(FileInfo(_, None))
+    }
+  }
+
+  /**
+   * Applies the regular expression to a file path, ordering and
+   * joining the matches as specified by `config.columns`.
+   */
+  private def extractValues(path: Path): List[String] = {
+    val groups: List[String] =
+      config.pattern.findFirstMatchIn(path.toString())
+        .map(_.subgroups)
+        .getOrElse(List.empty)
+
+    config.columns.map { ci =>
+      if (groups.length > ci.flatten.max) {
+        ci.map(_.map(groups(_)).mkString(" "))
+      } else List.empty
+    }.getOrElse(groups)
+  }
+
+  /**
+   * Constructs the appropriate RangeData, taking into account whether
+   * the size is required and whether the file URIs should be relative
+   * to a given base directory.
+   */
+  private def makeRange(
+    range: List[Scalar],
+    path: Path,
+    size: Option[Long]
+  ): Either[LatisException, RangeData] = {
+    val uri: URI = {
+      val fileUri = path.toUri()
+      val baseUri = config.baseDir.map(_.toUri())
+      baseUri.map(_.relativize(fileUri)).getOrElse(fileUri)
+    }
+
+    range match {
+      case (u: Scalar) :: Nil if u.id == "uri" =>
+        u.parseValue(uri.toString()).map(RangeData(_))
+      case (u: Scalar) :: (s: Scalar) :: Nil
+          if u.id == "uri" && s.id == "size"   => for {
+            uriDatum  <- u.parseValue(uri.toString())
+            sizeLong  <- size.toRight {
+              // This shouldn't happen. If we have the size scalar in
+              // the model, we should have gotten the size in
+              // listFiles, so this variable should be defined.
+              LatisException("Missing size")
+            }
+            sizeDatum <- Data.fromValue(sizeLong)
+          } yield RangeData(uriDatum, sizeDatum)
+      case _ => LatisException("Unsupported range").asLeft
+    }
+  }
+}
+
+object FileListAdapter extends AdapterFactory {
+  /**
+   * Creates a [[FileListAdapter]].
+   *
+   * @throws LatisException if required configuration keys are unset
+   * or if any configuration values are malformed
+   */
+  def apply(model: DataType, config: AdapterConfig): FileListAdapter = {
+    val c = FileListAdapter.Config.fromConfigLike(config).fold(throw _, identity)
+    new FileListAdapter(model, c)
+  }
+
+  /**
+   * Information required from each file in the directory listing.
+   *
+   * This type represents a pair of the file path and the file size.
+   * The file size is defined only if the file size was requested.
+   */
+  final case class FileInfo(path: Path, size: Option[Long])
+
+  /**
+   * Type-safe configuration for the file list adapter.
+   *
+   * @param pattern regular expression to apply to each path
+   * @param columns nested list of column indices, the Nth inner list
+   * contains the indices of capture groups to be mapped to the Nth
+   * scalar in the domain
+   * @param baseDir path to relativize file paths against
+   */
+  final case class Config(
+    pattern: Regex,
+    columns: Option[List[List[Int]]],
+    baseDir: Option[Path]
+  )
+
+  object Config {
+    /**
+     * Creates a type-safe configuration from a stringly typed map.
+     *
+     * Handles the following configuration keys:
+     *
+     *  - `pattern`: A required regular expression string. The regular
+     *    expression should have `N` capture groups for `N` scalars in
+     *    the domain.
+     *  - `columns`: An optional string of zero-based indices
+     *    separated by semicolons or commas. See [[FileListAdapter]]
+     *    for a more detailed description.
+     *  - `baseDir`: An optional file URI that the URIs of files
+     *    returned by this adapter will be relativized against.
+     */
+    def fromConfigLike(cl: ConfigLike): Either[LatisException, Config] = for {
+      pattern <- cl.get("pattern").map(_.r).toRight {
+        LatisException("Adapter requires a pattern definition")
+      }
+      columns <- cl.get("columns").traverse(parseColumns)
+      baseDir <- cl.get("baseDir").traverse {
+        NetUtils.parseUri(_).flatMap(NetUtils.getFilePath)
+      }
+    } yield Config(pattern, columns, baseDir)
+
+    private def parseColumns(cols: String): Either[LatisException, List[List[Int]]] =
+      Either.catchOnly[NumberFormatException] {
+        cols.split(";").map(_.split(",").map(_.toInt).toList).toList
+      }.leftMap {
+        new LatisException("Column specification must contain only numbers", _)
+      }
+  }
+}

--- a/core/src/main/scala/latis/util/NetUtils.scala
+++ b/core/src/main/scala/latis/util/NetUtils.scala
@@ -1,6 +1,8 @@
 package latis.util
 
 import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
 
 import cats.implicits._
 import fs2.text
@@ -8,6 +10,12 @@ import fs2.text
 import latis.input.StreamSource
 
 object NetUtils {
+
+  /** Returns a Path corresponding to the given file URI. */
+  def getFilePath(uri: URI): Either[LatisException, Path] =
+    if (uri.getScheme() != "file") {
+      LatisException("Only file URIs are supported").asLeft
+    } else Paths.get(uri).asRight
 
   /**
    * Creates a URI from the given string.

--- a/core/src/test/scala/latis/input/FileListAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/FileListAdapterSpec.scala
@@ -1,0 +1,413 @@
+package latis.input
+
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.FileVisitResult
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+import org.scalactic.Equality
+import org.scalatest.EitherValues._
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+import latis.data._
+import latis.metadata.Metadata
+import latis.model._
+import latis.util.LatisException
+import latis.util.StreamUtils
+import FileListAdapter.Config
+
+class FileListAdapterSpec extends FlatSpec {
+
+  "A file list adapter" should "list files in a flat directory" in withFlatDir { root =>
+    val adapter = {
+      val config = Config(raw"(\d{4})-[abc]".r, None, None)
+
+      val model: DataType = Function(
+        Scalar(Metadata(
+          "id" -> "time",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy",
+          "type" -> "string"
+        )),
+        Scalar(Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010"), RangeData(root.resolve("2010-a").toUri().toString())),
+      Sample(DomainData("2011"), RangeData(root.resolve("2011-b").toUri().toString())),
+      Sample(DomainData("2012"), RangeData(root.resolve("2012-c").toUri().toString()))
+    )
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "list files in subdirectories" in withNestedDir { root =>
+    val adapter = {
+      val config = Config(raw"(\d{4})-[abc]".r, None, None)
+
+      val model: DataType = Function(
+        Scalar(Metadata(
+          "id" -> "time",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy",
+          "type" -> "string"
+        )),
+        Scalar(Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010"), RangeData(root.resolve("a/2010-a").toUri().toString())),
+      Sample(DomainData("2011"), RangeData(root.resolve("b/2011-b").toUri().toString())),
+      Sample(DomainData("2012"), RangeData(root.resolve("c/2012-c").toUri().toString()))
+    )
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "make URIs relative to baseDir config" in withNestedDir { root =>
+    val adapter = {
+      val config = Config(raw"(\d{4})-[abc]".r, None, Option(root))
+
+      val model: DataType = Function(
+        Scalar(Metadata(
+          "id" -> "time",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy",
+          "type" -> "string"
+        )),
+          Scalar(Metadata(
+            "id" -> "uri",
+            "type" -> "string"
+          ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010"), RangeData("a/2010-a")),
+      Sample(DomainData("2011"), RangeData("b/2011-b")),
+      Sample(DomainData("2012"), RangeData("c/2012-c"))
+    )
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "include file size when size scalar is present" in withFlatDir { root =>
+    val adapter = {
+      val config = Config(raw"(\d{4})-[abc]".r, None, None)
+
+      val model: DataType = Function(
+        Scalar(Metadata(
+          "id" -> "time",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy",
+          "type" -> "string"
+        )),
+        Tuple(
+          Scalar(Metadata(
+            "id" -> "uri",
+            "type" -> "string"
+          )),
+          Scalar(Metadata(
+            "id" -> "size",
+            "type" -> "long"
+          ))
+        )
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010"), RangeData(root.resolve("2010-a").toUri().toString(), 0l)),
+      Sample(DomainData("2011"), RangeData(root.resolve("2011-b").toUri().toString(), 0l)),
+      Sample(DomainData("2012"), RangeData(root.resolve("2012-c").toUri().toString(), 0l))
+    )
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "silently drop files that don't match the pattern" in withFlatDir { root =>
+    val adapter = {
+      // Note this pattern will exclude 'b'
+      val config = Config(raw"(\d{4})-[ac]".r, None, None)
+
+      val model: DataType = Function(
+        Scalar(Metadata(
+          "id" -> "time",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy",
+          "type" -> "string"
+        )),
+        Scalar(Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010"), RangeData(root.resolve("2010-a").toUri().toString())),
+      Sample(DomainData("2012"), RangeData(root.resolve("2012-c").toUri().toString()))
+    )
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "construct domains with multiple scalars from matches" in withFlatDir { root =>
+    val adapter = {
+      val config = Config(raw"(\d{4})-([abc])".r, None, None)
+
+      val model: DataType = Function(
+        Tuple(
+          Scalar(Metadata(
+            "id" -> "time",
+            "class" -> "latis.time.Time",
+            "units" -> "yyyyMMdd",
+            "type" -> "string"
+          )),
+          Scalar(Metadata(
+            "id" -> "type",
+            "type" -> "string"
+          ))
+        ),
+        Scalar(Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010", "a"), RangeData(root.resolve("2010-a").toUri().toString())),
+      Sample(DomainData("2011", "b"), RangeData(root.resolve("2011-b").toUri().toString())),
+      Sample(DomainData("2012", "c"), RangeData(root.resolve("2012-c").toUri().toString()))
+    )
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "arrange matches based on the column specification" in withFlatDir { root =>
+    val adapter = {
+      val config = Config(
+        raw"(\d{4})-([abc])".r,
+        Option(List(List(1), List(0))),
+        None
+      )
+
+      val model: DataType = Function(
+        Tuple(
+          Scalar(Metadata(
+            "id" -> "type",
+            "type" -> "string"
+          )),
+          Scalar(Metadata(
+            "id" -> "time",
+            "class" -> "latis.time.Time",
+            "units" -> "yyyy",
+            "type" -> "string"
+          ))
+        ),
+        Scalar(Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("a", "2010"), RangeData(root.resolve("2010-a").toUri().toString())),
+      Sample(DomainData("b", "2011"), RangeData(root.resolve("2011-b").toUri().toString())),
+      Sample(DomainData("c", "2012"), RangeData(root.resolve("2012-c").toUri().toString()))
+    )
+
+    val samples: List[Sample] =
+      adapter.getData(root.toUri()).samples.compile.toList.unsafeRunSync
+
+    samples should contain theSameElementsAs (expected)
+  }
+
+  it should "join columns separated by commas in the specifiation" in {
+    // Create the directory.
+    val root: Path = {
+      val dir = Files.createTempDirectory(null)
+      Files.createFile(dir.resolve("01201001-a"))
+      Files.createFile(dir.resolve("02201106-b"))
+      Files.createFile(dir.resolve("03201212-c"))
+
+      dir
+    }
+
+    // Create the adapter.
+    val adapter = {
+      val config = Config(
+        raw"(\d{2})(\d{4})(\d{2})-[abc]".r,
+        Option(List(List(1, 2, 0))),
+        None
+      )
+
+      val model: DataType = Function(
+        Scalar(Metadata(
+          "id" -> "time",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy MM dd",
+          "type" -> "string"
+        )),
+        Scalar(Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        ))
+      )
+
+      new FileListAdapter(model, config)
+    }
+
+    val expected: List[Sample] = List(
+      Sample(DomainData("2010 01 01"), RangeData(root.resolve("01201001-a").toUri().toString())),
+      Sample(DomainData("2011 06 02"), RangeData(root.resolve("02201106-b").toUri().toString())),
+      Sample(DomainData("2012 12 03"), RangeData(root.resolve("03201212-c").toUri().toString()))
+    )
+
+    // Run the test.
+    withTmpDir(root) { dir =>
+      val samples: List[Sample] =
+        adapter.getData(dir.toUri()).samples.compile.toList.unsafeRunSync
+
+      samples should contain theSameElementsAs (expected)
+    }
+  }
+
+  // We need to override how Configs are compared for equality because
+  // we can't compare regular expressions for equality.
+  private implicit val configEquality: Equality[Config] = new Equality[Config] {
+    override def areEqual(a: Config, b: Any): Boolean = b match {
+      case b: Config =>
+        a.pattern.toString() == b.pattern.toString() &&
+        a.columns == b.columns &&
+        a.baseDir == b.baseDir
+      case _         => false
+    }
+  }
+
+  "A file list adapter config" should "be buildable from a ConfigLike" in {
+    val conf = Config.fromConfigLike(
+      AdapterConfig(
+        "class" -> "",
+        "pattern" -> raw"(\d{4})",
+        "columns" -> "1,2,3;4;5",
+        "baseDir" -> "file:///base/dir"
+      )
+    ).fold(throw _, identity)
+
+    val expected = Config(
+      raw"(\d{4})".r,
+      Option(List(List(1, 2, 3), List(4), List(5))),
+      Option(Paths.get("/base/dir"))
+    )
+
+    conf should equal (expected)
+  }
+
+  it should "require a pattern definition" in {
+    val conf = Config.fromConfigLike(AdapterConfig("class" -> ""))
+
+    conf.left.value shouldBe a [LatisException]
+  }
+
+  it should "require numeric columns" in {
+    val conf = Config.fromConfigLike(
+      AdapterConfig("class" -> "", "columns" -> "1; a; 3")
+    )
+
+    conf.left.value shouldBe a [LatisException]
+  }
+
+  it should "require file URI for baseDir" in {
+    val conf = Config.fromConfigLike(
+      AdapterConfig("class" -> "", "baseDir" -> "base dir")
+    )
+
+    conf.left.value shouldBe a [LatisException]
+  }
+
+  private def withTmpDir(tmp: Path)(f: Path => Any): Any =
+    try f(tmp) finally deleteTmpDir(tmp)
+
+  private def deleteTmpDir(tmp: Path): Unit = {
+    val visitor = new SimpleFileVisitor[Path] {
+      override def visitFile(p: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.deleteIfExists(p)
+        FileVisitResult.CONTINUE
+      }
+
+      override def postVisitDirectory(p: Path, e: IOException): FileVisitResult = {
+        Files.deleteIfExists(p)
+        FileVisitResult.CONTINUE
+      }
+    }
+
+    Files.walkFileTree(tmp, visitor)
+  }
+
+  private def withFlatDir(f: Path => Any): Any = {
+    val dir = Files.createTempDirectory(null)
+    Files.createFile(dir.resolve("2010-a"))
+    Files.createFile(dir.resolve("2011-b"))
+    Files.createFile(dir.resolve("2012-c"))
+
+    withTmpDir(dir)(f)
+  }
+
+  private def withNestedDir(f: Path => Any): Any = {
+    val dir = Files.createTempDirectory(null)
+    val dirA = Files.createDirectory(dir.resolve("a"))
+    val dirB = Files.createDirectory(dir.resolve("b"))
+    val dirC = Files.createDirectory(dir.resolve("c"))
+    Files.createFile(dirA.resolve("2010-a"))
+    Files.createFile(dirB.resolve("2011-b"))
+    Files.createFile(dirC.resolve("2012-c"))
+
+    withTmpDir(dir)(f)
+  }
+}


### PR DESCRIPTION
See the comment on `FileListAdapter` for how this works. I tried to be thorough.

I am duplicating the column reordering and regular expression logic from `RegexAdapter` because it doesn't make sense to subclass that and it's clunky for other reasons. It would be nice to pull those things as traits or something and put the relevant documentation there instead.

There's more work to be done cleaning up the tests, but rather than try to force something now I was hoping that looking at tests for different kinds of adapters as we write them would inspire something.