### PR TITLE
Add schemas for different text adapters

### DIFF
--- a/core/src/main/resources/fdml-with-columnar-adapter.xsd
+++ b/core/src/main/resources/fdml-with-columnar-adapter.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+    <xs:redefine schemaLocation="http://latis-data.io/schemas/1.0/fdml-with-text-adapter.xsd">
+        <xs:attributeGroup name="adapter_attributes">
+            <xs:attributeGroup ref="adapter_attributes"/>
+            <xs:attribute name="columns" type="xs:string" use="required"/>
+        </xs:attributeGroup>
+    </xs:redefine>
+</xs:schema>

--- a/core/src/main/resources/fdml-with-formatted-text-adapter.xsd
+++ b/core/src/main/resources/fdml-with-formatted-text-adapter.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+    <xs:redefine schemaLocation="http://latis-data.io/schemas/1.0/fdml-with-text-adapter.xsd">
+        <xs:attributeGroup name="adapter_attributes">
+            <xs:attributeGroup ref="adapter_attributes"/>
+            <xs:attribute name="format" type="xs:string" use="required"/>
+        </xs:attributeGroup>
+    </xs:redefine>
+</xs:schema>

--- a/core/src/main/resources/fdml-with-regex-adapter.xsd
+++ b/core/src/main/resources/fdml-with-regex-adapter.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+    <xs:redefine schemaLocation="http://latis-data.io/schemas/1.0/fdml-with-text-adapter.xsd">
+        <xs:attributeGroup name="adapter_attributes">
+            <xs:attributeGroup ref="adapter_attributes"/>
+            <xs:attribute name="pattern" type="xs:string" use="required"/>
+            <xs:attribute name="columns" type="xs:string"/>
+        </xs:attributeGroup>
+    </xs:redefine>
+</xs:schema>

--- a/core/src/main/resources/fdml-with-substring-adapter.xsd
+++ b/core/src/main/resources/fdml-with-substring-adapter.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
+    <xs:redefine schemaLocation="http://latis-data.io/schemas/1.0/fdml-with-text-adapter.xsd">
+        <xs:attributeGroup name="adapter_attributes">
+            <xs:attributeGroup ref="adapter_attributes"/>
+            <xs:attribute name="substring" type="xs:string" use="required"/>
+        </xs:attributeGroup>
+    </xs:redefine>
+</xs:schema>


### PR DESCRIPTION
Once this PR is merged, I'll add these schemas to the latis-data.github.io repo.

I put `use="required"` on any attribute that is required of the adapter. Does that do what it looks like it does?

I asked this in the Slack #latis-872, but I'll put it here too: 
The matrix text adapter doesn't add any parameters on top of the regular text adapter. That means when making an fdml for something like columnar adapter, you need to use the schema `fdml-with-columnar-adapter.xsd`, but for the matrix adapter, you need to know that there is no `fdml-with-matrix.adapter.xsd`. I'm open to adding a schema for the matrix adapter that adds nothing to the text adapter.
