### PR TITLE
Add CSV encoder to DAP 2 service

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -14,6 +14,7 @@ import latis.input.DatasetResolver
 import latis.dataset.Dataset
 import latis.ops
 import latis.ops.UnaryOperation
+import latis.output.CsvEncoder
 import latis.output.Encoder
 import latis.output.TextEncoder
 import latis.server.ServiceInterface
@@ -67,6 +68,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
     ext match {
       case ""    => getEncoder("html")
       case "txt" => Right(new TextEncoder)
+      case "csv" => Right(CsvEncoder.withColumnName)
       // TODO: Here we may need to dynamically construct an instance
       // of an encoder based on the extension and server/interface
       // configuration.


### PR DESCRIPTION
Very small change to use the CSV encoder when requesting a dataset with the `csv` suffix.