### PR TITLE
Add operations to fdml

### DIFF
--- a/core/src/main/scala/latis/input/fdml/FdmlParser.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlParser.scala
@@ -9,6 +9,8 @@ import cats.implicits._
 
 import latis.metadata.Metadata
 import latis.model.ValueType
+import latis.ops.parser.ast.CExpr
+import latis.ops.parser.parsers.subexpression
 import latis.util.FdmlUtils
 import latis.util.LatisException
 import latis.util.NetUtils

--- a/core/src/main/scala/latis/input/fdml/fdml.scala
+++ b/core/src/main/scala/latis/input/fdml/fdml.scala
@@ -5,13 +5,15 @@ import java.net.URI
 import latis.input.AdapterConfig
 import latis.metadata.Metadata
 import latis.model.ValueType
+import latis.ops.parser.ast.CExpr
 
 /** Abstract representation of an FDML file. */
 final case class Fdml(
   metadata: Metadata,
   source: FSource,
   adapter: FAdapter,
-  model: FFunction
+  model: FFunction,
+  operations: List[CExpr] = List.empty
 )
 
 /**

--- a/core/src/main/scala/latis/ops/parser/ast.scala
+++ b/core/src/main/scala/latis/ops/parser/ast.scala
@@ -1,0 +1,48 @@
+package latis.ops.parser
+
+object ast {
+
+  sealed trait CExpr
+
+  final case class Projection(
+    names: List[String]
+  ) extends CExpr
+
+  final case class Selection(
+    name: String, op: SelectionOp, value: String
+  ) extends CExpr
+
+  final case class Operation(
+    name: String, args: List[String]
+  ) extends CExpr
+
+  sealed trait SelectionOp
+  final case object Gt extends SelectionOp
+  final case object Lt extends SelectionOp
+  final case object Eq extends SelectionOp
+  final case object GtEq extends SelectionOp
+  final case object LtEq extends SelectionOp
+  final case object EqEq extends SelectionOp
+  final case object NeEq extends SelectionOp
+  final case object Tilde extends SelectionOp
+  final case object EqTilde extends SelectionOp
+  final case object NeEqTilde extends SelectionOp
+
+  /**
+   * Pretty print a selection operator.
+   *
+   * @param op selection operator to pretty print
+   */
+  def prettyOp(op: SelectionOp): String = op match {
+    case Gt        => ">"
+    case Lt        => "<"
+    case Eq        => "="
+    case GtEq      => ">="
+    case LtEq      => "<="
+    case EqEq      => "=="
+    case NeEq      => "!="
+    case Tilde     => "~"
+    case EqTilde   => "=~"
+    case NeEqTilde => "!=~"
+  }
+}

--- a/core/src/main/scala/latis/ops/parser/parsers.scala
+++ b/core/src/main/scala/latis/ops/parser/parsers.scala
@@ -1,0 +1,118 @@
+package latis.ops.parser
+
+import atto.Atto._
+import atto.Parser
+
+import ast._
+
+object parsers {
+
+  /*
+   * A note about "|" and "choice":
+   *
+   * The order of parsers combined by "|" or "choice" is important.
+   * The resulting parser will stop parsing after the first success.
+   *
+   * For instance, imagine we want to parse one of ">" or ">=". If ">"
+   * appears first, the parser will never reach ">=" because ">" will
+   * succeed.
+   */
+
+  def subexpression: Parser[CExpr] =
+    selection | operation | projection
+
+  def projection: Parser[CExpr] =
+    sepBy1(variable.token, char(',').token).map(xs => Projection(xs.toList))
+
+  def selectionOp: Parser[SelectionOp] = choice(
+    string("~")   ~> ok(Tilde),
+    string(">=")  ~> ok(GtEq),
+    string("<=")  ~> ok(LtEq),
+    string("==")  ~> ok(EqEq),
+    string("=~")  ~> ok(EqTilde),
+    string("!=~") ~> ok(NeEqTilde),
+    string("!=")  ~> ok(NeEq),
+    string(">")   ~> ok(Gt),
+    string("<")   ~> ok(Lt),
+    string("=")   ~> ok(Eq)
+  )
+
+  def selection: Parser[CExpr] = for {
+    name  <- variable.token
+    op    <- selectionOp.token
+    value <- time | number | stringLit
+  } yield Selection(name, op, value)
+
+  def operation: Parser[CExpr] = for {
+    name <- identifier
+    argP  = time | number | stringLit | variable
+    args <- parens(sepBy(argP.token, char(',').token))
+  } yield Operation(name, args)
+
+  def variable: Parser[String] =
+    sepBy1(identifier, char('.')).map(_.toList.mkString("."))
+
+  def identifier: Parser[String] = for {
+    init <- letter | char('_')
+    rest <- many(letterOrDigit | char('_'))
+  } yield (init :: rest).mkString
+
+  def stringLit: Parser[String] = for {
+    lit <- stringLiteral
+  } yield "\"" + lit + "\""
+
+  def sign: Parser[String] = string("+") | string("-")
+
+  def integer: Parser[String] = for {
+    s <- sign | ok("")
+    n <- stringOf1(digit)
+  } yield s + n
+
+  def decimal: Parser[String] = {
+    // A decimal variant for which the fractional part is optional.
+    val n1: Parser[String] = for {
+      int  <- stringOf1(digit)
+      dec  <- string(".")
+      frac <- stringOf(digit)
+    } yield int + dec + frac
+
+    // A decimal variant for which the integral part is optional.
+    val n2: Parser[String] = for {
+      int  <- stringOf(digit)
+      dec  <- string(".")
+      frac <- stringOf1(digit)
+    } yield int + dec + frac
+
+    for {
+      s <- sign | ok("")
+      n <- n1 | n2
+    } yield s + n
+  }
+
+  def scientific: Parser[String] = for {
+    significand <- decimal | integer
+    e           <- string("e") | string("E")
+    exponent    <- integer
+  } yield significand + e + exponent
+
+  def number: Parser[String] = scientific | decimal | integer
+
+  def time: Parser[String] = {
+    def stringN(n: Int, p: Parser[Char]): Parser[String] =
+      count(n, p).map(_.mkString)
+
+    val timeP: Parser[String] = for {
+      _ <- char('T')
+      h <- stringN(2, digit) <~ char(':')
+      m <- stringN(2, digit) <~ char(':')
+      s <- stringN(2, digit)
+    } yield "T" + List(h, m, s).mkString(":")
+
+    for {
+      y <- stringN(4, digit) <~ char('-')
+      m <- stringN(2, digit) <~ char('-')
+      d <- stringN(2, digit)
+      t <- timeP | ok("")
+    } yield List(y, m, d).mkString("-") + t
+  }
+}

--- a/core/src/test/resources/datasets/dataWithOperations.fdml
+++ b/core/src/test/resources/datasets/dataWithOperations.fdml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dataset id="data"
+         title="Test Dataset"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://latis-data.io/schemas/1.0/fdml-with-text-adapter.xsd">
+
+  <source uri="data/data.txt"/>
+
+  <adapter class="latis.input.TextAdapter"
+           skipLines="1"/>
+
+  <function>
+    <scalar id="time"
+            units="days since 2000-01-01"
+            type="int"
+            class="latis.time.Time"/>
+    <tuple>
+      <scalar id="b" type="int"/>
+      <scalar id="Constantinople" type="double"/>
+      <scalar id="d" type="string"/>
+    </tuple>
+  </function>
+
+  <?latis-operation expression="time > 0"?>
+
+  <?latis-operation expression="b, Constantinople"?>
+
+  <?latis-operation expression="rename(Constantinople, Istanbul)"?>
+
+</dataset>

--- a/core/src/test/resources/fdml-parser/operation-with-bad-expression.fdml
+++ b/core/src/test/resources/fdml-parser/operation-with-bad-expression.fdml
@@ -29,10 +29,6 @@
     </function>
   </function>
 
-  <?latis-operation expression="time > 2000-01-01"?>
-
-  <?latis-operation expression="a, b, c"?>
-
-  <?latis-operation expression="rename(Constantinople, Istanbul)"?>
+  <?latis-operation expression=",,,"?>
 
 </dataset>

--- a/core/src/test/resources/fdml-parser/operation-without-expression.fdml
+++ b/core/src/test/resources/fdml-parser/operation-without-expression.fdml
@@ -29,10 +29,6 @@
     </function>
   </function>
 
-  <?latis-operation expression="time > 2000-01-01"?>
-
-  <?latis-operation expression="a, b, c"?>
-
-  <?latis-operation expression="rename(Constantinople, Istanbul)"?>
+  <?latis-operation expiration="time > 2000-01-01"?>
 
 </dataset>

--- a/core/src/test/scala/latis/input/fdml/FdmlParserSpec.scala
+++ b/core/src/test/scala/latis/input/fdml/FdmlParserSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.Matchers._
 import latis.model.DoubleValueType
 import latis.model.IntValueType
 import latis.model.StringValueType
+import latis.ops.parser.ast
 import latis.util.LatisException
 import latis.util.NetUtils
 

--- a/core/src/test/scala/latis/input/fdml/FdmlReaderSpec.scala
+++ b/core/src/test/scala/latis/input/fdml/FdmlReaderSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 
 import latis.data._
+import latis.model._
 import latis.util.StreamUtils
 
 class FdmlReaderSpec extends FlatSpec {
@@ -28,5 +29,20 @@ class FdmlReaderSpec extends FlatSpec {
     }
 
     err.getMessage should include ("'{source}' is expected")
+  }
+
+  it should "apply operations to the returned dataset" in {
+    val ds = FdmlReader.read(new URI("datasets/dataWithOperations.fdml"), true)
+
+    StreamUtils.unsafeHead(ds.samples) match {
+      case Sample(DomainData(Number(t)), RangeData(Integer(b), Real(c))) =>
+        assert(t == 1)
+        assert(b == 2)
+        assert(c == 2.2)
+    }
+    ds.model match {
+      case Function(_, range) =>
+        assert(range.getScalars.map(_.id) == List("b", "Istanbul"))
+    }
   }
 }

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -10,17 +10,18 @@ import org.http4s.HttpRoutes
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
 
-import latis.input.DatasetResolver
 import latis.dataset.Dataset
+import latis.input.DatasetResolver
 import latis.ops
 import latis.ops.UnaryOperation
 import latis.output.CsvEncoder
+import latis.ops.parser.ast
 import latis.output.Encoder
 import latis.output.TextEncoder
 import latis.server.ServiceInterface
 import latis.service.dap2.error._
 import latis.util.dap2.parser.ConstraintParser
-import latis.util.dap2.parser.ast
+import latis.util.dap2.parser.ast.ConstraintExpression
 
 /**
  * A service interface implementing the DAP 2 specification.
@@ -52,7 +53,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
 
     ConstraintParser.parse(ce)
       .leftMap(ParseFailure(_))
-      .flatMap { cexprs: ast.ConstraintExpression =>
+      .flatMap { cexprs: ConstraintExpression =>
         cexprs.exprs.traverse {
           case ast.Projection(vs)      => Right(ops.Projection(vs:_*))
           case ast.Selection(n, op, v) => Right(ops.Selection(n, ast.prettyOp(op), v))

--- a/dap2-service/src/main/scala/latis/util/dap2/parser/ConstraintParser.scala
+++ b/dap2-service/src/main/scala/latis/util/dap2/parser/ConstraintParser.scala
@@ -3,7 +3,8 @@ package latis.util.dap2.parser
 import atto._, Atto._
 import cats.implicits._
 
-import ast._
+import latis.ops.parser.ast.CExpr
+import latis.ops.parser.parsers._
 
 /**
  * Module for parsing DAP 2 constraint expressions.
@@ -20,7 +21,7 @@ object ConstraintParser {
    * @param expr non-URL-encoded DAP 2 constraint expression
    */
   def parse(expr: String): Either[String, ast.ConstraintExpression] = {
-    def p(sexpr: String): Either[String, ast.CExpr] =
+    def p(sexpr: String): Either[String, CExpr] =
       (phrase(subexpression) | err(s"Invalid subexpression: $sexpr"))
         .parseOnly(sexpr).either
 
@@ -32,112 +33,4 @@ object ConstraintParser {
     }
   }
 
-  /*
-   * A note about "|" and "choice":
-   *
-   * The order of parsers combined by "|" or "choice" is important.
-   * The resulting parser will stop parsing after the first success.
-   *
-   * For instance, imagine we want to parse one of ">" or ">=". If ">"
-   * appears first, the parser will never reach ">=" because ">" will
-   * succeed.
-   */
-
-  private def subexpression: Parser[CExpr] =
-    selection | operation | projection
-
-  private def projection: Parser[CExpr] =
-    sepBy1(variable.token, char(',').token).map(xs => Projection(xs.toList))
-
-  private def selectionOp: Parser[SelectionOp] = choice(
-    string("~")   ~> ok(Tilde),
-    string(">=")  ~> ok(GtEq),
-    string("<=")  ~> ok(LtEq),
-    string("==")  ~> ok(EqEq),
-    string("=~")  ~> ok(EqTilde),
-    string("!=~") ~> ok(NeEqTilde),
-    string("!=")  ~> ok(NeEq),
-    string(">")   ~> ok(Gt),
-    string("<")   ~> ok(Lt),
-    string("=")   ~> ok(Eq)
-  )
-
-  private def selection: Parser[CExpr] = for {
-    name  <- variable.token
-    op    <- selectionOp.token
-    value <- time | number | stringLit
-  } yield Selection(name, op, value)
-
-  private def operation: Parser[CExpr] = for {
-    name <- identifier
-    argP  = time | number | stringLit | variable
-    args <- parens(sepBy(argP.token, char(',').token))
-  } yield Operation(name, args)
-
-  private def variable: Parser[String] =
-    sepBy1(identifier, char('.')).map(_.toList.mkString("."))
-
-  private def identifier: Parser[String] = for {
-    init <- letter | char('_')
-    rest <- many(letterOrDigit | char('_'))
-  } yield (init :: rest).mkString
-
-  private def stringLit: Parser[String] = for {
-    lit <- stringLiteral
-  } yield "\"" + lit + "\""
-
-  private def sign: Parser[String] = string("+") | string("-")
-
-  private def integer: Parser[String] = for {
-    s <- sign | ok("")
-    n <- stringOf1(digit)
-  } yield s + n
-
-  private def decimal: Parser[String] = {
-    // A decimal variant for which the fractional part is optional.
-    val n1: Parser[String] = for {
-      int  <- stringOf1(digit)
-      dec  <- string(".")
-      frac <- stringOf(digit)
-    } yield int + dec + frac
-
-    // A decimal variant for which the integral part is optional.
-    val n2: Parser[String] = for {
-      int  <- stringOf(digit)
-      dec  <- string(".")
-      frac <- stringOf1(digit)
-    } yield int + dec + frac
-
-    for {
-      s <- sign | ok("")
-      n <- n1 | n2
-    } yield s + n
-  }
-
-  private def scientific: Parser[String] = for {
-    significand <- decimal | integer
-    e           <- string("e") | string("E")
-    exponent    <- integer
-  } yield significand + e + exponent
-
-  private def number: Parser[String] = scientific | decimal | integer
-
-  private def time: Parser[String] = {
-    def stringN(n: Int, p: Parser[Char]): Parser[String] =
-      count(n, p).map(_.mkString)
-
-    val timeP: Parser[String] = for {
-      _ <- char('T')
-      h <- stringN(2, digit) <~ char(':')
-      m <- stringN(2, digit) <~ char(':')
-      s <- stringN(2, digit)
-    } yield "T" + List(h, m, s).mkString(":")
-
-    for {
-      y <- stringN(4, digit) <~ char('-')
-      m <- stringN(2, digit) <~ char('-')
-      d <- stringN(2, digit)
-      t <- timeP | ok("")
-    } yield List(y, m, d).mkString("-") + t
-  }
 }

--- a/dap2-service/src/main/scala/latis/util/dap2/parser/ast.scala
+++ b/dap2-service/src/main/scala/latis/util/dap2/parser/ast.scala
@@ -1,35 +1,11 @@
 package latis.util.dap2.parser
 
+import latis.ops.parser.ast._
+
 /**
  * Module for the DAP 2 constraint expression AST.
  */
 object ast {
-
-  sealed abstract trait CExpr
-
-  final case class Projection(
-    names: List[String]
-  ) extends CExpr
-
-  final case class Selection(
-    name: String, op: SelectionOp, value: String
-  ) extends CExpr
-
-  final case class Operation(
-    name: String, args: List[String]
-  ) extends CExpr
-
-  sealed abstract trait SelectionOp
-  final case object Gt extends SelectionOp
-  final case object Lt extends SelectionOp
-  final case object Eq extends SelectionOp
-  final case object GtEq extends SelectionOp
-  final case object LtEq extends SelectionOp
-  final case object EqEq extends SelectionOp
-  final case object NeEq extends SelectionOp
-  final case object Tilde extends SelectionOp
-  final case object EqTilde extends SelectionOp
-  final case object NeEqTilde extends SelectionOp
 
   /**
    * Wrapper for DAP 2 constraint expressions.
@@ -48,23 +24,5 @@ object ast {
       case Selection(n, op, v) => s"$n${prettyOp(op)}$v"
       case Operation(n, args)  => s"$n(${args.mkString(",")})"
     }.mkString("&")
-  }
-
-  /**
-   * Pretty print a selection operator.
-   *
-   * @param op selection operator to pretty print
-   */
-  def prettyOp(op: SelectionOp): String = op match {
-    case Gt        => ">"
-    case Lt        => "<"
-    case Eq        => "="
-    case GtEq      => ">="
-    case LtEq      => "<="
-    case EqEq      => "=="
-    case NeEq      => "!="
-    case Tilde     => "~"
-    case EqTilde   => "=~"
-    case NeEqTilde => "!=~"
   }
 }

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
@@ -3,6 +3,7 @@ package latis.util.dap2.parser
 import org.scalacheck._
 import org.scalacheck.ScalacheckShapeless._
 
+import latis.ops.parser.ast._
 import ast._
 
 object ConstraintParserProps extends Properties("DAP 2 Constraint Parser") {

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
@@ -3,6 +3,7 @@ package latis.util.dap2.parser
 import org.junit._, Assert._
 import org.scalatestplus.junit.JUnitSuite
 
+import latis.ops.parser.ast._
 import ast._
 
 class TestConstraintParser extends JUnitSuite {


### PR DESCRIPTION
It looks like the diff is pretty confusing for the files that were moved from dap2-service to core. I just moved ast and ConstraintParser over, and moved all the individual parsers from ContraintParser into it's own object file called parsers. 