### PR TITLE
Add Identifier string interpolator to core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,7 @@ lazy val core = project
   .settings(
     name := "latis3-core",
     libraryDependencies ++= Seq(
+      "com.propensive"         %% "contextual"          % "1.2.1",
       "org.scala-lang"          % "scala-reflect"       % scalaVersion.value,
       "org.scala-lang.modules" %% "scala-xml"           % "1.3.0",
       "io.circe"               %% "circe-core"          % "0.13.0",

--- a/core/src/main/scala/latis/util/identifier.scala
+++ b/core/src/main/scala/latis/util/identifier.scala
@@ -1,0 +1,44 @@
+package latis.util
+
+import contextual._
+import latis.util.IdentifierInterpolator.checkValidIdentifier
+
+/**
+ * Defines a LaTiS identifier, a name that may contain only:
+ *   - letters
+ *   - numbers
+ *   - underscores
+ * so long as the identifier does not start with a number.
+ */
+sealed abstract case class Identifier(asString: String)
+object Identifier {
+  def fromString(id: String): Option[Identifier] =
+    if (checkValidIdentifier(id)) Some(new Identifier(id) {}) else None
+  
+  implicit class IdentifierStringContext(val sc: StringContext) extends AnyVal {
+    def id = Prefix(IdentifierInterpolator, sc)
+  }
+}
+
+/**
+ * Defines a String interpolator that will raise a compile error if the String isn't a valid LaTiS identifier. 
+ */
+object IdentifierInterpolator extends Interpolator {
+  
+  type Output = Identifier
+
+  def contextualize(interpolation: StaticInterpolation) = {
+    val lit@Literal(_, idString) = interpolation.parts.head
+    if(!checkValidIdentifier(idString))
+      interpolation.abort(lit, 0, "not a valid LaTiS identifier")
+
+    Nil
+  }
+
+  def evaluate(interpolation: RuntimeInterpolation): Identifier =
+    Identifier.fromString(interpolation.literals.head).get
+  
+  /** Returns whether the String is a regex "word" that doesn't start with a digit. */
+  def checkValidIdentifier(str: String): Boolean = str.matches("^(?!\\d)\\w+")
+  
+}

--- a/core/src/test/scala/latis/util/IdentifierSpec.scala
+++ b/core/src/test/scala/latis/util/IdentifierSpec.scala
@@ -1,0 +1,34 @@
+package latis.util
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+import latis.util.Identifier._
+
+class IdentifierSpec extends FlatSpec {
+
+  "A valid Identifier" should "compile" in {
+    id"myString"
+  }
+  
+  it should "equal the original string when .asString is used" in {
+    val id: Identifier = id"myString"
+    id.asString should be ("myString")
+  }
+  
+  it should "be able to contain letters, numbers (not the first character), and underscores" in {
+    id"myString_1"
+    id"_myString"
+    id"abcABC_123"
+    id"_123"
+    id"__"
+    
+  }
+  
+  "An invalid Identifier" should "not compile" in {
+    assertDoesNotCompile("val id = id\"my string\"") //contains a space
+    assertDoesNotCompile("val id = id\"123_abc\"")   //starts with a number
+    assertDoesNotCompile("Identifier(\"myString\")") //can't construct them like this
+  }
+  
+}


### PR DESCRIPTION
This PR cherry picks the identifier commit from [my other PR](https://github.com/latis-data/latis3/pull/93) so that we don't have to merge the identifier and python stuff in the same squashed commit. We'll merge this first and then merge the other one.