### PR TITLE
Add GranuleListAppendAdapter

### DIFF
--- a/core/src/main/scala/latis/input/GranuleListAppendAdapter.scala
+++ b/core/src/main/scala/latis/input/GranuleListAppendAdapter.scala
@@ -1,0 +1,46 @@
+package latis.input
+
+import java.net.URI
+
+import cats.implicits._
+import cats.effect.IO
+import fs2.Stream
+
+import latis.data.RangeData
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.data.Text
+import latis.dataset.Dataset
+import latis.ops.Operation
+import latis.util.LatisException
+import latis.util.NetUtils
+
+/**
+ * An adapter for creating a dataset from a list of granules.
+ *
+ * This adapter creates a dataset by applying a template adapter to
+ * each granule in a granule list dataset and appending the results.
+ *
+ * The granule list dataset is expected to be of the form `(d,,1,,,
+ * ..., d,,n,,) -> uri` or `(d,,1,,, ..., d,,n,,) -> (uri, ...)`.
+ */
+final class GranuleListAppendAdapter(granules: Dataset, template: URI => Dataset) {
+
+  /** Gets data using this adapter. */
+  def getData(ops: Seq[Operation]): SampledFunction = {
+    val samples: Stream[IO, Sample] = for {
+      sample <- granules.samples
+      uri    <- Stream.fromEither[IO](extractUri(sample))
+      dataset = template(uri)
+      result <- dataset.samples
+    } yield result
+
+    SampledFunction(samples)
+  }
+
+  private def extractUri(s: Sample): Either[LatisException, URI] = s match {
+    case Sample(_, RangeData(Text(uri)))    => NetUtils.parseUri(uri)
+    case Sample(_, RangeData(Text(uri), _)) => NetUtils.parseUri(uri)
+    case _ => LatisException("Expected sample with granule URI").asLeft
+  }
+}

--- a/core/src/main/scala/latis/input/fdml/fdml.scala
+++ b/core/src/main/scala/latis/input/fdml/fdml.scala
@@ -8,13 +8,24 @@ import latis.model.ValueType
 import latis.ops.parser.ast.CExpr
 
 /** Abstract representation of an FDML file. */
-final case class Fdml(
+sealed trait Fdml
+
+/** FDML file defining a dataset from a URI and adapter. */
+final case class DatasetFdml(
   metadata: Metadata,
-  source: FSource,
+  source: UriSource,
   adapter: FAdapter,
   model: FFunction,
   operations: List[CExpr] = List.empty
-)
+) extends Fdml
+
+/** FDML file defining a dataset from granules. */
+final case class GranuleAppendFdml(
+  metadata: Metadata,
+  source: GranuleSource,
+  template: FTemplate,
+  operations: List[CExpr] = List.empty
+) extends Fdml
 
 /**
  * Abstract representation of an adapter.
@@ -44,7 +55,18 @@ final case class FAdapter(
 }
 
 /** Abstract representation of a dataset source. */
-final case class FSource(uri: URI)
+sealed trait FSource
+
+final case class UriSource(uri: URI) extends FSource
+
+final case class GranuleSource(fdml: DatasetFdml) extends FSource
+
+/** Abstract representation of a dataset template. */
+final case class FTemplate(
+  adapter: FAdapter,
+  model: FFunction,
+  operations: List[CExpr] = List.empty
+)
 
 // Not using the FDM definition in latis.model because it can't
 // enforce useful invariants (scalars have an ID and a type, tuples

--- a/core/src/test/resources/fdml-parser/granule-append.fdml
+++ b/core/src/test/resources/fdml-parser/granule-append.fdml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dataset id="granuleAppend">
+
+  <source>
+    <granules>
+      <adapter class="granule-class"/>
+      <source uri="file:///source"/>
+      <function>
+        <scalar id="time"
+                units="days since 2000-01-01"
+                type="int"
+                class="latis.time.Time"/>
+        <scalar id="uri" type="string"/>
+      </function>
+    </granules>
+  </source>
+
+  <template>
+    <adapter class="template-class"/>
+    <function>
+      <scalar id="time"
+              units="days since 2000-01-01"
+              type="int"
+              class="latis.time.Time"/>
+      <scalar id="a" type="int"/>
+    </function>
+  </template>
+</dataset>

--- a/core/src/test/scala/latis/input/GranuleListAppendAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/GranuleListAppendAdapterSpec.scala
@@ -1,0 +1,177 @@
+package latis.input
+
+import java.net.URI
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+import latis.data.Data.IntValue
+import latis.data.Data.StringValue
+import latis.data.MemoizedFunction
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.dataset.Dataset
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+import latis.model.DataType
+import latis.model.Function
+import latis.model.Scalar
+
+final class GranuleListAppendAdapterSpec extends FlatSpec {
+
+  "A granule list append adapter" should
+    "create a dataset from appended granules" in {
+
+      val glaSamples = new GranuleListAppendAdapter(granuleList, template)
+        .getData(List.empty)
+        .samples
+        .compile
+        .toList
+        .unsafeRunSync
+
+      val gSamples = (g1.samples ++ g2.samples ++ g3.samples)
+        .compile
+        .toList
+        .unsafeRunSync
+
+      glaSamples should equal (gSamples)
+  }
+
+  private val granules: List[List[Sample]] = List(
+    // Contents of first granule
+    List(
+      Sample(List(StringValue("2020-01-01")), List(IntValue(1))),
+      Sample(List(StringValue("2020-01-02")), List(IntValue(2))),
+      Sample(List(StringValue("2020-01-03")), List(IntValue(3)))
+    ),
+    // Contents of second granule
+    List(
+      Sample(List(StringValue("2020-01-04")), List(IntValue(4))),
+      Sample(List(StringValue("2020-01-05")), List(IntValue(5))),
+      Sample(List(StringValue("2020-01-06")), List(IntValue(6)))
+    ),
+    // Contents of third granule
+    List(
+      Sample(List(StringValue("2020-01-07")), List(IntValue(7))),
+      Sample(List(StringValue("2020-01-08")), List(IntValue(8))),
+      Sample(List(StringValue("2020-01-09")), List(IntValue(9)))
+    )
+  )
+
+  // Dataset for first granule
+  private val g1: Dataset = {
+    val md: Metadata = Metadata("g1")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "value",
+          "type" -> "int"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(granules(0))
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // Dataset for second granule
+  private val g2: Dataset = {
+    val md: Metadata = Metadata("g2")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "value",
+          "type" -> "int"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(granules(1))
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // Dataset for third granule
+  private val g3: Dataset = {
+    val md: Metadata = Metadata("g3")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "value",
+          "type" -> "int"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(granules(2))
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // Granule list dataset
+  private val granuleList: Dataset = {
+    val md: Metadata = Metadata("granuleList")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(
+      List(
+        Sample(List(StringValue("2020-01-01")), List(StringValue("file:///1"))),
+        Sample(List(StringValue("2020-01-04")), List(StringValue("file:///2"))),
+        Sample(List(StringValue("2020-01-07")), List(StringValue("file:///3")))
+      )
+    )
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // A very simple adapter.
+  private def template(uri: URI): Dataset = uri.toString() match {
+    case "file:///1" => g1
+    case "file:///2" => g2
+    case "file:///3" => g3
+  }
+}


### PR DESCRIPTION
Here's what I have so far. Is this generally the kind of thing we want?

I'm ignoring ordering and operations at the moment because the semantics, if they are defined anywhere, are unclear to me.

I'm noticing more reasons that the granule append adapter is a different sort of adapter:
- The `Adapter` trait defines a `getData` method that requires a `URI`. Here we don't have a URI, because the source is the granule list dataset.
- The `AdapterFactory` apply method requires a `DataType`, which this adapter could get from the template. (It might be useful to have a model to check against each application of the template rather than assume the first is correct.)
- It seems likely that this adapter would be constructed specially in `FdmlReader` rather than using `AdapterFactory` because it has special syntax.