### PR TITLE
Add rename operation to dap2service

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -57,6 +57,8 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
         cexprs.exprs.traverse {
           case ast.Projection(vs)      => Right(ops.Projection(vs:_*))
           case ast.Selection(n, op, v) => Right(ops.Selection(n, ast.prettyOp(op), v))
+          case ast.Operation("rename", oldName :: newName :: Nil) =>
+            Right(ops.Rename(oldName, newName))
           // TODO: Here we may need to dynamically construct an
           // instance of an operation based on the query string and
           // server/interface configuration.

--- a/dap2-service/src/main/scala/latis/service/dap2/error/error.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/error/error.scala
@@ -5,3 +5,4 @@ final case class DatasetResolutionFailure(msg: String) extends Dap2Error
 final case class ParseFailure(msg: String) extends Dap2Error
 final case class UnknownExtension(msg: String) extends Dap2Error
 final case class UnknownOperation(msg: String) extends Dap2Error
+final case class InvalidOperation(msg: String) extends Dap2Error


### PR DESCRIPTION
Pretty self-explanatory. I make sure both names given are valid identifiers, but I can't check if the old name exists or if the new name is not taken because of reasons.