### PR TITLE
Fix construction of scalars using custom classes

### DIFF
--- a/core/src/main/scala/latis/input/fdml/FdmlReader.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlReader.scala
@@ -56,7 +56,7 @@ object FdmlReader {
     }
 
   private def makeScalar(scalar: FScalar): Either[LatisException, Scalar] =
-    scalar.attributes.get("clss") match {
+    scalar.attributes.get("class") match {
       case None       => Scalar(scalar.metadata).asRight
       case Some(clss) => Either.catchNonFatal {
         ReflectionUtils.callMethodOnCompanionObject(

--- a/core/src/test/resources/datasets/dataWithOperations.fdml
+++ b/core/src/test/resources/datasets/dataWithOperations.fdml
@@ -22,7 +22,7 @@
     </tuple>
   </function>
 
-  <?latis-operation expression="time > 0"?>
+  <?latis-operation expression="time > 2000-01-01"?>
 
   <?latis-operation expression="b, Constantinople"?>
 

--- a/core/src/test/scala/latis/input/fdml/FdmlReaderSpec.scala
+++ b/core/src/test/scala/latis/input/fdml/FdmlReaderSpec.scala
@@ -3,6 +3,7 @@ package latis.input.fdml
 import java.net.URI
 
 import org.scalatest.FlatSpec
+import org.scalatest.Inside._
 import org.scalatest.Matchers._
 
 import latis.data._
@@ -13,6 +14,17 @@ class FdmlReaderSpec extends FlatSpec {
 
   "An FDML Reader" should "create a dataset from FDML" in {
     val ds = FdmlReader.read(new URI("datasets/data.fdml"), true)
+
+    inside(ds.model) { case Function(domain, range) =>
+      domain shouldBe a [latis.time.Time]
+      range shouldBe a [Tuple]
+
+      inside(range) { case Tuple(s1, s2, s3) =>
+        s1 shouldBe a [Scalar]
+        s2 shouldBe a [Scalar]
+        s3 shouldBe a [Scalar]
+      }
+    }
 
     StreamUtils.unsafeHead(ds.samples) match {
       case Sample(DomainData(Number(t)), RangeData(Integer(b), Real(c), Text(d))) =>


### PR DESCRIPTION
Fixes the issue Shawn was having with selecting on time. The problem was that it was looking for a `clss` key when it was really `class`, so scalars using custom classes were never constructed using the custom class. I've updated a test to ensure that scalars using custom classes are constructed correctly.

I had to change another test because it was using a selection that no longer works when the scalar is actually `Time` rather than just `Scalar`.