### PR TITLE
Test NetCDF beta

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val coursierVersion   = "2.0.0-RC6-13"
 val fs2Version        = "2.3.0"
 val http4sVersion     = "0.21.3"
 val junitVersion      = "4.13"
-val netcdfVersion     = "5.3.1"
+val netcdfVersion     = "5.4.0-SNAPSHOT"
 val pureconfigVersion = "0.12.3"
 
 lazy val commonSettings = compilerFlags ++ Seq(
@@ -174,6 +174,7 @@ lazy val netcdf = project
       "edu.ucar"            % "netcdf4"          % netcdfVersion,
     ),
     resolvers ++= Seq(
-      "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases"
+      "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases",
+      "Unidata Snapshots" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-snapshots"
     )
   )

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -9,6 +9,7 @@ import ucar.ma2.{Range => URange}
 import ucar.ma2.Section
 import ucar.nc2.{Variable => NcVariable}
 import ucar.nc2.dataset.NetcdfDataset
+import ucar.nc2.dataset.NetcdfDatasets
 
 import latis.data._
 import latis.model._
@@ -149,7 +150,7 @@ object NetcdfAdapter extends AdapterFactory {
     }
 
     Stream.bracket(IO {
-      NetcdfDataset.openDataset(path)
+      NetcdfDatasets.openDataset(path)
     })(nc => IO(nc.close()))
   }
 

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -1,7 +1,6 @@
 package latis.input
 
 import java.net.URI
-import java.nio.file._
 
 import cats.effect.IO
 import fs2.Stream


### PR DESCRIPTION
I've updated this branch to use NetCDF 4.5.0-SNAPSHOT and fixed the deprecation warnings.

It's possible to do what we've been doing with the new API, but it's sort of clunky. The biggest difference is that we no longer have direct access to `Variable`s until after `build`ing the NetCDF file, so the clever trick of zipping variables and data together for writing now needs an extra step.

I didn't spend much time thinking if there was a better way to do this that took more advantage of the new API.