### PR TITLE
Hard code some things for the server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,6 +123,7 @@ lazy val `fdml-validator` = project
 
 lazy val `dap2-service` = project
   .dependsOn(core)
+  .dependsOn(netcdf)
   .dependsOn(`service-interface`)
   .settings(commonSettings)
   .settings(
@@ -149,6 +150,7 @@ lazy val python = project
 
 lazy val server = project
   .dependsOn(core)
+  .dependsOn(`dap2-service`)
   .dependsOn(`service-interface`)
   .enablePlugins(DockerPlugin)
   .settings(commonSettings)

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -6,6 +6,6 @@ latis {
   mapping = ${?LATIS_MAPPING}
 
   services = [
-    {type: "maven", name: "dap2-service-interface", version: "0.1.0-SNAPSHOT", mapping: "/dap2", class: "latis.service.dap2.Dap2Service"}
+    {type: "class", mapping: "/dap2", class: "latis.service.dap2.Dap2Service"}
   ]
 }


### PR DESCRIPTION
This hard-codes some encoders and the DAP2 service interface so we don't need to deal with plugins for the moment.

You'll notice that every encoder is handled differently, which is why it's so hard to come up with a plugin mechanism. One part of the challenge is how they are constructed (we've talked about this before), but the other part is that they need to be converted into something of the same type. I've chosen to combine getting the encoder by the extension and encoding the dataset into a single step so I can represent them all as streams of bytes.

The only reasons the DAP2 interface is being hard-coded are:
- depending on the NetCDF subproject means the dependency resolution needs to support additional resolvers, which it currently does not (to get the Unidata artifact repo)
- the dependency resolution assumes 2.12 artifacts

These are both things that could be fixed with some effort, which maybe I'll do before this gets merged. Right now it's in a weird state where this stuff is configurable but the default configuration is the only one that works.

Closes #103.