### PR TITLE
Add selection operation to NetCDF adapter

### DIFF
--- a/core/src/test/scala/latis/ops/SelectionSpec.scala
+++ b/core/src/test/scala/latis/ops/SelectionSpec.scala
@@ -5,7 +5,6 @@ import latis.metadata.Metadata
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import latis.model._
-import latis.time
 import latis.time.Time
 
 

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -4,6 +4,7 @@ import java.net.URI
 
 import cats.effect.IO
 import cats.implicits._
+import cats.Semigroupal
 import fs2.Stream
 import ucar.ma2.{Array => NcArray}
 import ucar.ma2.{Range => URange}
@@ -34,8 +35,10 @@ case class NetcdfAdapter(
    */
   override def canHandleOperation(op: Operation): Boolean = op match {
     case Stride(stride) if stride.length == model.arity => true
-    case Selection(v, _, _) => model.getVariable(v).flatMap(_("cadence")).nonEmpty &&
-      model.getVariable(v).flatMap(_("start")).nonEmpty
+    case Selection(v, _, _) => Semigroupal[Option].product(
+      model.getVariable(v).flatMap(_("cadence")),
+      model.getVariable(v).flatMap(_("start"))
+    ).nonEmpty
     //TODO: take, drop, ...
     case _ => false
   }

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -2,24 +2,23 @@ package latis.input
 
 import java.net.URI
 
-import scala.math.min
 import scala.math.max
+import scala.math.min
 
 import cats.effect.IO
 import cats.implicits._
-import cats.Semigroupal
 import fs2.Stream
+import ucar.ma2.Section
 import ucar.ma2.{Array => NcArray}
 import ucar.ma2.{Range => URange}
-import ucar.ma2.Section
-import ucar.nc2.{Variable => NcVariable}
 import ucar.nc2.dataset.NetcdfDataset
+import ucar.nc2.{Variable => NcVariable}
 
 import latis.data._
 import latis.model._
 import latis.ops.Operation
-import latis.ops.Stride
 import latis.ops.Selection
+import latis.ops.Stride
 import latis.ops.parser.ast._
 import latis.util._
 
@@ -41,12 +40,11 @@ case class NetcdfAdapter(
    */
   override def canHandleOperation(op: Operation): Boolean = op match {
     case Stride(stride) if stride.length == model.arity => true
-    case s@Selection(v, _, _) => Semigroupal[Option].product(
-      model.getVariable(v).flatMap(_("cadence")),
-      model.getVariable(v).flatMap(_("start"))
-    ).nonEmpty && (s.getSelectionOp match {
-      case Right(Gt) | Right(Lt) | Right(GtEq) | Right(LtEq) | Right(Eq) | Right(EqEq) => true
-      case _ => false
+    case s@Selection(v, _, _) => model.getVariable(v).exists(
+      v => v("cadence").nonEmpty && v("start").nonEmpty) &&
+      (s.getSelectionOp match {
+        case Right(Gt) | Right(Lt) | Right(GtEq) | Right(LtEq) | Right(Eq) | Right(EqEq) => true
+        case _ => false
     })
     //TODO: take, drop, ...
     case _ => false

--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -1,22 +1,77 @@
+package latis.input
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import ucar.ma2.Range
 import ucar.ma2.Section
 
-import latis.input.NetcdfAdapter
+import latis.metadata.Metadata
+import latis.model._
+import latis.ops.Selection
+import latis.util.LatisException
 
 class NetcdfAdapterSpec extends FlatSpec {
 
   "A section" should "be strided" in {
-    val section = new Section("0:9:3, 1:4:2")
-    val stride: Array[Int] = Array(2,2)
-    val s = NetcdfAdapter.applyStride(section: Section, stride: Array[Int])
-    s.toString should be ("0:6:6,1:1:4")
+    val section            = new Section("0:9:3, 1:4:2")
+    val stride: Array[Int] = Array(2, 2)
+    val s                  = NetcdfAdapter.applyStride(section: Section, stride: Array[Int])
+    s.toString should be("Right(0:6:6,1:1:4)")
   }
 
   "A range with a stride" should "make a consistent last value" in {
     val range = new Range(1, 4, 2) // 1:3:2
-    range.last should be (3)
+    range.last should be(3)
   }
+
+  "A NetcdfAdapter selection operation" should "support LT selection" in {
+    val expectedSection = new Section("0:1")
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 8.5")) should be(
+      Right(expectedSection)
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 9")) should be(
+      Right(expectedSection)
+    )
+  }
+
+  "A NetcdfAdapter selection operation" should "support GT selection" in {
+    val expectedSection = new Section("1:2")
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time > 7.5")) should be(
+      Right(expectedSection)
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time > 7")) should be(
+      Right(expectedSection)
+    )
+  }
+
+  "A NetcdfAdapter selection operation" should "support LE selection" in {
+    val expectedSection = new Section("0:1")
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time <= 8.5")) should be(
+      Right(expectedSection)
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time <= 8")) should be(
+      Right(expectedSection)
+    )
+  }
+
+  "A NetcdfAdapter selection operation" should "support GE selection" in {
+    val expectedSection = new Section("1:2")
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 7.5")) should be(
+      Right(expectedSection)
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 8")) should be(
+      Right(expectedSection)
+    )
+  }
+
+  "A NetcdfAdapter selection operation" should "handle invalid selections gracefully" in {
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 6")) should be(
+      Left(LatisException("Selection value is outside of data range"))
+    )
+  }
+
+  private val model = Function(
+    Scalar(Metadata("id" -> "time", "type" -> "int", "cadence" -> "1", "start" -> "7")),
+    Scalar(Metadata("id" -> "flux", "type" -> "double"))
+  )
 }

--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -2,7 +2,7 @@ package latis.input
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
-import ucar.ma2.Range
+import ucar.ma2.{Range => URange}
 import ucar.ma2.Section
 
 import latis.metadata.Metadata
@@ -32,6 +32,12 @@ class NetcdfAdapterSpec extends FlatSpec {
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 9")) should be(
       Right(expectedSection)
     )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 9001")) should be(
+      Right(new Section("0:2"))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 0")) should be(
+      Right(new Section(URange.EMPTY))
+    )
   }
 
   "A NetcdfAdapter selection operation" should "support GT selection" in {
@@ -41,6 +47,12 @@ class NetcdfAdapterSpec extends FlatSpec {
     )
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time > 7")) should be(
       Right(expectedSection)
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time > 0")) should be(
+      Right(new Section("0:2"))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time > 9000")) should be(
+      Right(new Section(URange.EMPTY))
     )
   }
 
@@ -52,6 +64,12 @@ class NetcdfAdapterSpec extends FlatSpec {
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time <= 8")) should be(
       Right(expectedSection)
     )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time <= 9001")) should be(
+      Right(new Section("0:2"))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time <= 0")) should be(
+      Right(new Section(URange.EMPTY))
+    )
   }
 
   "A NetcdfAdapter selection operation" should "support GE selection" in {
@@ -62,11 +80,11 @@ class NetcdfAdapterSpec extends FlatSpec {
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 8")) should be(
       Right(expectedSection)
     )
-  }
-
-  "A NetcdfAdapter selection operation" should "handle invalid selections gracefully" in {
-    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 6")) should be(
-      Left(LatisException("Selection value is outside of data range"))
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 0")) should be(
+      Right(new Section("0:2"))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 9001")) should be(
+      Right(new Section(URange.EMPTY))
     )
   }
 

--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -2,13 +2,12 @@ package latis.input
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
-import ucar.ma2.{Range => URange}
 import ucar.ma2.Section
+import ucar.ma2.{Range => URange}
 
 import latis.metadata.Metadata
 import latis.model._
 import latis.ops.Selection
-import latis.util.LatisException
 
 class NetcdfAdapterSpec extends FlatSpec {
 

--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -20,7 +20,7 @@ class NetcdfAdapterSpec extends FlatSpec {
   }
 
   "A range with a stride" should "make a consistent last value" in {
-    val range = new Range(1, 4, 2) // 1:3:2
+    val range = new URange(1, 4, 2) // 1:3:2
     range.last should be(3)
   }
 

--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -24,7 +24,7 @@ class NetcdfAdapterSpec extends FlatSpec {
     range.last should be(3)
   }
 
-  "A NetcdfAdapter selection operation" should "support LT selection" in {
+  "A NetcdfAdapter selection operation" should "support < selection" in {
     val expectedSection = new Section("0:1")
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time < 8.5")) should be(
       Right(expectedSection)
@@ -40,7 +40,7 @@ class NetcdfAdapterSpec extends FlatSpec {
     )
   }
 
-  "A NetcdfAdapter selection operation" should "support GT selection" in {
+  "A NetcdfAdapter selection operation" should "support > selection" in {
     val expectedSection = new Section("1:2")
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time > 7.5")) should be(
       Right(expectedSection)
@@ -56,7 +56,7 @@ class NetcdfAdapterSpec extends FlatSpec {
     )
   }
 
-  "A NetcdfAdapter selection operation" should "support LE selection" in {
+  "A NetcdfAdapter selection operation" should "support <= selection" in {
     val expectedSection = new Section("0:1")
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time <= 8.5")) should be(
       Right(expectedSection)
@@ -72,7 +72,7 @@ class NetcdfAdapterSpec extends FlatSpec {
     )
   }
 
-  "A NetcdfAdapter selection operation" should "support GE selection" in {
+  "A NetcdfAdapter selection operation" should "support >= selection" in {
     val expectedSection = new Section("1:2")
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 7.5")) should be(
       Right(expectedSection)
@@ -84,6 +84,27 @@ class NetcdfAdapterSpec extends FlatSpec {
       Right(new Section("0:2"))
     )
     NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time >= 9001")) should be(
+      Right(new Section(URange.EMPTY))
+    )
+  }
+
+  "A NetcdfAdapter selection operation" should "support = and == selections" in {
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time = 8")) should be(
+      Right(new Section("1"))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time == 8")) should be(
+      Right(new Section("1"))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time = 8.01")) should be(
+      Right(new Section(URange.EMPTY))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time == 8.01")) should be(
+      Right(new Section(URange.EMPTY))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time = 0")) should be(
+      Right(new Section(URange.EMPTY))
+    )
+    NetcdfAdapter.applySelection(new Section("0:2"), model, Selection("time == 0")) should be(
       Right(new Section(URange.EMPTY))
     )
   }


### PR DESCRIPTION
The selection operation only works for datasets with cadence and start value metadata. 

This does not work for datasets where the range data is time formatted strings. I'll have to learn more about the latis time package to add that functionality.