### PR TITLE
Generalize Operations to use Data instead of SampledFunction

### DIFF
--- a/core/src/main/scala/latis/data/CompositeSampledFunction.scala
+++ b/core/src/main/scala/latis/data/CompositeSampledFunction.scala
@@ -58,8 +58,8 @@ case class CompositeSampledFunction(sampledFunctions: Seq[SampledFunction])
    * but unary is just partially applied binary
    */
 
-  override def applyOperation(op: UnaryOperation, model: DataType): SampledFunction =
-    CompositeSampledFunction(sampledFunctions.map(_.applyOperation(op, model)))
+  override def applyOperation(op: UnaryOperation, model: DataType): Data =
+    CompositeSampledFunction(sampledFunctions.map(_.applyOperation(op, model).asFunction)) //TODO: consider ConstantFunction
 
   //TODO: optimize other operations by delegating to granules; e.g. select, project
 }

--- a/core/src/main/scala/latis/data/Data.scala
+++ b/core/src/main/scala/latis/data/Data.scala
@@ -14,6 +14,7 @@ import latis.util.StreamUtils
  * The Data trait is the root of all data values that go into a Sample.
  */
 sealed trait Data extends Any {
+  //TODO: implicit ConstantFunction?
   def asFunction: SampledFunction = this match {
     case sf: SampledFunction => sf
     case d => ConstantFunction(d)
@@ -73,7 +74,7 @@ trait SampledFunction extends Data {
     }
 
   //def canHandleOperation(op: UnaryOperation): Boolean
-  def applyOperation(op: UnaryOperation, model: DataType): SampledFunction = //TODO: Either
+  def applyOperation(op: UnaryOperation, model: DataType): Data = //TODO: Either
     op.applyToData(this, model) //default when special SF can't apply op
 
   def unsafeForce: MemoizedFunction = this match { //TODO: Either

--- a/core/src/main/scala/latis/dataset/TappedDataset.scala
+++ b/core/src/main/scala/latis/dataset/TappedDataset.scala
@@ -50,20 +50,20 @@ class TappedDataset(
   /**
    * Applies the operations and returns a Stream of Samples.
    */
-  def samples: Stream[IO, Sample] = applyOperations().samples
+  def samples: Stream[IO, Sample] = applyOperations().asFunction.samples
 
   /**
    * Applies the Operations to the Data and returns a SampledFunction.
    */
-  private def applyOperations(): SampledFunction = {
+  private def applyOperations(): Data = {
     //TODO: compile/optimize the operations
 
-    // Defines a function to apply an Operation to a SampledFunction.
+    // Defines a function to apply an Operation to Data.
     // The model (DataType) needs to ride along to provide context.
-    val f: ((DataType, SampledFunction), UnaryOperation) => (DataType, SampledFunction) =
-      (modat: (DataType, SampledFunction), op: UnaryOperation) =>
+    val f: ((DataType, Data), UnaryOperation) => (DataType, Data) =
+      (modat: (DataType, Data), op: UnaryOperation) =>
         modat match {
-          case (model: DataType, data: SampledFunction) =>
+          case (model: DataType, data: Data) =>
             val mod2 = op.applyToModel(model)
             // Enables a smart SampledFunction to apply the Operation.
             // Note that it will return a superclass if it can't.
@@ -72,7 +72,7 @@ class TappedDataset(
         }
 
     // Apply the operations to the data
-    operations.foldLeft((_model, data.asFunction))(f)._2
+    operations.foldLeft((_model, data))(f)._2
   }
 
   /**
@@ -83,7 +83,7 @@ class TappedDataset(
   def unsafeForce(): MemoizedDataset = new MemoizedDataset(
     metadata,  //from super with ops applied
     model,     //from super with ops applied
-    applyOperations().unsafeForce
+    applyOperations().asFunction.unsafeForce
   )
 
 }

--- a/core/src/main/scala/latis/ops/Append.scala
+++ b/core/src/main/scala/latis/ops/Append.scala
@@ -13,10 +13,7 @@ case class Append() extends BinaryOperation {
 
   def applyToModel(model1: DataType, model2: DataType): DataType = model1
 
-  def applyToData(
-    data1: SampledFunction,
-    data2: SampledFunction
-  ): SampledFunction =
-    SampledFunction(data1.samples ++ data2.samples)
+  def applyToData(data1: Data, data2: Data): SampledFunction =
+    SampledFunction(data1.asFunction.samples ++ data2.asFunction.samples)
 
 }

--- a/core/src/main/scala/latis/ops/BinaryOperation.scala
+++ b/core/src/main/scala/latis/ops/BinaryOperation.scala
@@ -1,6 +1,6 @@
 package latis.ops
 
-import latis.data.SampledFunction
+import latis.data.Data
 import latis.model.DataType
 
 /**
@@ -22,9 +22,6 @@ trait BinaryOperation extends Operation {
   /**
    * Combines the Data of two Datasets.
    */
-  def applyToData(
-    data1: SampledFunction,
-    data2: SampledFunction
-  ): SampledFunction
+  def applyToData(data1: Data, data2: Data): Data
 
 }

--- a/core/src/main/scala/latis/ops/Evaluation.scala
+++ b/core/src/main/scala/latis/ops/Evaluation.scala
@@ -5,27 +5,27 @@ import latis.model._
 
 /**
  * Defines an operation that evaluates a Dataset at a given value
- * returning a new Dataset encapsulatng the range value as a
- * ConstantFunction.
+ * returning a new Dataset.
  */
-case class Evaluation(data: Data) extends UnaryOperation {
+case class Evaluation(domainData: Data) extends UnaryOperation {
 
-  def applyToModel(model: DataType): DataType = {
+  def applyToModel(model: DataType): DataType =
     //TODO: assert that data is of the right type based on the model domain
     model match {
       case Function(_, r) => r
-      case _ => model
+      case _              => model
     }
-  }
 
-  def applyToData(sf: SampledFunction, model: DataType): SampledFunction = sf match {
-    case cf: ConstantFunction => cf
-    case sf: SampledFunction =>
-      val ecf = for {
-        dd <- DomainData.fromData(data)
-        rd <- sf(dd)
-        d   = Data.fromSeq(rd)
-      } yield ConstantFunction(d)
-      ecf.toTry.get //throw the exception if Left
-  }
+  def applyToData(data: Data, model: DataType): Data =
+    data match {
+      case sf: SampledFunction =>
+        val ecf = for {
+          dd <- DomainData.fromData(domainData)
+          rd <- sf(dd)
+          d = Data.fromSeq(rd)
+        } yield d
+        ecf.toTry.get //throw the exception if Left
+      // Other Data are effectively constant functions
+      case const => const
+    }
 }

--- a/core/src/main/scala/latis/ops/GranuleListJoin.scala
+++ b/core/src/main/scala/latis/ops/GranuleListJoin.scala
@@ -30,7 +30,7 @@ case class GranuleListJoin(
    * to generate a SampledFunction for each and wrap them all
    * in a CompositeSampledFunction.
    */
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction = {
+  override def applyToData(data: Data, model: DataType): Data = {
 
     // Get the position of the "uri" value within a Sample
     val pos: SamplePosition = model.getPath("uri") match {
@@ -53,7 +53,7 @@ case class GranuleListJoin(
     // and combine into a CompositeSampledFunction.
     // Note the unsafeForce so we can get the Seq out of IO.
     //TODO: do we need a CompositeDataset?
-    CompositeSampledFunction(data.unsafeForce.sampleSeq.map(f))
+    CompositeSampledFunction(data.asFunction.unsafeForce.sampleSeq.map(f))
   }
 
 }

--- a/core/src/main/scala/latis/ops/GroupByBin.scala
+++ b/core/src/main/scala/latis/ops/GroupByBin.scala
@@ -22,8 +22,8 @@ case class GroupByBin(
   /**
    * Extends the default by constructing a SetFunction with the domainSet.
    */
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction = {
-    val range = super.applyToData(data, model).unsafeForce.sampleSeq.map(_.range).toIndexedSeq
+  override def applyToData(data: Data, model: DataType): Data = {
+    val range = super.applyToData(data, model).asFunction.unsafeForce.sampleSeq.map(_.range).toIndexedSeq
     SetFunction(domainSet, range)
   }
 

--- a/core/src/main/scala/latis/ops/PartiallyAppliedBinaryOperation.scala
+++ b/core/src/main/scala/latis/ops/PartiallyAppliedBinaryOperation.scala
@@ -1,6 +1,6 @@
 package latis.ops
 
-import latis.data.SampledFunction
+import latis.data.Data
 import latis.dataset._
 import latis.model.DataType
 
@@ -18,7 +18,7 @@ case class PartiallyAppliedBinaryOperation(
   override def applyToModel(model: DataType): DataType =
     binOp.applyToModel(dataset.model, model)
 
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction = {
+  override def applyToData(data: Data, model: DataType): Data = {
     val data0 = dataset match {
       case ad: AdaptedDataset => ad.tap().data.asFunction
       case td: TappedDataset  => td.data.asFunction

--- a/core/src/main/scala/latis/ops/Rename.scala
+++ b/core/src/main/scala/latis/ops/Rename.scala
@@ -1,6 +1,6 @@
 package latis.ops
 
-import latis.data.SampledFunction
+import latis.data.Data
 import latis.model._
 
 /**
@@ -19,5 +19,5 @@ case class Rename(origName: String, newName: String) extends UnaryOperation {
   /**
    * Provides a no-op implementation for Rename.
    */
-  def applyToData(data: SampledFunction, model: DataType): SampledFunction = data
+  def applyToData(data: Data, model: DataType): Data = data
 }

--- a/core/src/main/scala/latis/ops/Resample.scala
+++ b/core/src/main/scala/latis/ops/Resample.scala
@@ -28,13 +28,13 @@ case class Resample(dset: DomainSet) extends UnaryOperation {
   /**
    * Apply the DomainSet to the given SampledFunction.
    */
-  def applyToData(sf: SampledFunction, model: DataType): SampledFunction = sf match {
-    case ConstantFunction(data) =>
+  def applyToData(data: Data, model: DataType): Data = data match {
+    case sf: SampledFunction =>
+      sf(dset).toTry.get //throw the exception if Left
+    case data =>
       // Duplicate const for every domain value
       val range: IndexedSeq[RangeData] = Vector.fill(dset.length)(RangeData(data))
       SetFunction(dset, range)
-    case sf: SampledFunction =>
-      sf(dset).toTry.get //throw the exception if Left
   }
 
 }

--- a/core/src/main/scala/latis/ops/StreamOperation.scala
+++ b/core/src/main/scala/latis/ops/StreamOperation.scala
@@ -3,6 +3,7 @@ package latis.ops
 import cats.effect.IO
 import fs2.Pipe
 
+import latis.data.Data
 import latis.data.Sample
 import latis.data.SampledFunction
 import latis.model.DataType
@@ -27,9 +28,9 @@ trait StreamOperation extends UnaryOperation {
   //TODO: simply compose pipes? but need to be able to build Op of original type
 
   /**
-   * Applies this operation to SampledFunction data.
+   * Applies this operation to Samples.
    */
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction =
-    SampledFunction(data.samples.through(pipe(model)))
+  override def applyToData(data: Data, model: DataType): Data =
+    SampledFunction(data.asFunction.samples.through(pipe(model)))
 
 }

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -1,6 +1,6 @@
 package latis.ops
 
-import latis.data.SampledFunction
+import latis.data.Data
 import latis.model.DataType
 
 /**
@@ -16,6 +16,6 @@ trait UnaryOperation extends Operation {
   /**
    * Provides new Data resulting from this Operation.
    */
-  def applyToData(data: SampledFunction, model: DataType): SampledFunction
+  def applyToData(data: Data, model: DataType): Data
 
 }

--- a/core/src/test/scala/latis/ops/EvaluationSpec.scala
+++ b/core/src/test/scala/latis/ops/EvaluationSpec.scala
@@ -9,50 +9,57 @@ import latis.util.DatasetGenerator
 class EvaluationSpec extends FlatSpec {
 
   "Evaluation" should "evaluate a 1D dataset" in {
-    DatasetGenerator.generate1DDataset(
-      Vector(0, 1, 2),
-      Vector(10, 20, 30)
-    ).withOperation(Evaluation(1)).unsafeForce().data match {
+    DatasetGenerator
+      .generate1DDataset(
+        Vector(0, 1, 2),
+        Vector(10, 20, 30)
+      )
+      .withOperation(Evaluation(1))
+      .unsafeForce()
+      .data match {
       case ConstantFunction(Number(d)) =>
-        d should be (20)
+        d should be(20)
     }
   }
 
   "Evaluation" should "evaluate a 2D dataset" in {
     val d = TupleData(1, 4)
-    DatasetGenerator.generate2DDataset(
-      Vector(0, 1, 2),
-      Vector(3, 4),
-      Vector(
-        Vector(10, 20),
-        Vector(12, 22),
-        Vector(14, 24)
+    DatasetGenerator
+      .generate2DDataset(
+        Vector(0, 1, 2),
+        Vector(3, 4),
+        Vector(
+          Vector(10, 20),
+          Vector(12, 22),
+          Vector(14, 24)
+        )
       )
-    ).withOperation(Evaluation(d)).unsafeForce().data match {
+      .withOperation(Evaluation(d))
+      .unsafeForce()
+      .data match {
       case ConstantFunction(Number(d)) =>
-        d should be (22)
+        d should be(22)
     }
   }
 
-
   "Evaluation" should "evaluate a nested dataset" in {
-    val ds = DatasetGenerator.generate2DDataset(
-      Vector(0, 1, 2),
-      Vector(100, 200, 300),
-      Vector(
-        Vector(10, 20, 30),
-        Vector(12, 22, 32),
-        Vector(14, 24, 34)
+    val ds = DatasetGenerator
+      .generate2DDataset(
+        Vector(0, 1, 2),
+        Vector(100, 200, 300),
+        Vector(
+          Vector(10, 20, 30),
+          Vector(12, 22, 32),
+          Vector(14, 24, 34)
+        )
       )
-    ).curry(1)
-     .eval(1)
+      .curry(1)
+      .eval(1)
+
     ds.unsafeForce().data.sampleSeq.head match {
-      case Sample(_, RangeData(mf: MemoizedFunction)) =>
-        mf.sampleSeq.head match {
-          case Sample(DomainData(Number(x)), RangeData(Number(a))) =>
-            x should be (100)
-            a should be (12)
-        }
+      case Sample(DomainData(Number(x)), RangeData(Number(a))) =>
+        x should be(100)
+        a should be(12)
     }
   }
 


### PR DESCRIPTION
This is the initial step of widening the use of `SampledFunction` to use any `Data` (#102). The general solution is to use `Data.asFunction` to put `Datum` and `TupleData` into a `ConstantFunction`. Some implications still need to be revisited to make sure they make sense in the context of non-`SampledFunction` data.

I also plan to change return types of `Operation's` apply methods to `Either[LatisException, ?]` as part of this PR.