### PR TITLE
Add metadata encoder

### DIFF
--- a/core/src/main/scala/latis/output/MetadataEncoder.scala
+++ b/core/src/main/scala/latis/output/MetadataEncoder.scala
@@ -1,0 +1,52 @@
+package latis.output
+
+import cats.effect.IO
+import fs2.Stream
+import io.circe.{Encoder => JEncoder}
+import io.circe.Json
+import io.circe.syntax._
+
+import latis.dataset.Dataset
+
+/**
+ * An encoder that only encodes metadata.
+ *
+ * This encoder emits a single JSON object similar to the following:
+ *
+ * {{{
+ * {
+ *   "id": "...",
+ *   "model": "...",
+ *   ... other dataset metadata,
+ *   "variables": [
+ *     {
+ *       "id": "...",
+ *       ... other variable metadata
+ *     },
+ *     ...
+ *   ]
+ * }
+ * }}}
+ */
+class MetadataEncoder extends Encoder[IO, Json] {
+
+  override def encode(dataset: Dataset): Stream[IO, Json] =
+    Stream.emit(MetadataEncoder.MetadataOnly(dataset).asJson)
+}
+
+object MetadataEncoder {
+  private final case class MetadataOnly(ds: Dataset) extends AnyVal
+
+  private implicit val mdEncoder: JEncoder[MetadataOnly] =
+    new JEncoder[MetadataOnly] {
+      def apply(md: MetadataOnly): Json = {
+        val datasetMetadata = md.ds.metadata.properties.asJsonObject
+        val variableMetadata = md.ds.model.getScalars.map(_.metadata.properties).asJson
+        Json.fromJsonObject(
+          datasetMetadata
+            .add("model", md.ds.model.toString().asJson)
+            .add("variables", variableMetadata)
+        )
+      }
+    }
+}

--- a/core/src/test/scala/latis/output/MetadataEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/MetadataEncoderSpec.scala
@@ -1,0 +1,55 @@
+package latis.output
+
+import io.circe.Json
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+import latis.data.SampledFunction
+import latis.dataset.Dataset
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+import latis.model.Function
+import latis.model.Scalar
+
+final class MetadataEncoderSpec extends FlatSpec {
+
+  private val dataset: Dataset = {
+    val metadata = Metadata("dataset")
+
+    val model = Function(
+      Metadata("function"),
+      Scalar(Metadata("id" -> "a", "type" -> "int")),
+      Scalar(Metadata("id" -> "b", "type" -> "int"))
+    )
+
+    val data = SampledFunction(Seq.empty)
+
+    new MemoizedDataset(metadata, model, data)
+  }
+
+  "A metadata encoder" should "encode the ID of the dataset being encoded" in {
+    val md = (new MetadataEncoder).encode(dataset).compile.lastOrError.unsafeRunSync()
+
+    val cursor = md.hcursor
+    cursor.get[String]("id").getOrElse {
+      fail("Missing dataset ID")
+    } should equal ("dataset")
+    cursor.get[String]("model").getOrElse {
+      fail("Missing model")
+    } should equal ("a -> b")
+
+    val variables = cursor.downField("variables")
+    variables.downN(0).get[String]("id").getOrElse {
+      fail("Missing variable ID")
+    } should equal ("a")
+    variables.downN(0).get[String]("type").getOrElse {
+      fail("Missing variable type")
+    } should equal ("int")
+    variables.downN(1).get[String]("id").getOrElse {
+      fail("Missing variable ID")
+    } should equal ("b")
+    variables.downN(1).get[String]("type").getOrElse {
+      fail("Missing variable type")
+    } should equal ("int")
+  }
+}


### PR DESCRIPTION
How about something like this?

The output for a dataset `dataset: a -> b` looks like this:

```json
{
  "id" : "dataset",
  "history" : "",
  "variables" : [
    {
      "id" : "a",
      "type" : "int"
    },
    {
      "id" : "b",
      "type" : "int"
    }
  ]
}
```

Any metadata on the dataset or on the scalars will be added to the JSON. Are there other things we want?