### PR TITLE
Add request/response logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val server = project
       "org.http4s"            %% "http4s-dsl"             % http4sVersion,
       "com.github.pureconfig" %% "pureconfig"             % pureconfigVersion,
       "com.github.pureconfig" %% "pureconfig-cats-effect" % pureconfigVersion,
+      "io.chrisdavenport"     %% "log4cats-slf4j"         % "1.1.1",
       "ch.qos.logback"         % "logback-classic"        % "1.2.3" % Runtime
     ),
     // Required to suppress spurious warnings with 2.13.3

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.http4s" level="INFO" />
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -45,6 +45,7 @@ object Latis3Server extends IOApp {
           .withHttpApp {
             Router(mapping -> routes).orNotFound
           }
+          .withoutBanner
           .serve
           .compile
           .drain

--- a/server/src/main/scala/latis/server/LatisServiceLogger.scala
+++ b/server/src/main/scala/latis/server/LatisServiceLogger.scala
@@ -1,0 +1,51 @@
+package latis.server
+
+import cats.Monad
+import cats.data.Kleisli
+import cats.effect.Clock
+import cats.effect.Timer
+import cats.implicits._
+import io.chrisdavenport.log4cats.Logger
+import org.http4s.HttpApp
+import org.http4s.Response
+import org.http4s.Request
+import java.util.concurrent.TimeUnit
+
+/**
+ * Middleware that logs requests and responses (without bodies) and
+ * the time elapsed between receiving the request and starting the
+ * response.
+ */
+object LatisServiceLogger {
+
+  def apply[F[_]: Monad: Timer](
+    app: HttpApp[F],
+    logger: Logger[F]
+  ): HttpApp[F] = Kleisli { req =>
+    for {
+      t0  <- Clock[F].monotonic(TimeUnit.MILLISECONDS)
+      res <- app(req)
+      t1  <- Clock[F].monotonic(TimeUnit.MILLISECONDS)
+      elapsed = t1 - t0
+      _   <- logger.info(makeMessage(req, res, elapsed))
+    } yield res
+  }
+
+  private def makeMessage[F[_]](
+    req: Request[F],
+    res: Response[F],
+    elapsed: Long
+  ): String = {
+    val reqMsg = req match {
+      case Request(method, uri, version, headers, _, _) =>
+        s"$version $method $uri $headers"
+    }
+
+    val resMsg = res match {
+      case Response(status, version, headers, _, _) =>
+        s"$version $status $headers"
+    }
+
+    s"Request: {$reqMsg} Response: {$resMsg} Elapsed (ms): $elapsed"
+  }
+}


### PR DESCRIPTION
This adds [http4s middleware](https://http4s.org/v0.21/middleware/) (a fancy name for a function with a specific shape) that logs requests and responses (without bodies) and the time between getting the request and starting the response. (In other words, the time it takes for us to start sending data.)

The logs end up looking like this:

```
23:51:04.992 [ioapp-compute-0] INFO  latis.server.Latis3Server - Request: {HTTP/1.1 GET /dap2/cak.txt Headers(Host: localhost:8080, User-Agent: curl/7.52.1, Accept: */*)} Response: {HTTP/1.1 200 OK Headers(Transfer-Encoding: chunked)} Elapsed (ms): 148
```

This does not log errors or warnings for things that go wrong during the request, but it will log if an error response is generated:

```
00:19:39.798 [ioapp-compute-2] INFO  latis.server.Latis3Server - Request: {HTTP/1.1 GET /dap2/cak.txt?fake%28%29 Headers(Host: localhost:8080, User-Agent: curl/7.52.1, Accept: */*)} Response: {HTTP/1.1 400 Bad Request Headers(Content-Type: text/plain; charset=UTF-8, Content-Length: 23)} Elapsed (ms): 353
00:20:14.482 [ioapp-compute-3] INFO  latis.server.Latis3Server - Request: {HTTP/1.1 GET /dap2/cak.txt?time%2Cfake Headers(Host: localhost:8080, User-Agent: curl/7.52.1, Accept: */*)} Response: {HTTP/1.1 500 Internal Server Error Headers(Content-Length: 0)} Elapsed (ms): 161
```

I'm not settled on the format of the message, and I'm also not entirely convinced this is better than having multiple messages with a unique identifier. I just wanted to get this out there so we can start talking about it.

I did not use the built-in middleware for logging because it generates two messages (one for the request and one for the response) and it doesn't capture the duration.

See #120.