### PR TITLE
Add request/response logging 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,6 +165,7 @@ lazy val server = project
       "org.http4s"            %% "http4s-dsl"             % http4sVersion,
       "com.github.pureconfig" %% "pureconfig"             % pureconfigVersion,
       "com.github.pureconfig" %% "pureconfig-cats-effect" % pureconfigVersion,
+      "io.chrisdavenport"     %% "log4cats-slf4j"         % "1.1.1",
       "ch.qos.logback"         % "logback-classic"        % "1.2.3" % Runtime
     ),
     // Required to suppress spurious warnings with 2.13.3

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.http4s" level="INFO" />
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %X %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -45,6 +45,7 @@ object Latis3Server extends IOApp {
           .withHttpApp {
             Router(mapping -> routes).orNotFound
           }
+          .withoutBanner
           .serve
           .compile
           .drain

--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -6,6 +6,8 @@ import cats.effect.Blocker
 import cats.effect.ExitCode
 import cats.effect.IO
 import cats.effect.IOApp
+import io.chrisdavenport.log4cats.StructuredLogger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.http4s.HttpRoutes
 import org.http4s.implicits._
 import org.http4s.server.Router
@@ -37,28 +39,32 @@ object Latis3Server extends IOApp {
     Router(routes:_*)
   }
 
-  private def startServer(routes: HttpRoutes[IO], conf: ServerConf): IO[Unit] =
-    conf match {
-      case ServerConf(port, mapping) =>
-        BlazeServerBuilder[IO](ExecutionContext.global)
-          .bindHttp(port, "0.0.0.0")
-          .withHttpApp {
-            Router(mapping -> routes).orNotFound
-          }
-          .withoutBanner
-          .serve
-          .compile
-          .drain
-    }
+  private def startServer(
+    routes: HttpRoutes[IO],
+    conf: ServerConf,
+    logger: StructuredLogger[IO]
+  ): IO[Unit] = conf match {
+    case ServerConf(port, mapping) =>
+      BlazeServerBuilder[IO](ExecutionContext.global)
+        .bindHttp(port, "0.0.0.0")
+        .withHttpApp {
+          LatisServiceLogger(Router(mapping -> routes).orNotFound, logger)
+        }
+        .withoutBanner
+        .serve
+        .compile
+        .drain
+  }
 
   def run(args: List[String]): IO[ExitCode] =
     Blocker[IO].use { blocker =>
       for {
+        logger      <- Slf4jLogger.create[IO]
         serverConf  <- getServerConf(blocker)
         serviceConf <- getServiceConf(blocker)
         services    <- loader.loadServices(serviceConf)
         routes       = constructRoutes(services)
-        _           <- startServer(routes, serverConf)
+        _           <- startServer(routes, serverConf, logger)
       } yield ExitCode.Success
     }
 }

--- a/server/src/main/scala/latis/server/LatisServiceLogger.scala
+++ b/server/src/main/scala/latis/server/LatisServiceLogger.scala
@@ -1,0 +1,44 @@
+package latis.server
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+import cats.data.Kleisli
+import cats.effect.Clock
+import cats.effect.Sync
+import cats.effect.Timer
+import cats.implicits._
+import io.chrisdavenport.log4cats.StructuredLogger
+import org.http4s.HttpApp
+import org.http4s.Response
+import org.http4s.Request
+import org.http4s.server.middleware.{Logger => Http4sLogger}
+
+/**
+ * Middleware that logs requests and responses (without bodies) and
+ * the time elapsed between receiving the request and starting the
+ * response.
+ */
+object LatisServiceLogger {
+
+  def apply[F[_]: Sync: Timer](
+    app: HttpApp[F],
+    logger: StructuredLogger[F]
+  ): HttpApp[F] = Kleisli { req =>
+    for {
+      id       <- Sync[F].delay(UUID.randomUUID().toString())
+      ctxLogger = StructuredLogger.withContext(logger)(Map("request-id" -> id))
+      _        <- Http4sLogger.logMessage[F, Request[F]](req)(
+        logHeaders = true, logBody = false
+      )(ctxLogger.info(_))
+      t0       <- Clock[F].monotonic(TimeUnit.MILLISECONDS)
+      res      <- app(req)
+      t1       <- Clock[F].monotonic(TimeUnit.MILLISECONDS)
+      _        <- Http4sLogger.logMessage[F, Response[F]](res)(
+        logHeaders = true, logBody = false
+      )(ctxLogger.info(_))
+      elapsed   = t1 - t0
+      _        <- ctxLogger.info(s"Elapsed (ms): $elapsed")
+    } yield res
+  }
+}


### PR DESCRIPTION
Here's an alternative to #123 that logs multiple messages but with a unique ID per request. The features are the same otherwise.

This is what the messages look like:

```
00:13:20.552 [ioapp-compute-3] INFO  latis.server.Latis3Server - request-id=7053652d-99ce-40ad-8739-9140cb8b4673 HTTP/1.1 GET /dap2/cak.txt Headers(Host: localhost:8080, User-Agent: curl/7.52.1, Accept: */*)
00:13:21.594 [ioapp-compute-3] INFO  latis.server.Latis3Server - request-id=7053652d-99ce-40ad-8739-9140cb8b4673 HTTP/1.1 200 OK Headers(Transfer-Encoding: chunked)
00:13:21.596 [ioapp-compute-3] INFO  latis.server.Latis3Server - request-id=7053652d-99ce-40ad-8739-9140cb8b4673 Elapsed (ms): 1034
```

I think the Splunk query will be easier than the LaTiS 2 query because these are UUIDs that shouldn't be repeated instead of IDs that get recycled between requests.