### PR TITLE
Add PI support for more operations

### DIFF
--- a/core/src/main/scala/latis/dataset/package.scala
+++ b/core/src/main/scala/latis/dataset/package.scala
@@ -21,7 +21,7 @@ package object dataset {
     def compose(df: Dataset): Dataset = dataset.withOperation(Composition(df))
     def contains(varName: String, values: String*): Dataset = dataset.withOperation(Contains(varName, values: _*))
     def rename(varName: String, newName: String): Dataset = dataset.withOperation(Rename(varName, newName))
-    def eval(value: Data): Dataset = dataset.withOperation(Evaluation(value))
+    def eval(value: String): Dataset = dataset.withOperation(Evaluation(value))
     def withReader(reader: DatasetReader): Dataset = dataset.withOperation(ReaderOperation(reader))
 
     def filter(predicate: Sample => Boolean): Dataset = dataset.withOperation(Filter(predicate))

--- a/core/src/main/scala/latis/input/fdml/FdmlParser.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlParser.scala
@@ -40,7 +40,7 @@ object FdmlParser {
     function   <- findRootFunction(xml)
     model      <- parseFunction(function)
     exprs      <- parseProcessingInstructions(xml)
-    operations <- parseExpressions(exprs)
+    operations <- exprs.traverse(parseExpression)
   } yield Fdml(metadata, source, adapter, model, operations)
 
   // Assuming that this is an FDML file if the root element is
@@ -154,11 +154,6 @@ object FdmlParser {
         LatisException(s"latis-operation must contain expression in $s").asLeft
     }.toList.sequence
   }
-
-  private def parseExpressions(
-    expressions: List[String]
-  ): Either[LatisException, List[CExpr]] =
-    expressions.traverse(parseExpression)
 
   private def parseExpression(
     expression: String

--- a/core/src/main/scala/latis/input/fdml/FdmlReader.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlReader.scala
@@ -87,9 +87,6 @@ object FdmlReader {
       case ast.Selection(n, op, v) =>
         Right(ops.Selection(n, ast.prettyOp(op), v))
       case ast.Operation(name, args) =>
-        UnaryOperation.makeOperation(name, args) match {
-          case Some(o) => Right(o)
-          case None => Left(LatisException(s"Failed to construct operation $name"))
-        }
+        UnaryOperation.makeOperation(name, args)
     }
 }

--- a/core/src/main/scala/latis/input/fdml/FdmlReader.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlReader.scala
@@ -28,7 +28,7 @@ object FdmlReader {
   def read(fdml: Fdml): Either[LatisException, Dataset] = for {
     model      <- makeFunction(fdml.model)
     adapter    <- makeAdapter(fdml.adapter, model)
-    operations <- makeOperations(fdml.operations)
+    operations <- fdml.operations.traverse(makeOperation)
   } yield new AdaptedDataset(
     fdml.metadata,
     model,
@@ -79,21 +79,17 @@ object FdmlReader {
     ).asInstanceOf[Adapter]
   }.leftMap(LatisException(_))
 
-  private def makeOperations(
-    op: List[ast.CExpr]
-  ): Either[LatisException, List[UnaryOperation]] =
-    op.traverse(parseOperation)
-
-  private def parseOperation(
+  private def makeOperation(
     expression: ast.CExpr
   ): Either[LatisException, UnaryOperation] =
     expression match {
       case ast.Projection(vs) => Right(ops.Projection(vs: _*))
       case ast.Selection(n, op, v) =>
         Right(ops.Selection(n, ast.prettyOp(op), v))
-      case ast.Operation("rename", oldName :: newName :: Nil) =>
-        Right(ops.Rename(oldName, newName))
-      case ast.Operation("project", vs) => Right(ops.Projection(vs: _*))
-      case ast.Operation(op, _) => Left(LatisException(s"Unknown operation: $op"))
+      case ast.Operation(name, args) =>
+        UnaryOperation.makeOperation(name, args) match {
+          case Some(o) => Right(o)
+          case None => Left(LatisException(s"Failed to construct operation $name"))
+        }
     }
 }

--- a/core/src/main/scala/latis/ops/Curry.scala
+++ b/core/src/main/scala/latis/ops/Curry.scala
@@ -1,7 +1,6 @@
 package latis.ops
 
-import scala.util.Try
-import scala.util.Success
+import cats.implicits._
 
 import latis.data.DomainData
 import latis.data.Sample
@@ -73,12 +72,10 @@ case class Curry(arity: Int = 1) extends GroupOperation {
 
 object Curry {
 
-  def fromArgs(args: List[String]): Option[UnaryOperation] = args match {
-    case arity :: Nil => Try(arity.toInt) match {
-      case Success(a) => Some(Curry(a))
-      case _ => None
-    }
-    case Nil => Some(Curry())
-    case _ => None
+  def fromArgs(args: List[String]): Either[LatisException, Curry] = args match {
+    case arity :: Nil => Either.catchOnly[NumberFormatException](Curry(arity.toInt))
+      .leftMap(LatisException(_))
+    case Nil => Right(Curry())
+    case _ => Left(LatisException("Too many arguments to Curry"))
   }
 }

--- a/core/src/main/scala/latis/ops/Curry.scala
+++ b/core/src/main/scala/latis/ops/Curry.scala
@@ -1,5 +1,8 @@
 package latis.ops
 
+import scala.util.Try
+import scala.util.Success
+
 import latis.data.DomainData
 import latis.data.Sample
 import latis.model.DataType
@@ -66,4 +69,16 @@ case class Curry(arity: Int = 1) extends GroupOperation {
     DefaultAggregation().compose(mapOp)
   }
 
+}
+
+object Curry {
+
+  def fromArgs(args: List[String]): Option[UnaryOperation] = args match {
+    case arity :: Nil => Try(arity.toInt) match {
+      case Success(a) => Some(Curry(a))
+      case _ => None
+    }
+    case Nil => Some(Curry())
+    case _ => None
+  }
 }

--- a/core/src/main/scala/latis/ops/Evaluation.scala
+++ b/core/src/main/scala/latis/ops/Evaluation.scala
@@ -1,18 +1,15 @@
 package latis.ops
 
-import atto.Atto._
-import cats.implicits._
-
 import latis.data._
 import latis.model._
-import latis.ops.parser.parsers.data
+import latis.util.LatisException
 
 /**
  * Defines an operation that evaluates a Dataset at a given value
  * returning a new Dataset encapsulating the range value as a
  * ConstantFunction.
  */
-case class Evaluation(data: Data) extends UnaryOperation {
+case class Evaluation(data: String) extends UnaryOperation {
 
   def applyToModel(model: DataType): DataType = {
     //TODO: assert that data is of the right type based on the model domain
@@ -26,7 +23,8 @@ case class Evaluation(data: Data) extends UnaryOperation {
     case cf: ConstantFunction => cf
     case sf: SampledFunction =>
       val ecf = for {
-        dd <- DomainData.fromData(data)
+        v  <- model.getScalars.head.parseValue(data)
+        dd <- DomainData.fromData(v)
         rd <- sf(dd)
         d   = Data.fromSeq(rd)
       } yield ConstantFunction(d)
@@ -36,8 +34,8 @@ case class Evaluation(data: Data) extends UnaryOperation {
 
 object Evaluation {
 
-  def fromArgs(args: List[String]): Option[UnaryOperation] = for {
-    ds <- args.traverse(data.parseOnly(_).option)
-    d = Data.fromSeq(ds)
-  } yield Evaluation(d)
+  def fromArgs(args: List[String]): Either[LatisException, Evaluation] = args match {
+    case arg :: Nil => Right(Evaluation(arg))
+    case _ => Left(LatisException("Evaluation requires exactly one argument"))
+  }
 }

--- a/core/src/main/scala/latis/ops/Evaluation.scala
+++ b/core/src/main/scala/latis/ops/Evaluation.scala
@@ -1,11 +1,15 @@
 package latis.ops
 
+import atto.Atto._
+import cats.implicits._
+
 import latis.data._
 import latis.model._
+import latis.ops.parser.parsers.data
 
 /**
  * Defines an operation that evaluates a Dataset at a given value
- * returning a new Dataset encapsulatng the range value as a
+ * returning a new Dataset encapsulating the range value as a
  * ConstantFunction.
  */
 case class Evaluation(data: Data) extends UnaryOperation {
@@ -28,4 +32,12 @@ case class Evaluation(data: Data) extends UnaryOperation {
       } yield ConstantFunction(d)
       ecf.toTry.get //throw the exception if Left
   }
+}
+
+object Evaluation {
+
+  def fromArgs(args: List[String]): Option[UnaryOperation] = for {
+    ds <- args.traverse(data.parseOnly(_).option)
+    d = Data.fromSeq(ds)
+  } yield Evaluation(d)
 }

--- a/core/src/main/scala/latis/ops/Pivot.scala
+++ b/core/src/main/scala/latis/ops/Pivot.scala
@@ -1,7 +1,10 @@
 package latis.ops
 
+import atto.Atto._
+
 import latis.data._
 import latis.model._
+import latis.ops.parser.parsers.scalarArg
 
 /**
  * Pivot the samples of a nested Function such that each outer sample becomes
@@ -79,4 +82,20 @@ case class Pivot(values: Seq[String], vids: Seq[String]) extends MapOperation {
     case _ => ??? //invalid data type
   }
 
+}
+
+object Pivot {
+
+  def fromArgs(args: List[String]): Option[UnaryOperation] = {
+    // define a parser that doesn't allow nested lists
+    val argParser = parens(sepBy(scalarArg.token, char(',').token))
+
+    args match {
+      case valuesStr :: vidsStr :: Nil => for {
+        values <- argParser.parseOnly(valuesStr).option
+        vids   <- argParser.parseOnly(vidsStr).option
+      } yield Pivot(values, vids)
+      case _ => None
+    }
+  }
 }

--- a/core/src/main/scala/latis/ops/Pivot.scala
+++ b/core/src/main/scala/latis/ops/Pivot.scala
@@ -5,6 +5,7 @@ import atto.Atto._
 import latis.data._
 import latis.model._
 import latis.ops.parser.parsers.scalarArg
+import latis.util.LatisException
 
 /**
  * Pivot the samples of a nested Function such that each outer sample becomes
@@ -86,16 +87,18 @@ case class Pivot(values: Seq[String], vids: Seq[String]) extends MapOperation {
 
 object Pivot {
 
-  def fromArgs(args: List[String]): Option[UnaryOperation] = {
+  def fromArgs(args: List[String]): Either[LatisException, Pivot] = {
     // define a parser that doesn't allow nested lists
     val argParser = parens(sepBy(scalarArg.token, char(',').token))
 
     args match {
       case valuesStr :: vidsStr :: Nil => for {
         values <- argParser.parseOnly(valuesStr).option
+          .toRight(LatisException(s"Failed to parse Pivot input 'values': $valuesStr"))
         vids   <- argParser.parseOnly(vidsStr).option
+          .toRight(LatisException(s"Failed to parse Pivot input 'vids': $vidsStr"))
       } yield Pivot(values, vids)
-      case _ => None
+      case _ => Left(LatisException("Pivot requires exactly two list arguments"))
     }
   }
 }

--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -61,8 +61,8 @@ object Projection {
   def apply(exp: String): Projection =
     Projection(exp.split(",").toIndexedSeq: _*)
 
-  def fromArgs(args: List[String]): Option[UnaryOperation] = args match {
-    case Nil => None
-    case _   => Some(Projection(args: _*))
+  def fromArgs(args: List[String]): Either[LatisException, Projection] = args match {
+    case Nil => Left(LatisException("Projection requires at least one argument"))
+    case _   => Right(Projection(args: _*))
   }
 }

--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -60,4 +60,9 @@ object Projection {
 
   def apply(exp: String): Projection =
     Projection(exp.split(",").toIndexedSeq: _*)
+
+  def fromArgs(args: List[String]): Option[UnaryOperation] = args match {
+    case Nil => None
+    case _   => Some(Projection(args: _*))
+  }
 }

--- a/core/src/main/scala/latis/ops/Rename.scala
+++ b/core/src/main/scala/latis/ops/Rename.scala
@@ -21,3 +21,11 @@ case class Rename(origName: String, newName: String) extends UnaryOperation {
    */
   def applyToData(data: SampledFunction, model: DataType): SampledFunction = data
 }
+
+object Rename {
+
+  def fromArgs(args: List[String]): Option[UnaryOperation] = args match {
+    case oldName :: newName :: Nil => Some(Rename(oldName, newName))
+    case _ => None
+  }
+}

--- a/core/src/main/scala/latis/ops/Rename.scala
+++ b/core/src/main/scala/latis/ops/Rename.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data.SampledFunction
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Define an Operation that renames a specific variable within a Dataset.
@@ -24,8 +25,8 @@ case class Rename(origName: String, newName: String) extends UnaryOperation {
 
 object Rename {
 
-  def fromArgs(args: List[String]): Option[UnaryOperation] = args match {
-    case oldName :: newName :: Nil => Some(Rename(oldName, newName))
-    case _ => None
+  def fromArgs(args: List[String]): Either[LatisException, Rename] = args match {
+    case oldName :: newName :: Nil => Right(Rename(oldName, newName))
+    case _ => Left(LatisException("Rename requires exactly two arguments"))
   }
 }

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -19,3 +19,15 @@ trait UnaryOperation extends Operation {
   def applyToData(data: SampledFunction, model: DataType): SampledFunction
 
 }
+
+object UnaryOperation {
+
+  def makeOperation(name: String, args: List[String]): Option[UnaryOperation] = name match {
+    case "project" => Projection.fromArgs(args)
+    case "rename" => Rename.fromArgs(args)
+    case "curry" => Curry.fromArgs(args)
+    case "pivot" => Pivot.fromArgs(args)
+    case "evaluation" => Evaluation.fromArgs(args)
+    case _ => None
+  }
+}

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data.SampledFunction
 import latis.model.DataType
+import latis.util.LatisException
 
 /**
  * Defines an Operation that acts on a single Dataset.
@@ -22,12 +23,16 @@ trait UnaryOperation extends Operation {
 
 object UnaryOperation {
 
-  def makeOperation(name: String, args: List[String]): Option[UnaryOperation] = name match {
+  def makeOperation(
+    name: String,
+    args: List[String]
+  ): Either[LatisException, UnaryOperation] = name match {
     case "project" => Projection.fromArgs(args)
     case "rename" => Rename.fromArgs(args)
     case "curry" => Curry.fromArgs(args)
     case "pivot" => Pivot.fromArgs(args)
     case "evaluation" => Evaluation.fromArgs(args)
-    case _ => None
+    case "eval" => Evaluation.fromArgs(args)
+    case n => Left(LatisException(s"Unknown operator: $n"))
   }
 }

--- a/core/src/main/scala/latis/ops/parser/parsers.scala
+++ b/core/src/main/scala/latis/ops/parser/parsers.scala
@@ -3,7 +3,6 @@ package latis.ops.parser
 import atto.Atto._
 import atto.Parser
 
-import latis.data.Data
 import latis.ops.parser.ast._
 
 object parsers {
@@ -127,38 +126,4 @@ object parsers {
       t <- timeP | ok("")
     } yield List(y, m, d).mkString("-") + t
   }
-
-  def booleanValue: Parser[Data] = for {
-    n <- string("true") | string("True") | string("false") | string("False")
-  } yield Data.BooleanValue(n.toBoolean)
-
-  def floatValue: Parser[Data] = for {
-    n <- scientific | decimal
-    _ <- char('f') | char('F')
-  } yield Data.FloatValue(n.toFloat)
-
-  def doubleValue: Parser[Data] = for {
-    n <- scientific | decimal
-  } yield Data.DoubleValue(n.toDouble)
-
-  def intValue: Parser[Data] = for {
-    n <- integer
-  } yield Data.IntValue(n.toInt)
-
-  def longValue: Parser[Data] = for {
-    n <- integer
-    _ <- char('l') | char('L')
-  } yield Data.LongValue(n.toLong)
-
-  def numberValue: Parser[Data] =
-    floatValue | doubleValue | longValue | intValue
-
-  def stringValue: Parser[Data] = for {
-    s <- variable.token
-  // TODO: this will stop once it encounters a character that is not allowed as
-  //   a variable. Do we want to make StringValues from any string?
-  } yield Data.StringValue(s)
-
-  def data: Parser[Data] =
-    numberValue | booleanValue | stringValue
 }

--- a/core/src/main/scala/latis/ops/parser/parsers.scala
+++ b/core/src/main/scala/latis/ops/parser/parsers.scala
@@ -133,7 +133,7 @@ object parsers {
   } yield Data.BooleanValue(n.toBoolean)
 
   def floatValue: Parser[Data] = for {
-    n <- decimal
+    n <- scientific | decimal
     _ <- char('f') | char('F')
   } yield Data.FloatValue(n.toFloat)
 

--- a/core/src/test/scala/latis/ops/EvaluationSpec.scala
+++ b/core/src/test/scala/latis/ops/EvaluationSpec.scala
@@ -12,28 +12,11 @@ class EvaluationSpec extends FlatSpec {
     DatasetGenerator.generate1DDataset(
       Vector(0, 1, 2),
       Vector(10, 20, 30)
-    ).withOperation(Evaluation(1)).unsafeForce().data match {
+    ).withOperation(Evaluation("1")).unsafeForce().data match {
       case ConstantFunction(Number(d)) =>
         d should be (20)
     }
   }
-
-  "Evaluation" should "evaluate a 2D dataset" in {
-    val d = TupleData(1, 4)
-    DatasetGenerator.generate2DDataset(
-      Vector(0, 1, 2),
-      Vector(3, 4),
-      Vector(
-        Vector(10, 20),
-        Vector(12, 22),
-        Vector(14, 24)
-      )
-    ).withOperation(Evaluation(d)).unsafeForce().data match {
-      case ConstantFunction(Number(d)) =>
-        d should be (22)
-    }
-  }
-
 
   "Evaluation" should "evaluate a nested dataset" in {
     val ds = DatasetGenerator.generate2DDataset(
@@ -45,7 +28,7 @@ class EvaluationSpec extends FlatSpec {
         Vector(14, 24, 34)
       )
     ).curry(1)
-     .eval(1)
+     .eval("1")
     ds.unsafeForce().data.sampleSeq.head match {
       case Sample(_, RangeData(mf: MemoizedFunction)) =>
         mf.sampleSeq.head match {

--- a/core/src/test/scala/latis/ops/UnaryOperationSpec.scala
+++ b/core/src/test/scala/latis/ops/UnaryOperationSpec.scala
@@ -1,0 +1,25 @@
+package latis.ops
+
+import org.scalatest.FlatSpec
+import org.scalatest.Inside._
+import org.scalatest.Matchers._
+
+import latis.data.Data
+import latis.data.TupleData
+import latis.ops.UnaryOperation._
+
+class UnaryOperationSpec extends FlatSpec {
+
+  "makeOperation" should "make unary operations" in {
+    makeOperation("project", List("a", "b")) should be (Some(Projection("a", "b")))
+    makeOperation("rename", List("a", "b")) should be (Some(Rename("a", "b")))
+    makeOperation("curry", List("2")) should be (Some(Curry(2)))
+    makeOperation("curry", List()) should be (Some(Curry()))
+    makeOperation("pivot", List("(1,2)", "(Fe,Mg)")) should be (Some(Pivot(Seq("1", "2"), Seq("Fe", "Mg"))))
+    makeOperation("evaluation", List("1")) should be (Some(Evaluation(Data.IntValue(1))))
+    inside(makeOperation("evaluation", List("1", "b"))) { case Some(Evaluation(t)) =>
+      t.asInstanceOf[TupleData].elements should be (Seq(Data.IntValue(1), Data.StringValue("b")))
+    }
+  }
+
+}

--- a/core/src/test/scala/latis/ops/UnaryOperationSpec.scala
+++ b/core/src/test/scala/latis/ops/UnaryOperationSpec.scala
@@ -1,25 +1,18 @@
 package latis.ops
 
 import org.scalatest.FlatSpec
-import org.scalatest.Inside._
 import org.scalatest.Matchers._
 
-import latis.data.Data
-import latis.data.TupleData
 import latis.ops.UnaryOperation._
 
 class UnaryOperationSpec extends FlatSpec {
 
   "makeOperation" should "make unary operations" in {
-    makeOperation("project", List("a", "b")) should be (Some(Projection("a", "b")))
-    makeOperation("rename", List("a", "b")) should be (Some(Rename("a", "b")))
-    makeOperation("curry", List("2")) should be (Some(Curry(2)))
-    makeOperation("curry", List()) should be (Some(Curry()))
-    makeOperation("pivot", List("(1,2)", "(Fe,Mg)")) should be (Some(Pivot(Seq("1", "2"), Seq("Fe", "Mg"))))
-    makeOperation("evaluation", List("1")) should be (Some(Evaluation(Data.IntValue(1))))
-    inside(makeOperation("evaluation", List("1", "b"))) { case Some(Evaluation(t)) =>
-      t.asInstanceOf[TupleData].elements should be (Seq(Data.IntValue(1), Data.StringValue("b")))
-    }
+    makeOperation("project", List("a", "b")) should be (Right(Projection("a", "b")))
+    makeOperation("rename", List("a", "b")) should be (Right(Rename("a", "b")))
+    makeOperation("curry", List("2")) should be (Right(Curry(2)))
+    makeOperation("curry", List()) should be (Right(Curry()))
+    makeOperation("pivot", List("(1,2)", "(Fe,Mg)")) should be (Right(Pivot(Seq("1", "2"), Seq("Fe", "Mg"))))
+    makeOperation("evaluation", List("1")) should be (Right(Evaluation("1")))
   }
-
 }

--- a/core/src/test/scala/latis/ops/parser/ParsersSpec.scala
+++ b/core/src/test/scala/latis/ops/parser/ParsersSpec.scala
@@ -1,0 +1,43 @@
+package latis.ops.parser
+
+import atto.Atto._
+import atto.Parser
+import atto.ParseResult
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+import latis.data.Data
+
+class ParsersSpec extends FlatSpec {
+
+  "parsers.data" should "parse to Data of the correct type" in {
+    def testData = testParser(parsers.data)(_, _)
+    testData("1", Data.IntValue(1))
+    testData("1l", Data.LongValue(1L))
+    testData("1.1f", Data.FloatValue(1.1f))
+    testData("1.1", Data.DoubleValue(1.1))
+    testData("1.1e4", Data.DoubleValue(1.1e4))
+    testData("true", Data.BooleanValue(true))
+    testData("foo", Data.StringValue("foo"))
+  }
+
+  "parsers.operation" should "parse expressions to operations" in {
+    def testOperation = testParser(parsers.operation)(_, _)
+    testOperation("rename(Constantinople, Istanbul)", ast.Operation("rename", List("Constantinople", "Istanbul")))
+    testOperation("curry(1)", ast.Operation("curry", List("1")))
+    testOperation("pivot((1, 2), (Fe, Mg))", ast.Operation("pivot", List("(1,2)", "(Fe,Mg)")))
+    testOperation("foo((1, 2), ((a, b), (c)))", ast.Operation("foo", List("(1,2)", "((a,b),(c))")))
+  }
+
+  /**
+   * partially apply with a parser to get a function that takes the string you
+   * want to parse and the thing you expect to get back
+   */
+  private def testParser[A](p: Parser[A])(s: String, d: A): Unit = p.parseOnly(s) match {
+    case ParseResult.Done(_, result) => result should be (d)
+    case ParseResult.Fail(_, _, m) => throw new Exception(s"$m in $s")
+    // parseOnly will never return anything but Done or Fail, but the types don't
+    // know that so we get a warning without the following line.
+    case _ => throw new Exception(s"failed to parse $s")
+  }
+}

--- a/core/src/test/scala/latis/ops/parser/ParsersSpec.scala
+++ b/core/src/test/scala/latis/ops/parser/ParsersSpec.scala
@@ -17,7 +17,7 @@ class ParsersSpec extends FlatSpec {
   }
 
   /**
-   * partially apply with a parser to get a function that takes the string you
+   * Partially apply with a parser to get a function that takes the string you
    * want to parse and the thing you expect to get back
    */
   private def testParser[A](p: Parser[A])(s: String, d: A): Unit = p.parseOnly(s) match {

--- a/core/src/test/scala/latis/ops/parser/ParsersSpec.scala
+++ b/core/src/test/scala/latis/ops/parser/ParsersSpec.scala
@@ -1,28 +1,15 @@
 package latis.ops.parser
 
 import atto.Atto._
-import atto.Parser
 import atto.ParseResult
+import atto.Parser
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 
-import latis.data.Data
-
 class ParsersSpec extends FlatSpec {
 
-  "parsers.data" should "parse to Data of the correct type" in {
-    def testData = testParser(parsers.data)(_, _)
-    testData("1", Data.IntValue(1))
-    testData("1l", Data.LongValue(1L))
-    testData("1.1f", Data.FloatValue(1.1f))
-    testData("1.1", Data.DoubleValue(1.1))
-    testData("1.1e4", Data.DoubleValue(1.1e4))
-    testData("true", Data.BooleanValue(true))
-    testData("foo", Data.StringValue("foo"))
-  }
-
   "parsers.operation" should "parse expressions to operations" in {
-    def testOperation = testParser(parsers.operation)(_, _)
+    val testOperation = testParser(parsers.operation)(_, _)
     testOperation("rename(Constantinople, Istanbul)", ast.Operation("rename", List("Constantinople", "Istanbul")))
     testOperation("curry(1)", ast.Operation("curry", List("1")))
     testOperation("pivot((1, 2), (Fe, Mg))", ast.Operation("pivot", List("(1,2)", "(Fe,Mg)")))
@@ -35,9 +22,9 @@ class ParsersSpec extends FlatSpec {
    */
   private def testParser[A](p: Parser[A])(s: String, d: A): Unit = p.parseOnly(s) match {
     case ParseResult.Done(_, result) => result should be (d)
-    case ParseResult.Fail(_, _, m) => throw new Exception(s"$m in $s")
+    case ParseResult.Fail(_, _, m) => fail(s"$m in $s")
     // parseOnly will never return anything but Done or Fail, but the types don't
     // know that so we get a warning without the following line.
-    case _ => throw new Exception(s"failed to parse $s")
+    case _ => fail(s"failed to parse $s")
   }
 }


### PR DESCRIPTION
I got to have some fun with `atto` parsers in this one. I added a few parsers to allow parsing expressions that have lists for arguments (and even nested lists). I also added parsers that return `latis.data.Data` objects. I needed that to support `fromArgs` in the `Evaluation` operation, but if we decide we don't want those parsers we could always change the constructor for `Evaluation` to take something other than `Data`.

I moved the creation of operations from FdmlReader to UnaryOperation
Added support for the following operations in processing instructions:
- curry
- pivot
- evaluation