### PR TITLE
Support multiple sections in NetCDF adapter

### DIFF
--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -11,6 +11,11 @@ import latis.ops.Selection
 
 class NetcdfAdapterSpec extends FlatSpec {
 
+  private val model = Function(
+    Scalar(Metadata("id" -> "time", "type" -> "int", "cadence" -> "1", "start" -> "7")),
+    Scalar(Metadata("id" -> "flux", "type" -> "double"))
+  )
+
   "A section" should "be strided" in {
     val section            = new Section("0:9:3, 1:4:2")
     val stride: Array[Int] = Array(2, 2)
@@ -107,9 +112,4 @@ class NetcdfAdapterSpec extends FlatSpec {
       Right(new Section(URange.EMPTY))
     )
   }
-
-  private val model = Function(
-    Scalar(Metadata("id" -> "time", "type" -> "int", "cadence" -> "1", "start" -> "7")),
-    Scalar(Metadata("id" -> "flux", "type" -> "double"))
-  )
 }


### PR DESCRIPTION
The `section` attribute will now use semicolons to delimit multiple sections. `Section` was replaced with `List[Section]` where needed throughout the adapter. The idea is that if there is only one section, then that section should be used just as before, and if there are multiple sections, then there should be one for each scalar being read.

The operations that are supported in the adapter were written to operate on a single section. For these, I decided to just map over the sections. This will do the right thing when there is only one section, and even sometimes when there are multiple sections, but this logic should definitely be revisited.