### PR TITLE
Add sourceId to fdml

### DIFF
--- a/core/src/main/resources/fdml.xsd
+++ b/core/src/main/resources/fdml.xsd
@@ -88,6 +88,7 @@
         <xs:attribute name="resolution" type="xs:string"/>
         <xs:attribute name="start" type="xs:string"/>
         <xs:attribute name="end" type="xs:string"/>
+        <xs:attribute name="sourceId" type="xs:string"/>
     </xs:attributeGroup>
 
 </xs:schema>

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -362,7 +362,7 @@ case class NetcdfWrapper(ncDataset: NetcdfDataset, model: DataType, config: Netc
 
   // Note, get is safe since the id comes from the model in the first place
   private def getNcVarName(id: String): String =
-    makeValidPathName(model.findVariable(id).get.metadata.getProperty("origName").getOrElse(id))
+    makeValidPathName(model.findVariable(id).get.metadata.getProperty("sourceId").getOrElse(id))
 
   /**
    * Reads the section of the given variable into a NcArray.


### PR DESCRIPTION
We were already looking for an "origName" property in the Netcdf adaptor, but it wasn't a valid scalar attribute in fdml. We decided to go with "sourceId", so this PR adds that.