### PR TITLE
Refactor Operations to return Either

### DIFF
--- a/core/src/main/scala/latis/data/CompositeSampledFunction.scala
+++ b/core/src/main/scala/latis/data/CompositeSampledFunction.scala
@@ -1,6 +1,7 @@
 package latis.data
 
 import cats.effect.IO
+import cats.implicits._
 import fs2.Stream
 
 import latis.model.DataType
@@ -58,14 +59,14 @@ case class CompositeSampledFunction(sampledFunctions: Seq[SampledFunction])
    * but unary is just partially applied binary
    */
 
-  override def applyOperation(op: UnaryOperation, model: DataType): SampledFunction =
-    CompositeSampledFunction(sampledFunctions.map(_.applyOperation(op, model)))
+  override def applyOperation(op: UnaryOperation, model: DataType): Either[LatisException, SampledFunction] =
+    sampledFunctions.toList.traverse(_.applyOperation(op, model)).map(CompositeSampledFunction(_))
 
   //TODO: optimize other operations by delegating to granules; e.g. select, project
 }
 
 object CompositeSampledFunction {
 
-  def apply(sf1: SampledFunction, sfs: SampledFunction*) =
+  def apply(sf1: SampledFunction, sfs: SampledFunction*): CompositeSampledFunction =
     new CompositeSampledFunction(sf1 +: sfs)
 }

--- a/core/src/main/scala/latis/data/Data.scala
+++ b/core/src/main/scala/latis/data/Data.scala
@@ -73,7 +73,10 @@ trait SampledFunction extends Data {
     }
 
   //def canHandleOperation(op: UnaryOperation): Boolean
-  def applyOperation(op: UnaryOperation, model: DataType): SampledFunction = //TODO: Either
+  def applyOperation(
+    op: UnaryOperation,
+    model: DataType
+  ): Either[LatisException, SampledFunction] =
     op.applyToData(this, model) //default when special SF can't apply op
 
   def unsafeForce: MemoizedFunction = this match { //TODO: Either

--- a/core/src/main/scala/latis/dataset/AbstractDataset.scala
+++ b/core/src/main/scala/latis/dataset/AbstractDataset.scala
@@ -39,6 +39,6 @@ abstract class AbstractDataset(
    * original model returning the new model.
    */
   def model: DataType =
-    operations.foldLeft(_model)((mod, op) => op.applyToModel(mod))
+    operations.foldLeft(_model)((mod, op) => op.applyToModel(mod).fold(throw _, identity))
 
 }

--- a/core/src/main/scala/latis/ops/Append.scala
+++ b/core/src/main/scala/latis/ops/Append.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data._
 import latis.model.DataType
+import latis.util.LatisException
 
 /**
  * Joins two Datasets by appending their Streams of Samples.
@@ -11,12 +12,16 @@ case class Append() extends BinaryOperation {
   //TODO: deal with ConstantFunctions, add index domain
   //TODO: consider CompositeSampledFunction
 
-  def applyToModel(model1: DataType, model2: DataType): DataType = model1
+  def applyToModel(
+    model1: DataType,
+    model2: DataType
+  ): Either[LatisException, DataType] =
+    Right(model1)
 
   def applyToData(
     data1: SampledFunction,
     data2: SampledFunction
-  ): SampledFunction =
-    SampledFunction(data1.samples ++ data2.samples)
+  ): Either[LatisException, SampledFunction] =
+    Right(SampledFunction(data1.samples ++ data2.samples))
 
 }

--- a/core/src/main/scala/latis/ops/BinaryOperation.scala
+++ b/core/src/main/scala/latis/ops/BinaryOperation.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data.SampledFunction
 import latis.model.DataType
+import latis.util.LatisException
 
 /**
  * Defines an Operation that combines two Datasets into one.
@@ -17,7 +18,7 @@ trait BinaryOperation extends Operation {
   /**
    * Combines the models of two Datasets.
    */
-  def applyToModel(model1: DataType, model2: DataType): DataType
+  def applyToModel(model1: DataType, model2: DataType): Either[LatisException, DataType]
 
   /**
    * Combines the Data of two Datasets.
@@ -25,6 +26,6 @@ trait BinaryOperation extends Operation {
   def applyToData(
     data1: SampledFunction,
     data2: SampledFunction
-  ): SampledFunction
+  ): Either[LatisException, SampledFunction]
 
 }

--- a/core/src/main/scala/latis/ops/Composition.scala
+++ b/core/src/main/scala/latis/ops/Composition.scala
@@ -1,5 +1,7 @@
 package latis.ops
 
+import cats.implicits._
+
 import latis.data.Data
 import latis.data.DomainData
 import latis.dataset.ComputationalDataset
@@ -11,15 +13,18 @@ import latis.util.LatisException
 
 case class Composition(dataset: Dataset) extends MapRangeOperation {
 
-  override def applyToModel(model: DataType): DataType = {
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = {
     //TODO: make sure dataset range matches compFunction domain
     val domain = model match {
-      case Function(d, _) => d
+      case Function(d, _) => Right(d)
+      case _ => Left(LatisException("Model must be a function"))
     }
     val range = dataset.model match {
-      case Function(_, r) => r
+      case Function(_, r) => Right(r)
+      case _ => Left(LatisException("Composed dataset must be a function"))
+      // TODO: check this in a smart constructor
     }
-    Function(domain, range)
+    (domain, range).mapN(Function(_, _))
   }
 
   override def mapFunction(model: DataType): Data => Data = {

--- a/core/src/main/scala/latis/ops/Curry.scala
+++ b/core/src/main/scala/latis/ops/Curry.scala
@@ -52,14 +52,15 @@ case class Curry(arity: Int = 1) extends GroupOperation {
         }
 
       // takes the model for the dataset and returns the range of the curried dataset
-      override def applyToModel(model: DataType): DataType = model match {
+      override def applyToModel(model: DataType): Either[LatisException, DataType] = model match {
         // Ignore nested tuples
         case Function(d, range) =>
-          d.getScalars.drop(arity) match {
+          (d.getScalars.drop(arity) match {
             case Nil => range  // this happens when the arity is not changed
             case s1 :: Nil => Function(s1, range)
             case ss => Function(Tuple(ss), range)
-          }
+          }).asRight
+        case _ => Left(LatisException("Model must be a function"))
         //case Function(Tuple(es @ _*), range) => Function(Tuple(es.drop(arity)), range)
           //TODO: beef up edge cases
       }

--- a/core/src/main/scala/latis/ops/DefaultAggregation.scala
+++ b/core/src/main/scala/latis/ops/DefaultAggregation.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data._
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Defines an Operation that combines all the Samples
@@ -15,7 +16,7 @@ case class DefaultAggregation() extends Aggregation {
    * The input Data is lifted into the range of a
    * ConstantFunction so the type does not change.
    */
-  def applyToModel(model: DataType): DataType = model
+  def applyToModel(model: DataType): Either[LatisException, DataType] = Right(model)
 
   /**
    * Defines a function that puts the given Samples into

--- a/core/src/main/scala/latis/ops/GroupByBin.scala
+++ b/core/src/main/scala/latis/ops/GroupByBin.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable.ListBuffer
 
 import latis.data._
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Defines a GroupOperation that uses the given domainSet
@@ -22,10 +23,13 @@ case class GroupByBin(
   /**
    * Extends the default by constructing a SetFunction with the domainSet.
    */
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction = {
-    val range = super.applyToData(data, model).unsafeForce.sampleSeq.map(_.range).toIndexedSeq
-    SetFunction(domainSet, range)
-  }
+  override def applyToData(
+    data: SampledFunction,
+    model: DataType
+  ): Either[LatisException, SampledFunction] = for {
+    data <- super.applyToData(data, model)
+    range = data.unsafeForce.sampleSeq.map(_.range).toIndexedSeq
+  } yield SetFunction(domainSet, range)
 
   /*
   TODO: NearestNeaighborAgg, need diff agg for each bin, with DomainData to be closest to

--- a/core/src/main/scala/latis/ops/GroupOperation.scala
+++ b/core/src/main/scala/latis/ops/GroupOperation.scala
@@ -11,6 +11,7 @@ import latis.data._
 import latis.model.DataType
 import latis.model.Function
 import latis.util.CartesianDomainOrdering
+import latis.util.LatisException
 import latis.util.LatisOrdering
 import latis.util.StreamUtils
 
@@ -111,9 +112,7 @@ trait GroupOperation extends StreamOperation { self =>
    * The original model becomes the range which is then modified by the
    * Aggregation.
    */
-  override def applyToModel(model: DataType): DataType = {
-    val range = aggregation.applyToModel(model)
-    Function(domainType(model), range)
+  override def applyToModel(model: DataType): Either[LatisException, DataType] =
+    aggregation.applyToModel(model).map(Function(domainType(model), _))
     // TODO: preserve metadata from the original function
-  }
 }

--- a/core/src/main/scala/latis/ops/HeadAggregation.scala
+++ b/core/src/main/scala/latis/ops/HeadAggregation.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data._
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Defines an Aggregation that reduces the Samples of a Dataset to a ConstantFunction
@@ -11,14 +12,14 @@ case class HeadAggregation() extends Aggregation {
 
   def aggregateFunction(model: DataType): Iterable[Sample] => Data =
     (samples: Iterable[Sample]) =>
-      if (samples.isEmpty) applyToModel(model) match {
+      if (samples.isEmpty) applyToModel(model).fold(throw _, identity) match {
         case f: Function => SeqFunction(Seq.empty) //can't fill Function, use empty
         case dt => dt.fillValue
       }
       else Data.fromSeq(samples.head.range)
 
-  def applyToModel(model:DataType): DataType = model match {
-    case Function(_, r)=> r
-    case _ => ??? //TODO: error, model must be a Function
+  def applyToModel(model:DataType): Either[LatisException, DataType] = model match {
+    case Function(_, r) => Right(r)
+    case _ => Left(LatisException("Model must be a Function"))
   }
 }

--- a/core/src/main/scala/latis/ops/MapOperation.scala
+++ b/core/src/main/scala/latis/ops/MapOperation.scala
@@ -6,6 +6,7 @@ import fs2.Stream
 
 import latis.data._
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Defines an Operation that maps a function of Sample => Sample
@@ -32,11 +33,11 @@ trait MapOperation extends StreamOperation { self =>
    * Note that the given Operation will be applied first.
    */
   def compose(mapOp: MapOperation): MapOperation = new MapOperation {
-    def applyToModel(model: DataType): DataType =
-      self.applyToModel(mapOp.applyToModel(model))
+    def applyToModel(model: DataType): Either[LatisException, DataType] =
+      mapOp.applyToModel(model).flatMap(self.applyToModel)
 
     def mapFunction(model: DataType): Sample => Sample = {
-      val tmpModel = mapOp.applyToModel(model)
+      val tmpModel = mapOp.applyToModel(model).fold(throw _, identity)
       mapOp.mapFunction(model).andThen(self.mapFunction(tmpModel))
     }
   }

--- a/core/src/main/scala/latis/ops/NearestNeighborAggregation.scala
+++ b/core/src/main/scala/latis/ops/NearestNeighborAggregation.scala
@@ -2,6 +2,7 @@ package latis.ops
 
 import latis.data._
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Defines an Aggregation that reduces the Samples of a Dataset to a ConstantFunction
@@ -22,8 +23,8 @@ case class NearestNeighborAggregation(domain: DomainData) extends Aggregation {
       }
   }
 
-  def applyToModel(model:DataType): DataType = model match {
-    case Function(_, r)=> r
-    case _ => ??? //TODO: error, model must be a Function
+  def applyToModel(model:DataType): Either[LatisException, DataType] = model match {
+    case Function(_, r) => Right(r)
+    case _ => Left(LatisException("Model must be a Function"))
   }
 }

--- a/core/src/main/scala/latis/ops/Pivot.scala
+++ b/core/src/main/scala/latis/ops/Pivot.scala
@@ -70,17 +70,17 @@ case class Pivot(values: Seq[String], vids: Seq[String]) extends MapOperation {
    * Define new model. The nested Function is replaced with a Tuple
    * containing Scalars for each of the requested samples.
    */
-  override def applyToModel(model: DataType): DataType = model match {
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = model match {
     case Function(domain, Function(_, r)) =>
       val ranges = for {
         vid <- vids
         s <- r.getScalars
       } yield s.rename(vid ++ "_" ++ s.id)
-      ranges match {
+      Right(ranges match {
         case s1 :: Nil => Function(domain, s1)
         case ss => Function(domain, Tuple(ss))
-      }
-    case _ => ??? //invalid data type
+      })
+    case _ => Left(LatisException("Invalid DataType"))
   }
 
 }

--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -14,10 +14,8 @@ case class Projection(vnames: String*) extends MapOperation {
   //TODO: support dot notation for nested tuples
   //TODO: Index place holders for non-projected domain variables
 
-  override def applyToModel(model: DataType): DataType =
-    applyToVariable(model).getOrElse {
-      throw LatisException("Nothing projected")
-    }
+  override def applyToModel(model: DataType): Either[LatisException, DataType] =
+    applyToVariable(model).toRight(LatisException("Nothing projected"))
 
   /** Recursive method to apply the projection. */
   private def applyToVariable(v: DataType): Option[DataType] = v match {

--- a/core/src/main/scala/latis/ops/ReaderOperation.scala
+++ b/core/src/main/scala/latis/ops/ReaderOperation.scala
@@ -45,7 +45,8 @@ case class ReaderOperation(reader: DatasetReader, ops: Seq[UnaryOperation] = Seq
     }
   }
 
-  def applyToModel(model: DataType): DataType = model match {
-    case Function(d, _) => Function(d, reader.model)
+  def applyToModel(model: DataType): Either[LatisException, DataType] = model match {
+    case Function(d, _) => Right(Function(d, reader.model))
+    case _ => Left(LatisException("Model is not a function."))
   }
 }

--- a/core/src/main/scala/latis/ops/Rename.scala
+++ b/core/src/main/scala/latis/ops/Rename.scala
@@ -10,17 +10,21 @@ import latis.util.LatisException
  */
 case class Rename(origName: String, newName: String) extends UnaryOperation {
 
-  def applyToModel(model: DataType): DataType =
-    model.map {
-      case v if (v.id == origName) => v.rename(newName)
-      //TODO: support aliases with hasName
-      case v => v
+  def applyToModel(model: DataType): Either[LatisException, DataType] =
+  // TODO: support renaming tuples and functions
+    model.getVariable(origName) match {
+      case None => Left(LatisException(s"Variable '$origName' not found"))
+      case _ => Right(model.map { s =>
+        if (s.id == origName) s.rename(newName)
+        else s
+        //TODO: support aliases with hasName
+      })
     }
 
   /**
    * Provides a no-op implementation for Rename.
    */
-  def applyToData(data: SampledFunction, model: DataType): SampledFunction = data
+  def applyToData(data: SampledFunction, model: DataType): Either[LatisException, SampledFunction] = Right(data)
 }
 
 object Rename {

--- a/core/src/main/scala/latis/ops/Resample.scala
+++ b/core/src/main/scala/latis/ops/Resample.scala
@@ -15,26 +15,26 @@ case class Resample(dset: DomainSet) extends UnaryOperation {
   /**
    * Resampling does not affect the model.
    */
-  def applyToModel(model: DataType): DataType = model match {
+  def applyToModel(model: DataType): Either[LatisException, DataType] = model match {
     case f: Function =>
       //TODO: assert that set types matches dataset domain types
       if (f.arity != dset.rank)
-        throw LatisException("Function domain and domain set must have same dimensions")
-      else f
+        Left(LatisException("Function domain and domain set must have same dimensions"))
+      else Right(f)
     //Data that is not a Function needs domain added to it
-    case d => Function(dset.model, d)
+    case d => Right(Function(dset.model, d))
   }
 
   /**
    * Apply the DomainSet to the given SampledFunction.
    */
-  def applyToData(sf: SampledFunction, model: DataType): SampledFunction = sf match {
+  def applyToData(sf: SampledFunction, model: DataType): Either[LatisException, SampledFunction] = sf match {
     case ConstantFunction(data) =>
       // Duplicate const for every domain value
       val range: IndexedSeq[RangeData] = Vector.fill(dset.length)(RangeData(data))
-      SetFunction(dset, range)
+      Right(SetFunction(dset, range))
     case sf: SampledFunction =>
-      sf(dset).toTry.get //throw the exception if Left
+      sf(dset)
   }
 
 }

--- a/core/src/main/scala/latis/ops/StreamOperation.scala
+++ b/core/src/main/scala/latis/ops/StreamOperation.scala
@@ -6,6 +6,7 @@ import fs2.Pipe
 import latis.data.Sample
 import latis.data.SampledFunction
 import latis.model.DataType
+import latis.util.LatisException
 
 /**
  * Defines an Operation that can be applied one Sample at a time.
@@ -29,7 +30,7 @@ trait StreamOperation extends UnaryOperation {
   /**
    * Applies this operation to SampledFunction data.
    */
-  override def applyToData(data: SampledFunction, model: DataType): SampledFunction =
-    SampledFunction(data.samples.through(pipe(model)))
+  def applyToData(data: SampledFunction, model: DataType): Either[LatisException, SampledFunction] =
+    Right(SampledFunction(data.samples.through(pipe(model))))
 
 }

--- a/core/src/main/scala/latis/ops/TimeTupleToTime.scala
+++ b/core/src/main/scala/latis/ops/TimeTupleToTime.scala
@@ -1,8 +1,8 @@
 package latis.ops
 
 import cats.implicits._
+
 import latis.data._
-import latis.metadata.Metadata
 import latis.model._
 import latis.time.Time
 import latis.util.LatisException
@@ -14,22 +14,23 @@ import latis.util.LatisException
  */
 case class TimeTupleToTime(name: String = "time") extends MapOperation {
 
-  override def applyToModel(model: DataType): DataType = model.map {
-      case t @ Tuple(es @ _*) if t.id == name => //TODO: support aliases with hasName?
-        //build up format string
-        val format: String = es.toList.traverse(_("units"))
-          .fold(throw new LatisException("A time Tuple must have units defined for each element."))(_.mkString(" "))
-        //make the time Scalar
-        val metadata = t.metadata + ("units" -> format) + ("type" -> "string")
-        Time(metadata)
-      case v => v
-    }
+  def applyToModel(model: DataType): Either[LatisException, DataType] =
+    Either.catchOnly[LatisException](model.map {
+    case t @ Tuple(es @ _*) if t.id == name => //TODO: support aliases with hasName?
+      //build up format string
+      val format: String = es.toList.traverse(_("units"))
+        .fold(throw LatisException("A time Tuple must have units defined for each element."))(_.mkString(" "))
+      //make the time Scalar
+      val metadata = t.metadata + ("units" -> format) + ("type" -> "string")
+      Time(metadata)
+    case v => v
+    })
 
   override def mapFunction(model: DataType): Sample => Sample = {
     val timePos: SamplePosition = model.getPath(name) match {
       case Some(List(sp)) => sp
-      case None => throw new LatisException(s"Cannot find path to variable: $name")
-      case _ => throw new LatisException(s"Variable '$name' must not be in a nested Function.")
+      case None => throw LatisException(s"Cannot find path to variable: $name")
+      case _ => throw LatisException(s"Variable '$name' must not be in a nested Function.")
     }
     val timeLen: Int = model.findVariable(name)
       .getOrElse {
@@ -37,25 +38,25 @@ case class TimeTupleToTime(name: String = "time") extends MapOperation {
       } match {
           case t: Tuple => t.flatten match {
             case tf: Tuple => tf.elements.length //TODO: is this "dimensionality"? Should it be a first class citizen?
+            case _ => throw LatisException("Tuple did not flatten to a tuple.")
           }
-          case _ => throw new LatisException(s"Variable '$name' must be a Tuple.")
+          case _ => throw LatisException(s"Variable '$name' must be a Tuple.")
         }
 
-    (sample: Sample) => sample match {
-      case Sample(dd, rd) =>
-        //extract text values and join with space
-        //TODO: join with delimiter, problem when we use regex?
-        timePos match {
-          case DomainPosition(n) =>
-            val domain = DomainData.fromData(convertTimeTuple(dd, n, timeLen)) match {
-              case Right(d) => d
-              case Left(ex) => throw ex
-            }
-            Sample(domain, rd)
-          case RangePosition(n) =>
-            val range = convertTimeTuple(rd, n, timeLen)
-            Sample(dd, range)
-        }
+    { case Sample(dd, rd) =>
+      //extract text values and join with space
+      //TODO: join with delimiter, problem when we use regex?
+      timePos match {
+        case DomainPosition(n) =>
+          val domain = DomainData.fromData(convertTimeTuple(dd, n, timeLen)) match {
+            case Right(d) => d
+            case Left(ex) => throw ex
+          }
+          Sample(domain, rd)
+        case RangePosition(n) =>
+          val range = convertTimeTuple(rd, n, timeLen)
+          Sample(dd, range)
+      }
     }
   }
 
@@ -67,7 +68,10 @@ case class TimeTupleToTime(name: String = "time") extends MapOperation {
     val timeDatum = {
       val timeData = data.slice(pos, pos+len)
       Data.StringValue(
-        timeData.map { case d: Datum => d.asString }.mkString(" ")
+        timeData.map {
+          case d: Datum => d.asString
+          case _ => throw LatisException("Time tuple is not a tuple")
+        }.mkString(" ")
       )
     }
     data.slice(0, pos) ++ Seq(timeDatum) ++ data.slice(pos+len, data.length)

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -12,12 +12,12 @@ trait UnaryOperation extends Operation {
   /**
    * Provides a new model resulting from this Operation.
    */
-  def applyToModel(model: DataType): DataType
+  def applyToModel(model: DataType): Either[LatisException, DataType]
 
   /**
    * Provides new Data resulting from this Operation.
    */
-  def applyToData(data: SampledFunction, model: DataType): SampledFunction
+  def applyToData(data: SampledFunction, model: DataType): Either[LatisException, SampledFunction]
 
 }
 

--- a/core/src/main/scala/latis/ops/Uncurry.scala
+++ b/core/src/main/scala/latis/ops/Uncurry.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import latis.data._
 import latis.model._
+import latis.util.LatisException
 
 /**
  * Given a Dataset with potentially nested Functions, undo the nesting.
@@ -16,7 +17,7 @@ case class Uncurry() extends FlatMapOperation {
   //TODO: assume no Functions in Tuples, for now
   //TODO: neglect function and tuple IDs, for now
 
-  override def applyToModel(model: DataType): DataType = {
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = {
 
     // Define buffers to accumulate domain and range types.
     val ds = ArrayBuffer[DataType]()
@@ -43,12 +44,12 @@ case class Uncurry() extends FlatMapOperation {
       case 1 => rs.head
       case _ => Tuple(rs.toSeq)
     }
-    ds.length match {
+    Right(ds.length match {
       case 0 => rtype
       case 1 => Function(ds.head, rtype)
       case _ => Function(Tuple(ds.toSeq), rtype)
       //TODO: flatten domain, Traversable builder not working
-    }
+    })
   }
 
   /**

--- a/core/src/test/scala/latis/ops/RenameSpec.scala
+++ b/core/src/test/scala/latis/ops/RenameSpec.scala
@@ -22,7 +22,7 @@ class RenameSpec extends FlatSpec {
         )
       )
     )
-    val r = Rename("e", "f").applyToModel(model)
+    val r = Rename("e", "f").applyToModel(model).fold(e => fail(e.message), identity)
     r.toString should be ("(a, b) -> c -> (d, f)")
   }
 }


### PR DESCRIPTION
This branch has changes from another PR in order for the tests to pass.

I changed the return type of `applyToModel` and `applyToData` in each operation to `Either[LatisException, *]`. I tried to take the opportunity to reduce the number of exceptions being thrown outside of these two `applyTo` methods, but I didn't go so far as to refactor the `mapFunction` methods on Map Operations, and similar methods that have `???` and such throughout them. I also changed the return type of a few `applyOperation` methods.

I'll leave comments throughout the PR on any code I want to bring attention to.