### PR TITLE
Add support for granule appending

### DIFF
--- a/core/src/main/scala/latis/input/GranuleListAppendAdapter.scala
+++ b/core/src/main/scala/latis/input/GranuleListAppendAdapter.scala
@@ -1,0 +1,58 @@
+package latis.input
+
+import java.net.URI
+
+import cats.implicits._
+import cats.effect.IO
+import fs2.Stream
+
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.data.SamplePosition
+import latis.data.Text
+import latis.dataset.Dataset
+import latis.ops.Operation
+import latis.util.LatisException
+import latis.util.NetUtils
+
+/**
+ * An adapter for creating a dataset from a list of granules.
+ *
+ * This adapter creates a dataset by applying a template adapter to
+ * each granule in a granule list dataset and appending the results.
+ *
+ * The granule list dataset is expected to be of the form `(d,,1,,,
+ * ..., d,,n,,) -> (..., uri, ...)`.
+ */
+final class GranuleListAppendAdapter(granules: Dataset, template: URI => Dataset) {
+
+  /** Gets data using this adapter. */
+  def getData(ops: Seq[Operation]): SampledFunction = {
+    val samples: Stream[IO, Sample] = for {
+      sample <- granules.samples
+      pos    <- Stream.fromEither[IO] {
+        granules.model.getPath("uri").toRight(
+          LatisException("Expected 'uri' variable")
+        ).flatMap {
+          case p :: Nil => p.asRight
+          case _ => LatisException("Expected non-nested 'uri' variable").asLeft
+        }
+      }
+      uri    <- Stream.fromEither[IO](extractUri(sample, pos))
+      dataset = template(uri)
+      result <- dataset.samples
+    } yield result
+
+    SampledFunction(samples)
+  }
+
+  private def extractUri(
+    s: Sample,
+    p: SamplePosition
+  ): Either[LatisException, URI] = s.getValue(p).toRight {
+    LatisException("Expected sample with granule URI")
+  }.flatMap {
+    case Text(uri) => NetUtils.parseUri(uri)
+    case _ => LatisException("Expected text URI variable").asLeft
+  }
+}

--- a/core/src/main/scala/latis/input/fdml/FdmlReader.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlReader.scala
@@ -6,7 +6,9 @@ import cats.syntax.all._
 
 import latis.dataset.AdaptedDataset
 import latis.dataset.Dataset
+import latis.dataset.TappedDataset
 import latis.input.Adapter
+import latis.input.GranuleListAppendAdapter
 import latis.metadata.Metadata
 import latis.model._
 import latis.ops
@@ -25,7 +27,14 @@ object FdmlReader {
   } yield dataset).fold(throw _, identity)
 
   /** Creates a dataset from FDML. */
-  def read(fdml: Fdml): Either[LatisException, Dataset] = for {
+  def read(fdml: Fdml): Either[LatisException, Dataset] = fdml match {
+    case fdml: DatasetFdml       => readDatasetFdml(fdml)
+    case fdml: GranuleAppendFdml => readGranuleAppendFdml(fdml)
+  }
+
+  private def readDatasetFdml(
+    fdml: DatasetFdml
+  ): Either[LatisException, Dataset] = for {
     model      <- makeFunction(fdml.model)
     adapter    <- makeAdapter(fdml.adapter, model)
     operations <- fdml.operations.traverse(makeOperation)
@@ -34,6 +43,35 @@ object FdmlReader {
     model,
     adapter,
     fdml.source.uri,
+    operations
+  )
+
+  private def readGranuleAppendFdml(
+    fdml: GranuleAppendFdml
+  ): Either[LatisException, Dataset] = for {
+    granules   <- readDatasetFdml(fdml.source.fdml)
+    model      <- makeFunction(fdml.model)
+    operations <- fdml.operations.traverse(makeOperation)
+    template   <- makeDatasetTemplate(fdml.adapter.nested, model, operations)
+    adapter     = new GranuleListAppendAdapter(granules, template)
+  } yield new TappedDataset(
+    fdml.metadata,
+    model,
+    adapter.getData(operations),
+    operations
+  )
+
+  private def makeDatasetTemplate(
+    adapter: FAdapter,
+    model: Function,
+    operations: List[UnaryOperation]
+  ): Either[LatisException, URI => Dataset] = for {
+    adapter <- makeAdapter(adapter, model)
+  } yield uri => new AdaptedDataset(
+    Metadata(),
+    model,
+    adapter,
+    uri,
     operations
   )
 

--- a/core/src/test/resources/fdml-parser/granule-append.fdml
+++ b/core/src/test/resources/fdml-parser/granule-append.fdml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dataset id="granuleAppend">
+
+  <source>
+    <dataset>
+      <adapter class="granule-class"/>
+      <source uri="file:///source"/>
+      <function>
+        <scalar id="time"
+                units="days since 2000-01-01"
+                type="int"
+                class="latis.time.Time"/>
+        <scalar id="uri" type="string"/>
+      </function>
+    </dataset>
+  </source>
+
+  <adapter class="outer-class">
+    <adapter class="inner-class"/>
+  </adapter>
+
+  <function>
+    <scalar id="time"
+            units="days since 2000-01-01"
+            type="int"
+            class="latis.time.Time"/>
+    <scalar id="a" type="int"/>
+  </function>
+</dataset>

--- a/core/src/test/scala/latis/input/GranuleListAppendAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/GranuleListAppendAdapterSpec.scala
@@ -1,0 +1,177 @@
+package latis.input
+
+import java.net.URI
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers._
+
+import latis.data.Data.IntValue
+import latis.data.Data.StringValue
+import latis.data.MemoizedFunction
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.dataset.Dataset
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+import latis.model.DataType
+import latis.model.Function
+import latis.model.Scalar
+
+final class GranuleListAppendAdapterSpec extends FlatSpec {
+
+  "A granule list append adapter" should
+    "create a dataset from appended granules" in {
+
+      val glaSamples = new GranuleListAppendAdapter(granuleList, template)
+        .getData(List.empty)
+        .samples
+        .compile
+        .toList
+        .unsafeRunSync
+
+      val gSamples = (g1.samples ++ g2.samples ++ g3.samples)
+        .compile
+        .toList
+        .unsafeRunSync
+
+      glaSamples should equal (gSamples)
+  }
+
+  private val granules: List[List[Sample]] = List(
+    // Contents of first granule
+    List(
+      Sample(List(StringValue("2020-01-01")), List(IntValue(1))),
+      Sample(List(StringValue("2020-01-02")), List(IntValue(2))),
+      Sample(List(StringValue("2020-01-03")), List(IntValue(3)))
+    ),
+    // Contents of second granule
+    List(
+      Sample(List(StringValue("2020-01-04")), List(IntValue(4))),
+      Sample(List(StringValue("2020-01-05")), List(IntValue(5))),
+      Sample(List(StringValue("2020-01-06")), List(IntValue(6)))
+    ),
+    // Contents of third granule
+    List(
+      Sample(List(StringValue("2020-01-07")), List(IntValue(7))),
+      Sample(List(StringValue("2020-01-08")), List(IntValue(8))),
+      Sample(List(StringValue("2020-01-09")), List(IntValue(9)))
+    )
+  )
+
+  // Dataset for first granule
+  private val g1: Dataset = {
+    val md: Metadata = Metadata("g1")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "value",
+          "type" -> "int"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(granules(0))
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // Dataset for second granule
+  private val g2: Dataset = {
+    val md: Metadata = Metadata("g2")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "value",
+          "type" -> "int"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(granules(1))
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // Dataset for third granule
+  private val g3: Dataset = {
+    val md: Metadata = Metadata("g3")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "value",
+          "type" -> "int"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(granules(2))
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // Granule list dataset
+  private val granuleList: Dataset = {
+    val md: Metadata = Metadata("granuleList")
+
+    val model: DataType = Function(
+      Scalar(
+        Metadata(
+          "id" -> "time",
+          "type" -> "string",
+          "class" -> "latis.time.Time",
+          "units" -> "yyyy-MM-dd"
+        )
+      ),
+      Scalar(
+        Metadata(
+          "id" -> "uri",
+          "type" -> "string"
+        )
+      )
+    )
+
+    val samples: MemoizedFunction = SampledFunction(
+      List(
+        Sample(List(StringValue("2020-01-01")), List(StringValue("file:///1"))),
+        Sample(List(StringValue("2020-01-04")), List(StringValue("file:///2"))),
+        Sample(List(StringValue("2020-01-07")), List(StringValue("file:///3")))
+      )
+    )
+
+    new MemoizedDataset(md, model, samples)
+  }
+
+  // A very simple adapter.
+  private def template(uri: URI): Dataset = uri.toString() match {
+    case "file:///1" => g1
+    case "file:///2" => g2
+    case "file:///3" => g3
+  }
+}

--- a/core/src/test/scala/latis/input/fdml/FdmlSpec.scala
+++ b/core/src/test/scala/latis/input/fdml/FdmlSpec.scala
@@ -8,7 +8,7 @@ import latis.model.DoubleValueType
 class FdmlSpec extends FlatSpec {
 
   "An FAdapter" should "create a valid AdapterConfig" in {
-    val config = FAdapter("class", Map("key" -> "value")).config.properties
+    val config = SingleAdapter("class", Map("key" -> "value")).config.properties
 
     config should contain ("class" -> "class")
     config should contain ("key" -> "value")


### PR DESCRIPTION
This is the second stab at this. This is the original PR: https://github.com/latis-data/latis3/pull/95

This PR adds support for FDML written like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>

<dataset id="granuleAppend">

  <source>
    <dataset>
      <adapter class="granule-class"/>
      <source uri="file:///source"/>
      <function>
        <scalar id="time"
                units="days since 2000-01-01"
                type="int"
                class="latis.time.Time"/>
        <scalar id="uri" type="string"/>
      </function>
    </dataset>
  </source>

  <adapter class="outer-class">
    <adapter class="inner-class"/>
  </adapter>

  <function>
    <scalar id="time"
            units="days since 2000-01-01"
            type="int"
            class="latis.time.Time"/>
    <scalar id="a" type="int"/>
  </function>
</dataset>
```

The schema hasn't been updated yet. It'll be an interesting thing to try, because we'd need to do something clever or require that the schemas for each adater be imported with a namespace.

This PR ignores ordering and operations. I'm not sure what the semantics ought to be.

I wrote a simple test that suggests that everything works as expected, but I'm not sure how to include it here because the `FileListAdapter` requires file URIs, which I don't think I can provide in a portable way.