### PR TITLE
Get NetCDF var names better

### DIFF
--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -381,18 +381,22 @@ case class NetcdfWrapper(ncDataset: NetcdfDataset, model: DataType, config: Netc
    * Note, this will access the file but not read data arrays.
    */
   private lazy val variableMap: Map[String, NcVariable] = {
+    def getNcVarName(id: String): Option[NcVariable] = {
+      val validId = makeValidPathName(model.findVariable(id)
+        .flatMap(_.metadata.getProperty("sourceId"))
+        .getOrElse(id)
+      )
+      Option(ncDataset.findVariable(validId))
+    }
+
     //TODO: fail faster by not making this lazy?
     val ids = model.getScalars.map(_.id)
     val pairs = ids.flatMap { id =>
-      val vname = getNcVarName(id)
-      ncDataset.findVariable(vname) match {
-        case v: NcVariable => Some((id, v))
-        case null => None
-          //Note, domain variables not found will be replaced by index
-          //TODO: what about range vars?
-          //val msg = s"NetCDF variable not found: $vname"
-          //throw LatisException(msg)
-      }
+      getNcVarName(id).map((id, _))
+      //Note, domain variables not found will be replaced by index
+      //TODO: what about range vars?
+      //val msg = s"NetCDF variable not found: $vname"
+      //throw LatisException(msg)
     }
     pairs.toMap
   }
@@ -458,10 +462,6 @@ case class NetcdfWrapper(ncDataset: NetcdfDataset, model: DataType, config: Netc
    */
   def applyOperations(ops: Seq[Operation]): Either[LatisException, List[Section]] =
     ops.toList.foldM(sections)(NetcdfAdapter.applyOperation(_, model, _))
-
-  // Note, get is safe since the id comes from the model in the first place
-  private def getNcVarName(id: String): String =
-    makeValidPathName(model.findVariable(id).get.metadata.getProperty("sourceId").getOrElse(id))
 
   /**
    * Reads the section of the given variable into a NcArray.

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -381,9 +381,10 @@ case class NetcdfWrapper(ncDataset: NetcdfDataset, model: DataType, config: Netc
    * Note, this will access the file but not read data arrays.
    */
   private lazy val variableMap: Map[String, NcVariable] = {
-    def getNcVarName(id: String): Option[NcVariable] = {
-      val validId = makeValidPathName(model.findVariable(id)
-        .flatMap(_.metadata.getProperty("sourceId"))
+    def getNcVar(id: String): Option[NcVariable] = {
+      val validId = makeValidPathName(
+        model.findVariable(id)
+        .flatMap(_("sourceId"))
         .getOrElse(id)
       )
       Option(ncDataset.findVariable(validId))
@@ -392,7 +393,7 @@ case class NetcdfWrapper(ncDataset: NetcdfDataset, model: DataType, config: Netc
     //TODO: fail faster by not making this lazy?
     val ids = model.getScalars.map(_.id)
     val pairs = ids.flatMap { id =>
-      getNcVarName(id).map((id, _))
+      getNcVar(id).map((id, _))
       //Note, domain variables not found will be replaced by index
       //TODO: what about range vars?
       //val msg = s"NetCDF variable not found: $vname"


### PR DESCRIPTION
The failing tests in `latis3-lisird` were failing on the `.get` call that the comment above it said was safe because "the id comes from the model in the first place". It turned out not to be safe, and the stack trace was unhelpful because it was happening inside an fs2 stream. I just moved the function and replaced the `.get` call with a `.flatMap`. All the `latis3-lisird` tests passed with this change.