### PR TITLE
Use id interpolator with Metadata creation

### DIFF
--- a/core/src/test/scala/latis/ops/HeadSpec.scala
+++ b/core/src/test/scala/latis/ops/HeadSpec.scala
@@ -12,6 +12,7 @@ import latis.dataset.MemoizedDataset
 import latis.metadata.Metadata
 import latis.model.Scalar
 import latis.util.DatasetGenerator
+import latis.util.Identifier.IdentifierStringContext
 
 class HeadSpec extends FlatSpec {
 
@@ -37,8 +38,8 @@ class HeadSpec extends FlatSpec {
 
   it should "return an empty dataset when applied to an empty dataset" in {
     val md = new MemoizedDataset(
-      Metadata("MT"),
-      Scalar(Metadata("id") + ("type" -> "int")),
+      Metadata(id"MT"),
+      Scalar(Metadata(id"id") + ("type" -> "int")),
       SampledFunction(Seq.empty),
       Seq(Head())
     )

--- a/core/src/test/scala/latis/ops/LastSpec.scala
+++ b/core/src/test/scala/latis/ops/LastSpec.scala
@@ -12,6 +12,7 @@ import latis.dataset.MemoizedDataset
 import latis.metadata.Metadata
 import latis.model.Scalar
 import latis.util.DatasetGenerator
+import latis.util.Identifier.IdentifierStringContext
 
 class LastSpec extends FlatSpec {
 
@@ -37,8 +38,8 @@ class LastSpec extends FlatSpec {
 
   it should "return an empty dataset when applied to an empty dataset" in {
     val md = new MemoizedDataset(
-      Metadata("MT"),
-      Scalar(Metadata("id") + ("type" -> "int")),
+      Metadata(id"MT"),
+      Scalar(Metadata(id"id") + ("type" -> "int")),
       SampledFunction(Seq.empty),
       Seq(Last())
     )


### PR DESCRIPTION
Apparently Travis does not do what we thought: https://travis-ci.community/t/trigger-pr-build-on-base-branch-push/1084

When Ryan merged his "Add basic stream operations" PR recently, the Travis build in the PR passed because it wasn't running against the most up to date master. But when Travis ran after the merge, it failed with four errors relating to creating `Metadata` with Strings. 

To avoid this, we would need to enable a setting in GitHub that would require PRs to be fully up to date with master before they could be merged, which would imply Travis would run against the most up to date master.

This PR just fixes master's build.
