### PR TITLE
Strengthen Selection definition and creation from args

### DIFF
--- a/core/src/main/scala/latis/dataset/package.scala
+++ b/core/src/main/scala/latis/dataset/package.scala
@@ -11,7 +11,9 @@ package object dataset {
    * Defines the DSL for the functional algebra
    */
   implicit class DatasetOps(dataset: Dataset) {
-    def select(exp: String): Dataset = dataset.withOperation(Selection(exp))
+    def select(exp: String): Dataset = dataset.withOperation(
+      Selection.fromArgs(exp.split("\\s+").toList).fold(throw _, identity)
+    )
     def project(exp: String): Dataset = dataset.withOperation(Projection(exp))
     def stride(s: Int, ss: Int*): Dataset = dataset.withOperation(Stride((s +: ss).toIndexedSeq))
     def uncurry(): Dataset = dataset.withOperation(Uncurry())

--- a/core/src/main/scala/latis/input/fdml/FdmlReader.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlReader.scala
@@ -123,7 +123,7 @@ object FdmlReader {
     expression match {
       case ast.Projection(vs) => Right(ops.Projection(vs: _*))
       case ast.Selection(n, op, v) =>
-        Right(ops.Selection(n, ast.prettyOp(op), v))
+        Right(ops.Selection(n, op, v))
       case ast.Operation(name, args) =>
         UnaryOperation.makeOperation(name, args)
     }

--- a/core/src/main/scala/latis/ops/Selection.scala
+++ b/core/src/main/scala/latis/ops/Selection.scala
@@ -88,15 +88,8 @@ case class Selection(id: Identifier, operator: ast.SelectionOp, value: String) e
 
 object Selection {
 
-  def apply(expression: String): Selection = {
-    val ss = expression.split("\\s+") //split on whitespace
-    val id = Identifier.fromString(ss(0))
-      .getOrElse(throw LatisException(s"'${ss(0)}' is not a valid identifier"))
-    val op = getSelectionOp(ss(1))
-      .getOrElse(throw LatisException(s"'${ss(1)}' is not a valid operator"))
-
-    Selection(id, op, ss(2))
-  }
+  def apply(expression: String): Selection =
+    fromArgs(expression.split("\\s+").toList).fold(throw _, identity)
 
   def fromArgs(args: List[String]): Either[LatisException, Selection] = args match {
     case expr :: Nil => makeSelection(expr)

--- a/core/src/main/scala/latis/ops/Selection.scala
+++ b/core/src/main/scala/latis/ops/Selection.scala
@@ -14,17 +14,11 @@ import latis.util.LatisException
 /**
  * Operation to keep only Samples that meet the given selection criterion.
  */
-case class Selection(id: Identifier, operator: String, value: String) extends Filter {
+case class Selection(id: Identifier, operator: ast.SelectionOp, value: String) extends Filter {
   //TODO: use smaller types, enumerate operators?
   //TODO: enable IndexedFunction to use binary search...
   //TODO: support nested functions, all or none?
   //TODO: allow value to have units
-
-  def getSelectionOp: Either[LatisException, ast.SelectionOp] =
-    parsers.selectionOp.parseOnly(operator) match {
-    case ParseResult.Done(_, o) => Right(o)
-    case _ => Left(LatisException(s"failed to parse operator $operator"))
-  }
 
   def getValue(model: DataType): Either[LatisException, Datum] = for {
     scalar <- getScalar(model)
@@ -83,30 +77,45 @@ case class Selection(id: Identifier, operator: String, value: String) extends Fi
    * satisfies the selection operation.
    */
   private def matches(comparison: Int): Boolean =
-    if (operator == "!=") {
+    if (operator == ast.NeEq) {
       comparison != 0
     } else {
-      (comparison < 0 && operator.contains("<")) ||
-      (comparison > 0 && operator.contains(">")) ||
-      (comparison == 0 && operator.contains("="))
+      (comparison < 0 && ast.prettyOp(operator).contains("<")) ||
+      (comparison > 0 && ast.prettyOp(operator).contains(">")) ||
+      (comparison == 0 && ast.prettyOp(operator).contains("="))
     }
 }
 
 object Selection {
 
   def apply(expression: String): Selection = {
-    //TODO: beef up expression parsing
     val ss = expression.split("\\s+") //split on whitespace
-    Selection(
-      Identifier.fromString(ss(0)).getOrElse(throw LatisException(s"'${ss(0)}' is not a valid identifier")),
-      ss(1),
-      ss(2)
-    )
+    val id = Identifier.fromString(ss(0))
+      .getOrElse(throw LatisException(s"'${ss(0)}' is not a valid identifier"))
+    val op = getSelectionOp(ss(1))
+      .getOrElse(throw LatisException(s"'${ss(1)}' is not a valid operator"))
+
+    Selection(id, op, ss(2))
   }
+
+  def fromArgs(args: List[String]): Either[LatisException, Selection] = args match {
+    case expr :: Nil => makeSelection(expr)
+    case i :: o :: v :: Nil => for {
+      id <- Identifier.fromString(i).toRight(LatisException(s"'$i' is not a valid identifier"))
+      op <- getSelectionOp(o)
+    } yield Selection(id, op, v)
+    case _ => Left(LatisException("Selection requires either one or three arguments"))
+  }
+
+  def getSelectionOp(op: String): Either[LatisException, ast.SelectionOp] =
+    parsers.selectionOp.parseOnly(op) match {
+      case ParseResult.Done(_, o) => Right(o)
+      case _ => Left(LatisException(s"Failed to parse operator $op"))
+    }
 
   def makeSelection(expression: String): Either[LatisException, Selection] =
     parsers.selection.parseOnly(expression) match {
-      case ParseResult.Done(_, ast.Selection(id, op, value)) => Right(Selection(id, ast.prettyOp(op), value))
+      case ParseResult.Done(_, ast.Selection(id, op, value)) => Right(Selection(id, op, value))
       case _ => Left(LatisException(s"Failed to parse expression $expression"))
     }
 }

--- a/core/src/main/scala/latis/ops/Selection.scala
+++ b/core/src/main/scala/latis/ops/Selection.scala
@@ -88,9 +88,6 @@ case class Selection(id: Identifier, operator: ast.SelectionOp, value: String) e
 
 object Selection {
 
-  def apply(expression: String): Selection =
-    fromArgs(expression.split("\\s+").toList).fold(throw _, identity)
-
   def fromArgs(args: List[String]): Either[LatisException, Selection] = args match {
     case expr :: Nil => makeSelection(expr)
     case i :: o :: v :: Nil => for {

--- a/core/src/test/scala/latis/dataset/DatasetSpec.scala
+++ b/core/src/test/scala/latis/dataset/DatasetSpec.scala
@@ -8,6 +8,7 @@ import latis.data.Data._
 import latis.metadata.Metadata
 import latis.model._
 import latis.ops.Selection
+import latis.ops.parser.ast
 import latis.util.Identifier.IdentifierStringContext
 import latis.util.StreamUtils
 
@@ -45,7 +46,7 @@ class DatasetSpec extends FlatSpec {
   }
   
   it should "apply an operation" in {
-    val select = Selection(id"time", ">", "1")
+    val select = Selection(id"time", ast.Gt, "1")
     val ds2 = dataset.withOperation(select)
     StreamUtils.unsafeHead(ds2.samples) match {
       case Sample(DomainData(lv: Data.LongValue), RangeData(dv: Data.DoubleValue)) =>

--- a/core/src/test/scala/latis/input/TestGranuleListJoin.scala
+++ b/core/src/test/scala/latis/input/TestGranuleListJoin.scala
@@ -9,6 +9,7 @@ import latis.metadata.Metadata
 import latis.model._
 import latis.ops.GranuleListJoin
 import latis.ops.Selection
+import latis.ops.parser.ast
 import latis.util.Identifier.IdentifierStringContext
 import latis.util.StreamUtils
 
@@ -57,8 +58,8 @@ class TestGranuleListJoin {
 //    )
     
     val ds = gl.withOperation(glj)
-               .withOperation(Selection(id"a", ">=", "2"))
-               .withOperation(Selection(id"a", "<=", "3"))
+               .withOperation(Selection(id"a", ast.GtEq, "2"))
+               .withOperation(Selection(id"a", ast.LtEq, "3"))
                //.withOperation(Projection("a,b,d"))
     
     //val ds = ops.foldLeft(glj(gl))((ds, op) => op(ds))

--- a/core/src/test/scala/latis/ops/SelectionSpec.scala
+++ b/core/src/test/scala/latis/ops/SelectionSpec.scala
@@ -21,7 +21,7 @@ class SelectionSpec extends FlatSpec {
       RangeData(1)
     )
 
-    Selection("time > 1999").predicate(model)(sample) should be (true)
-    Selection("time > 2001").predicate(model)(sample) should be (false)
+    Selection.makeSelection("time > 1999").fold(throw _, identity).predicate(model)(sample) should be (true)
+    Selection.makeSelection("time > 2001").fold(throw _, identity).predicate(model)(sample) should be (false)
   }
 }

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -61,7 +61,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
       .flatMap { cexprs: ConstraintExpression =>
         cexprs.exprs.traverse {
           case ast.Projection(vs)      => Right(ops.Projection(vs:_*))
-          case ast.Selection(n, op, v) => Right(ops.Selection(n, ast.prettyOp(op), v))
+          case ast.Selection(n, op, v) => Right(ops.Selection(n, op, v))
           case ast.Operation("rename", oldName :: newName :: Nil) => for {
               oldName <- Identifier.fromString(oldName).toRight(
                 InvalidOperation(s"Invalid variable name $oldName")

--- a/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfAdapterSpec.scala
@@ -115,27 +115,47 @@ class NetcdfAdapterSpec extends FlatSpec {
 
   it should "apply selections on a 2D model" in {
     // simple2dSections = 0:9; 0:4; 0:9, 0:4
-    NetcdfAdapter.applySelection(simple2dSections, simple2dModel, Selection("wavelength == 5.2")) should be(
+    NetcdfAdapter.applySelection(
+      simple2dSections,
+      simple2dModel,
+      Selection.makeSelection("wavelength == 5.2").fold(throw _, identity)
+    ) should be(
       Right(makeSections("0:9; 2:2; 0:9, 2:2"))
     )
   }
 
   it should "apply selections on a model like SDO EVE diodes l3" in {
     // sdoDiodesSections = 0, 0:3760; 0:5; 0, 0:3760, 0:5; 0, 0:3760, 0:5
-    NetcdfAdapter.applySelection(sdoDiodesSections, sdoDiodesModel, Selection("time <= 100")) should be(
+    NetcdfAdapter.applySelection(
+      sdoDiodesSections,
+      sdoDiodesModel,
+      Selection.makeSelection("time <= 100").fold(throw _, identity)
+    ) should be(
       Right(makeSections("0, 0:93; 0:5; 0, 0:93, 0:5; 0, 0:93, 0:5"))
     )
   }
 
   it should "support selections that use formatted time strings" in {
-    NetcdfAdapter.applySelection(timeSections, timeModel, Selection("time > 19710102"))
+    NetcdfAdapter.applySelection(
+      timeSections,
+      timeModel,
+      Selection.makeSelection("time > 19710102").fold(throw _, identity)
+    )
       .flatMap(
-        NetcdfAdapter.applySelection(_, timeModel, Selection("time <= 19710115T123000.000"))
+        NetcdfAdapter.applySelection(
+          _,
+          timeModel,
+          Selection.makeSelection("time <= 19710115T123000.000").fold(throw _, identity)
+        )
       ) should be(Right(makeSections("2:14; 2:14")))
   }
 
   def simpleSelectTest(selection: String, expectedRange: URange): Unit =
-    NetcdfAdapter.applySelection(simple1dSections, simple1dModel, Selection(selection)) should be(
+    NetcdfAdapter.applySelection(
+      simple1dSections,
+      simple1dModel,
+      Selection.makeSelection(selection).fold(throw _, identity)
+    ) should be(
       Right(List.fill(2)(new Section(expectedRange)))
     )
 }


### PR DESCRIPTION
This PR replaces Selection's String operator with an `ast.SelectionOp` and adds the smart constructor `fromArgs`. This closes #161.

I haven't removed the companion object's `apply` yet. But `makeSelection` right underneath it serves the same purpose while wrapping the result in an Either and using the parser instead of manually converting Strings. So we could disable direct construction via `apply` in favor of using `makeSelection` or `fromArgs` to avoid invalid Selection operations. Do we want to?

We discussed moving the `sealed trait SelectionOp` from the `ast` into `Selection` itself. But I didn't see any value in doing that so I did not.  