### PR TITLE
Allow selection value to be parsed with Selection.getValue

### DIFF
--- a/core/src/main/scala/latis/ops/parser/parsers.scala
+++ b/core/src/main/scala/latis/ops/parser/parsers.scala
@@ -41,7 +41,7 @@ object parsers {
   def selection: Parser[CExpr] = for {
     name  <- identifier.token
     op    <- selectionOp.token
-    value <- stringLit //TODO: value gets parsed in Selection.getValue; reconsider parsing time or number here too again
+    value <- takeText
   } yield Selection(name, op, value)
 
   def operation: Parser[CExpr] = for {

--- a/core/src/main/scala/latis/ops/parser/parsers.scala
+++ b/core/src/main/scala/latis/ops/parser/parsers.scala
@@ -41,7 +41,7 @@ object parsers {
   def selection: Parser[CExpr] = for {
     name  <- identifier.token
     op    <- selectionOp.token
-    value <- time | number | stringLit
+    value <- stringLit //TODO: value gets parsed in Selection.getValue; reconsider parsing time or number here too again
   } yield Selection(name, op, value)
 
   def operation: Parser[CExpr] = for {

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
@@ -39,6 +39,33 @@ class TestConstraintParser extends JUnitSuite {
     }
 
   @Test
+  def selection_full_time(): Unit =
+    testParse("time>=2000-01-01T00:00:00.000Z") { ce =>
+      assertEquals(1, ce.exprs.length.toLong)
+
+      val expected = Selection(id"time", GtEq, "2000-01-01T00:00:00.000Z")
+      assertEquals(expected, ce.exprs.head)
+    }
+
+  @Test
+  def selection_partial_time(): Unit =
+    testParse("time>=2000-01-01T00:00:00") { ce =>
+      assertEquals(1, ce.exprs.length.toLong)
+
+      val expected = Selection(id"time", GtEq, "2000-01-01T00:00:00")
+      assertEquals(expected, ce.exprs.head)
+    }
+
+  @Test
+  def selection_short_time(): Unit =
+    testParse("time<2000-01-01") { ce =>
+      assertEquals(1, ce.exprs.length.toLong)
+
+      val expected = Selection(id"time", Lt, "2000-01-01")
+      assertEquals(expected, ce.exprs.head)
+    }
+
+  @Test
   def selection_leading_and(): Unit =
     testParse("&time>0") { ce =>
       assertEquals(1, ce.exprs.length.toLong)

--- a/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
+++ b/dap2-service/src/test/scala/latis/util/dap2/parser/TestConstraintParser.scala
@@ -49,10 +49,10 @@ class TestConstraintParser extends JUnitSuite {
 
   @Test
   def selection_partial_time(): Unit =
-    testParse("time>=2000-01-01T00:00:00") { ce =>
+    testParse("time>=2000-01-01T00:00") { ce =>
       assertEquals(1, ce.exprs.length.toLong)
 
-      val expected = Selection(id"time", GtEq, "2000-01-01T00:00:00")
+      val expected = Selection(id"time", GtEq, "2000-01-01T00:00")
       assertEquals(expected, ce.exprs.head)
     }
 


### PR DESCRIPTION
This PR closes #169 by implementing Doug's suggested fix of allowing selection value parsing to fall through to the Selection op. This issue arose in the context of time parsing; millisecond and time zones weren't supported by our time parser and it was breaking compatibility with Scicharts. With this fix, time values will be parsed with the `latis.time` code as expected (milliseconds and time zones supported).

We shouldn't throw away our richer parsing since we might want to come back to it though. I'd like to beef up our time parser before we close this PR, so look for a comment about that.

