### PR TITLE
Fits adapter outline

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,3 +212,13 @@ lazy val netcdf = project
       "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases"
     )
   )
+
+lazy val fits = project
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    name := "latis3-fits",
+    libraryDependencies ++= Seq(
+      "gov.nasa.gsfc.heasarc" % "nom-tam-fits" % "1.15.2"
+    )
+  )

--- a/fits/src/main/scala/latis/fits/Data.scala
+++ b/fits/src/main/scala/latis/fits/Data.scala
@@ -1,0 +1,9 @@
+package latis.fits
+
+sealed trait Data {}
+
+class BinaryTableData extends Data {}
+
+class AsciiTableData extends Data {}
+
+class ImageData extends Data {}

--- a/fits/src/main/scala/latis/fits/Fits.scala
+++ b/fits/src/main/scala/latis/fits/Fits.scala
@@ -1,0 +1,17 @@
+package latis.fits
+
+import cats.syntax.all._
+
+import latis.util.LatisException
+
+case class Fits private (hdus: List[Hdu]) {
+
+}
+
+object Fits {
+  def fromHdus(hdus: List[Hdu]): Either[LatisException, Fits] = hdus match {
+    case l@(_:ImageHdu :: _) => Fits(l).asRight
+    case _ => Left(LatisException("A FITS file must be a non-empty list of" +
+      " HDUs, starting with an image HDU."))
+  }
+}

--- a/fits/src/main/scala/latis/fits/Hdu.scala
+++ b/fits/src/main/scala/latis/fits/Hdu.scala
@@ -1,0 +1,9 @@
+package latis.fits
+
+sealed trait Hdu {}
+
+case class BinaryTableHdu(header: BinaryTableHeader, data: BinaryTableData) extends Hdu {}
+
+case class AsciiTableHdu(header: AsciiTableHeader, data: AsciiTableData) extends Hdu {}
+
+case class ImageHdu(header: ImageHeader, data: ImageData) extends Hdu {}

--- a/fits/src/main/scala/latis/fits/Header.scala
+++ b/fits/src/main/scala/latis/fits/Header.scala
@@ -1,0 +1,11 @@
+package latis.fits
+
+import latis.util.ConfigLike
+
+sealed trait Header extends ConfigLike {}
+
+case class BinaryTableHeader(properties: (String, String)*) extends Header {}
+
+case class AsciiTableHeader(properties: (String, String)*) extends Header {}
+
+case class ImageHeader(properties: (String, String)*) extends Header {}

--- a/fits/src/main/scala/latis/input/FitsAdapter.scala
+++ b/fits/src/main/scala/latis/input/FitsAdapter.scala
@@ -1,0 +1,27 @@
+package latis.input
+
+import java.net.URI
+
+import latis.data.Data
+import latis.model.DataType
+import latis.ops.Operation
+import latis.util.ConfigLike
+
+case class FitsAdapter(
+  model: DataType,
+  config: FitsAdapter.Config = FitsAdapter.Config()
+) extends Adapter {
+
+  def getData(baseUri: URI, ops: Seq[Operation]): Data = ???
+
+}
+
+object FitsAdapter extends AdapterFactory {
+  def apply(model: DataType, config: AdapterConfig): Adapter =
+    new FitsAdapter(model, FitsAdapter.Config(config.properties: _*))
+
+  /**
+   * Defines a FitsAdapter specific configuration.
+   */
+  case class Config(properties: (String, String)*) extends ConfigLike
+}


### PR DESCRIPTION
This PR just adds a FITS subproject and a very minimal outline of an adapter and interface to the nom-tam-fits Java library. 

I didn't put any required parameters in the adapter config because we talked about putting per-variable information like `HDU`, `column`, etc. in the `model` element of the FDML. We didn't make any firm decisions about implementation, so I'm moving toward putting that stuff in the `model` element until someone stops me.