### PR TITLE
Update NetCDF-Java to 5.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val coursierVersion   = "2.0.9"
 val fs2Version        = "2.5.0"
 val http4sVersion     = "0.21.16"
 val junitVersion      = "4.13.1"
-val netcdfVersion     = "5.3.3"
+val netcdfVersion     = "5.4.1"
 val pureconfigVersion = "0.14.0"
 
 lazy val commonSettings = compilerFlags ++ Seq(

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -13,7 +13,7 @@ import fs2.Stream
 import ucar.ma2.Section
 import ucar.ma2.{Array => NcArray}
 import ucar.ma2.{Range => URange}
-import ucar.nc2.NetcdfFiles.makeValidPathName
+import ucar.nc2.util.EscapeStrings.backslashEscape
 import ucar.nc2.dataset.NetcdfDataset
 import ucar.nc2.{Variable => NcVariable}
 
@@ -390,6 +390,10 @@ case class NetcdfWrapper(ncDataset: NetcdfDataset, model: DataType, config: Netc
    * Note, this will access the file but not read data arrays.
    */
   private lazy val variableMap: Map[Identifier, NcVariable] = {
+    /** Escape special characters in a netcdf short name when it is intended for use in a fullname. */
+    def makeValidPathName(name: String): String =
+        backslashEscape(name, ".\\")
+
     def getNcVar(id: Identifier): Option[NcVariable] = {
       val validId = makeValidPathName(
         model.findVariable(id)


### PR DESCRIPTION
I thought the encoder would break the most since it uses `ucar.nc2.NetcdfFileWriter`, and I don't see that class in the Java docs for 5.4 at all, but apparently it's still there. 

The only issue was the use of `makeValidPathName` in the adapter. We use it to escape special characters in a name before calling `NetcefFile.findVariables` because the Java docs for `findVariables` in 5.3 say to use that specific method. Well, the docs in 5.4 still say to use `makeValidPathName`, but the method is now private... There is already an open issue in their github repo about it. I just re-implemented it in the adapter since there isn't an equivalent public method. 