### PR TITLE
Add composite dataset

### DIFF
--- a/core/src/main/scala/latis/dataset/CompositeDataset.scala
+++ b/core/src/main/scala/latis/dataset/CompositeDataset.scala
@@ -1,0 +1,88 @@
+package latis.dataset
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.syntax.all._
+import fs2.Stream
+
+import latis.data.Data
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.data.StreamFunction
+import latis.metadata.Metadata
+import latis.model.DataType
+import latis.ops.Append
+import latis.ops.BinaryOperation
+import latis.ops.UnaryOperation
+import latis.util.LatisException
+
+/**
+ * Defines a Dataset with data provided via a list of Datasets to be appended.
+ */
+class CompositeDataset(
+  _metadata: Metadata,
+  datasets: NonEmptyList[Dataset],
+  operations: Seq[UnaryOperation] = Seq.empty
+) extends Dataset {
+
+  val joinOperation: BinaryOperation = Append()
+
+  // TODO: implement metadata appending
+  override def metadata: Metadata = _metadata
+
+  override def model: DataType = (for {
+    model <- compositeModel
+    opsModel <- operations.foldM(model)((mod, op) => op.applyToModel(mod))
+  } yield opsModel).fold(throw _, identity)
+
+  /**
+   * Returns a lazy fs2.Stream of Samples.
+   */
+  def samples: Stream[IO, Sample] =
+    applyOperations().fold(Stream.raiseError[IO](_), _.samples)
+
+  /**
+   * Returns a new Dataset with the given Operation *logically*
+   * applied to this one.
+   */
+  def withOperation(op: UnaryOperation): Dataset =
+    new CompositeDataset(
+      _metadata,
+      datasets,
+      operations :+ op
+    )
+
+  /**
+   * Applies the Operations to generate the new Data.
+   */
+  private def applyOperations(): Either[LatisException, Data] = for {
+      model <- compositeModel
+      data <- compositeData
+      newData <- operations.foldM((model, data)) { case ((mod1, dat1), op) =>
+        (op.applyToModel(mod1), op.applyToData(dat1, mod1)).mapN((_, _))
+      }.map(_._2)
+    } yield newData
+
+  /**
+   * Causes the data source to be read and released
+   * and existing Operations to be applied.
+   */
+  def unsafeForce(): MemoizedDataset = new MemoizedDataset(
+    metadata,  //from super with ops applied
+    model,     //from super with ops applied
+    applyOperations().fold(throw _, identity).asInstanceOf[SampledFunction].unsafeForce
+  )
+
+  private lazy val compositeData: Either[LatisException, Data] =
+    datasets.tail.foldM {
+      StreamFunction(datasets.head.samples): Data
+    } { (data, ds) =>
+      joinOperation.applyToData(data, StreamFunction(ds.samples))
+    }
+
+  private lazy val compositeModel: Either[LatisException, DataType] =
+    datasets.tail.foldM(datasets.head.model){ (model, ds) =>
+      joinOperation.applyToModel(model, ds.model)
+    }
+
+}

--- a/core/src/test/scala/latis/dataset/CompositeDatasetSpec.scala
+++ b/core/src/test/scala/latis/dataset/CompositeDatasetSpec.scala
@@ -1,0 +1,100 @@
+package latis.dataset
+
+import cats.data.NonEmptyList
+import org.scalatest.Inside._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+import latis.data.Data._
+import latis.data.Sample
+import latis.data._
+import latis.metadata.Metadata
+import latis.model.ModelParser.unsafeParse
+import latis.model._
+import latis.ops.Rename
+import latis.ops.Selection
+import latis.util.Identifier.IdentifierStringContext
+import latis.util.StreamUtils
+import latis.util.dap2.parser.ast
+
+class CompositeDatasetSpec extends AnyFlatSpec {
+
+  private val ds1 = {
+    val metadata = Metadata(id"test1")
+
+    val model = Function(
+      Scalar(Metadata("id" -> "time", "type" -> "int")),
+      Scalar(Metadata("id" -> "flux", "type" -> "double"))
+    )
+
+    val data = {
+      val samples = List(
+        Sample(DomainData(1), RangeData(1.2)),
+        Sample(DomainData(2), RangeData(2.4))
+      )
+      SampledFunction(samples)
+    }
+
+    new MemoizedDataset(metadata, model, data)
+  }
+  private val ds2 = {
+    val metadata = Metadata(id"test2")
+
+    val model = Function(
+      Scalar(Metadata("id" -> "time", "type" -> "int")),
+      Scalar(Metadata("id" -> "flux", "type" -> "double"))
+    )
+
+    val data = {
+      val samples = List(
+        Sample(DomainData(3), RangeData(3.6)),
+        Sample(DomainData(4), RangeData(4.8))
+      )
+      SampledFunction(samples)
+    }
+
+    new MemoizedDataset(metadata, model, data)
+  }
+  private val compDs =
+    new CompositeDataset(ds1.metadata, NonEmptyList(ds1, List(ds2)))
+
+  "A dataset" should "provide a composite model" in {
+    inside(compDs.model) {
+      case Function(t: Scalar, f: Scalar) =>
+        assert(t.valueType == IntValueType)
+        assert(t.id.get.asString == "time")
+        assert(f.valueType == DoubleValueType)
+        assert(f.id.get.asString == "flux")
+    }
+  }
+
+  it should "provide a stream of samples" in {
+    inside(StreamUtils.unsafeStreamToSeq(compDs.samples)) {
+      case Seq(s1, s2, s3, s4) =>
+        s1 should be (Sample(DomainData(1), RangeData(1.2)))
+        s2 should be (Sample(DomainData(2), RangeData(2.4)))
+        s3 should be (Sample(DomainData(3), RangeData(3.6)))
+        s4 should be (Sample(DomainData(4), RangeData(4.8)))
+      case _ => fail()
+    }
+  }
+
+  it should "apply an operation that mutates data" in {
+    val select = Selection(id"time", ast.Gt, "1")
+    val compDs2 = compDs.withOperation(select)
+    inside(StreamUtils.unsafeStreamToSeq(compDs2.samples)) {
+      case Seq(s2, s3, s4) =>
+        s2 should be (Sample(DomainData(2), RangeData(2.4)))
+        s3 should be (Sample(DomainData(3), RangeData(3.6)))
+        s4 should be (Sample(DomainData(4), RangeData(4.8)))
+      case _ => fail()
+    }
+  }
+
+  it should "apply an operation that mutates the model" in {
+    val rename = Rename(id"flux", id"foo")
+    val compDs2 = compDs.withOperation(rename)
+    compDs2.model.toString should be (unsafeParse("time: int -> foo: double").toString)
+  }
+
+}

--- a/core/src/test/scala/latis/model/ModelParser.scala
+++ b/core/src/test/scala/latis/model/ModelParser.scala
@@ -21,6 +21,9 @@ object ModelParser {
       LatisException(msg)
     }
 
+  def unsafeParse(exp: String): DataType =
+    ModelParser.parse(exp).fold(throw _, identity)
+
   def apply(exp: String): Either[LatisException, DataType] =
     ModelParser.parse(exp)
 


### PR DESCRIPTION
Here is a new PR for the `CompositeDataset`.

Since we decided to not use `TappedDataset` here, I had to implement a few things that `TappedDataset` did for us, like `applyOperations` and `unsafeForce`, so the tests make sure those things are done correctly. On that note though, I think those things should be handled in a parent class so we don't have to do it over again in `AdaptedDataset` when we remove `TappedDataset`.