### PR TITLE
Enforce that projections come first in DAP 2 constraint expressions

### DIFF
--- a/core/src/main/scala/latis/input/fdml/FdmlParser.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlParser.scala
@@ -17,6 +17,7 @@ import latis.util.Identifier
 import latis.util.LatisException
 import latis.util.NetUtils
 import latis.util.dap2.parser.ast.CExpr
+import latis.util.dap2.parser.parsers.projection
 import latis.util.dap2.parser.parsers.subexpression
 
 /** Provides methods for parsing things as FDML. */
@@ -217,7 +218,7 @@ object FdmlParser {
   private def parseExpression(
     expression: String
   ): Either[LatisException, CExpr] =
-    subexpression.parseOnly(expression) match {
+    (subexpression | projection).parseOnly(expression) match {
       case ParseResult.Done(_, e) => Right(e)
       case _                      => Left(LatisException(s"Failed to parse expression $expression"))
     }

--- a/dap2-parser/src/main/scala/latis/util/dap2/parser/parsers.scala
+++ b/dap2-parser/src/main/scala/latis/util/dap2/parser/parsers.scala
@@ -20,8 +20,7 @@ object parsers {
    * succeed.
    */
 
-  def subexpression: Parser[CExpr] =
-    selection | operation | projection
+  def subexpression: Parser[CExpr] = selection | operation
 
   def projection: Parser[CExpr] =
     sepBy1(identifier.token, char(',').token).map(xs => Projection(xs.toList))

--- a/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
+++ b/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
@@ -19,7 +19,7 @@ object ConstraintParserProps extends Properties("DAP 2 Constraint Parser") {
     init <- Gen.oneOf(Gen.alphaChar, Gen.const('_'))
     //TODO: remove const('.') after Identifier refactor
     rest <- Gen.listOf(Gen.oneOf(Gen.alphaNumChar, Gen.const('_'), Gen.const('.')))
-    id    = init + rest.mkString
+    id    = s"$init${rest.mkString}"
   } yield Identifier.fromString(id).getOrElse {
     throw new RuntimeException(s"Failed to generate identifier from: $id")
   }

--- a/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserSpec.scala
+++ b/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserSpec.scala
@@ -3,7 +3,7 @@ package latis.util.dap2.parser
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
-import latis.util.Identifier.IdentifierStringContext
+import latis.util.Identifier._
 
 import ast._
 
@@ -29,71 +29,102 @@ class ConstraintParserSpec extends AnyFlatSpec {
 
   it should "parse a selection" in
     testParse("time>0") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Selection(id"time", Gt, "0"))
+      val correct = ConstraintExpression(
+        List(Selection(id"time", Gt, "0"))
+      )
+      ce should be (correct)
     }
 
   it should "parse a selection with a full ISO 8601 time string" in
     testParse("time>=2000-01-01T00:00:00.000Z") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Selection(id"time", GtEq, "2000-01-01T00:00:00.000Z"))
+      val correct = ConstraintExpression(
+        List(Selection(id"time", GtEq, "2000-01-01T00:00:00.000Z"))
+      )
+      ce should be (correct)
     }
 
   it should "parse a selection with a partial ISO 8601 time string" in
     testParse("time>=2000-01-01T00:00") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Selection(id"time", GtEq, "2000-01-01T00:00"))
+      val correct = ConstraintExpression(
+        List(Selection(id"time", GtEq, "2000-01-01T00:00"))
+      )
+      ce should be (correct)
     }
 
   it should "parse a selection with only a date" in
     testParse("time<2000-01-01") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Selection(id"time", Lt, "2000-01-01"))
+      val correct = ConstraintExpression(
+        List(Selection(id"time", Lt, "2000-01-01"))
+      )
+      ce should be (correct)
     }
 
   it should "parse expressions with leading ampersands" in
     testParse("&time>0") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Selection(id"time", Gt, "0"))
+      val correct = ConstraintExpression(
+        List(Selection(id"time", Gt, "0"))
+      )
+      ce should be (correct)
     }
 
   it should "parse two selections joined by an ampersand" in
     testParse("time>0&time<10") { ce =>
-      ce.exprs.length should be (2)
-      ce.exprs(0) should be (Selection(id"time", Gt, "0"))
-      ce.exprs(1) should be (Selection(id"time", Lt, "10"))
+      val correct = ConstraintExpression(
+        List(
+          Selection(id"time", Gt, "0"),
+          Selection(id"time", Lt, "10")
+        )
+      )
+      ce should be (correct)
     }
 
   it should "parse a single-variable projection" in
     testParse("time") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Projection(List(id"time")))
+      val correct = ConstraintExpression(
+        List(Projection(List(id"time")))
+      )
+      ce should be (correct)
     }
 
   it should "parse a multi-variable projection" in
     testParse("time,value") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Projection(List(id"time", id"value")))
+      val correct = ConstraintExpression(
+        List(Projection(List(id"time", id"value")))
+      )
+      ce should be (correct)
     }
 
   it should "parse a single operation" in
     testParse("&first()") { ce =>
-      ce.exprs.length should be (1)
-      ce.exprs.head should be (Operation("first", List()))
+      val correct = ConstraintExpression(
+        List(Operation("first", List()))
+      )
+      ce should be (correct)
     }
 
   it should "parse multiple operations" in
     testParse("&first()&last()") { ce =>
-      ce.exprs.length should be (2)
-      ce.exprs(0) should be (Operation("first", List()))
-      ce.exprs(1) should be (Operation("last", List()))
+      val correct = ConstraintExpression(
+        List(
+          Operation("first", List()),
+          Operation("last", List())
+        )
+      )
+      ce should be (correct)
     }
 
-  it should "parse a mixture of projections, selections, and operations" in
+  it should "parse a projection followed by selections and operations" in
     testParse("time&time<10&last()") { ce =>
-      ce.exprs.length should be (3)
-      ce.exprs(0) should be (Projection(List(id"time")))
-      ce.exprs(1) should be (Selection(id"time", Lt, "10"))
-      ce.exprs(2) should be (Operation("last", List()))
+      val correct = ConstraintExpression(
+        List(
+          Projection(List(id"time")),
+          Selection(id"time", Lt, "10"),
+          Operation("last", List())
+        )
+      )
+      ce should be (correct)
     }
+
+  it should "not parse expressions where projections aren't first" in
+    ConstraintParser.parse("time>10&time").fold(_ => succeed, _ => fail())
 }


### PR DESCRIPTION
The constraint expression parser used to split the input by `&` and try to parse each substring as a selection, operation, or projection.

These changes make it so that the parser only checks if the first substring is a projection, so a projection anywhere else in the expression would fail to parse.

I've also fixed the few places this change broke something, and updated the tests to give more helpful messages if the expression is parsed incorrectly.