### PR TITLE
Support quoted string literals in DAP 2 parser

### DIFF
--- a/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserSpec.scala
+++ b/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserSpec.scala
@@ -78,6 +78,14 @@ class ConstraintParserSpec extends AnyFlatSpec {
       ce should be (correct)
     }
 
+  it should "parse selections with text values" in
+    testParse("&time>text") { ce =>
+      val correct = ConstraintExpression(
+        List(Selection(id"time", Gt, "text"))
+      )
+      ce should be (correct)
+    }
+
   it should "parse a single-variable projection" in
     testParse("time") { ce =>
       val correct = ConstraintExpression(
@@ -109,6 +117,22 @@ class ConstraintParserSpec extends AnyFlatSpec {
           Operation("first", List()),
           Operation("last", List())
         )
+      )
+      ce should be (correct)
+    }
+
+  it should "parse an operation with an argument" in
+    testParse("&take(5)") { ce =>
+      val correct = ConstraintExpression(
+        List(Operation("take", List("5")))
+      )
+      ce should be (correct)
+    }
+
+  it should "parse an operation with multiple arguments" in
+    testParse("&op(a,b)") { ce =>
+      val correct = ConstraintExpression(
+        List(Operation("op", List("a", "b")))
       )
       ce should be (correct)
     }

--- a/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserSpec.scala
+++ b/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserSpec.scala
@@ -86,6 +86,15 @@ class ConstraintParserSpec extends AnyFlatSpec {
       ce should be (correct)
     }
 
+  it should "parse selections with double-quoted values" in {
+    testParse("&time>\"text\"") { ce =>
+      val correct = ConstraintExpression(
+        List(Selection(id"time", Gt, "\"text\""))
+      )
+      ce should be (correct)
+    }
+  }
+
   it should "parse a single-variable projection" in
     testParse("time") { ce =>
       val correct = ConstraintExpression(
@@ -128,6 +137,15 @@ class ConstraintParserSpec extends AnyFlatSpec {
       )
       ce should be (correct)
     }
+
+  it should "parse an operation with a double-quoted argument" in {
+    testParse("&op(\"a\")") { ce =>
+      val correct = ConstraintExpression(
+        List(Operation("op", List("\"a\"")))
+      )
+      ce should be (correct)
+    }
+  }
 
   it should "parse an operation with multiple arguments" in
     testParse("&op(a,b)") { ce =>

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -22,7 +22,6 @@ import latis.output._
 import latis.server.ServiceInterface
 import latis.service.dap2.error._
 import latis.util.Identifier
-import latis.util.LatisException
 import latis.util.StreamUtils
 import latis.util.dap2.parser.ConstraintParser
 import latis.util.dap2.parser.ast

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -61,7 +61,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
       .flatMap { cexprs: ConstraintExpression =>
         cexprs.exprs.traverse {
           case ast.Projection(vs)      => Right(ops.Projection(vs:_*))
-          case ast.Selection(n, op, v) => Right(ops.Selection(n, op, v))
+          case ast.Selection(n, op, v) => Right(ops.Selection(n, op, stripQuotes(v)))
           case ast.Operation("rename", oldName :: newName :: Nil) => for {
               oldName <- Identifier.fromString(oldName).toRight(
                 InvalidOperation(s"Invalid variable name $oldName")
@@ -77,6 +77,9 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
         }
       }
   }
+
+  private def stripQuotes(str: String): String =
+    str.stripPrefix("\"").stripSuffix("\"")
 
   private def encode(ext: String, ds: Dataset): Either[Dap2Error, Stream[IO, Byte]] = ext match {
     case ""     => encode("html", ds)


### PR DESCRIPTION
Adds support for ~~single- and~~ double-quoted string literals in operation arguments. This was already supported by selections because the workaround used to not parse times ourselves was to consume everything after the selection operation.

I changed the DAP 2 service so it removes quotes from string literals before passing them on when making a LaTiS selection.