### PR TITLE
Add content types to responses

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -10,7 +10,9 @@ import cats.syntax.all._
 import fs2.Stream
 import fs2.io
 import fs2.text
+import org.http4s.headers.`Content-Type`
 import org.http4s.HttpRoutes
+import org.http4s.MediaType
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
 
@@ -41,7 +43,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
           ops      <- IO.fromEither(getOperations(req.queryString))
           result    = ops.foldLeft(dataset)((ds, op) => ds.withOperation(op))
           bytes    <- IO.fromEither(encode(ext, result))
-          response <- Ok(bytes)
+          response <- Ok(bytes._1).map(_.withContentType(bytes._2))
         } yield response).handleErrorWith {
           case err: Dap2Error => handleDap2Error(err)
           case _              => InternalServerError()
@@ -81,13 +83,15 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
   private def stripQuotes(str: String): String =
     str.stripPrefix("\"").stripSuffix("\"")
 
-  private def encode(ext: String, ds: Dataset): Either[Dap2Error, Stream[IO, Byte]] = ext match {
+  private def encode(ext: String, ds: Dataset): Either[Dap2Error, (Stream[IO, Byte], `Content-Type`)] = ext match {
     case ""     => encode("html", ds)
     case "bin"  => new BinaryEncoder().encode(ds).flatMap {
       bits => Stream.emits(bits.toByteArray)
-    }.asRight
+    }.asRight.map((_, `Content-Type`(MediaType.application.`octet-stream`)))
     case "csv"  => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
+      .map((_, `Content-Type`(MediaType.text.csv)))
     case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8Encode).asRight
+      .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl")))) //TODO: verify safety of unsafeParse
     case "nc"   =>
       implicit val cs = StreamUtils.contextShift
       (for {
@@ -97,9 +101,11 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
         )
         file    <- new NetcdfEncoder(tmpFile.toFile()).encode(ds)
         bytes   <- io.file.readAll[IO](file.toPath(), StreamUtils.blocker, 4096)
-      } yield bytes).asRight
+      } yield bytes).asRight.map((_, `Content-Type`(MediaType.application.`x-netcdf`)))
     case "txt"  => new TextEncoder().encode(ds).through(text.utf8Encode).asRight
+      .map((_,`Content-Type`(MediaType.text.plain)))
     case "meta" => new MetadataEncoder().encode(ds).map(_.noSpaces).through(text.utf8Encode).asRight
+      .map((_,`Content-Type`(MediaType.application.json)))
     case _      => UnknownExtension(s"Unknown extension: $ext").asLeft
   }
 

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -42,8 +42,10 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
           dataset  <- IO.fromEither(getDataset(ident))
           ops      <- IO.fromEither(getOperations(req.queryString))
           result    = ops.foldLeft(dataset)((ds, op) => ds.withOperation(op))
-          bytes    <- IO.fromEither(encode(ext, result))
-          response <- Ok(bytes._1).map(_.withContentType(bytes._2))
+          encoding <- IO.fromEither(encode(ext, result))
+          bytes     = encoding._1
+          content   = encoding._2
+          response <- Ok(bytes).map(_.withContentType(content))
         } yield response).handleErrorWith {
           case err: Dap2Error => handleDap2Error(err)
           case _              => InternalServerError()

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -91,7 +91,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
     case "csv"  => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
       .map((_, `Content-Type`(MediaType.text.csv)))
     case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8Encode).asRight
-      .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl")))) //TODO: verify safety of unsafeParse
+      .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl")))) //TODO: verify safety of unsafeParse. Could throw ParseFailure.
     case "nc"   =>
       implicit val cs = StreamUtils.contextShift
       (for {

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -91,7 +91,7 @@ class Dap2Service extends ServiceInterface with Http4sDsl[IO] {
     case "csv"  => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
       .map((_, `Content-Type`(MediaType.text.csv)))
     case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8Encode).asRight
-      .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl")))) //TODO: verify safety of unsafeParse. Could throw ParseFailure.
+      .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl"))))
     case "nc"   =>
       implicit val cs = StreamUtils.contextShift
       (for {


### PR DESCRIPTION
This PR adds content types to our `Dap2Service` responses.

The content types use http4s's pre-canned media types. I chose media types based off the ones we use in v2. The only differences are `application/x-netcdf`, which was chosen because it's the only NetCDF media type http4s includes, and `application/jsonl` because we don't have jsonl in v2.

`application/jsonl` is the only media type being constructed from a String. Http4s doesn't include a comparable media type. It's constructed with `unsafeParse`, which is just their `parse` function with `.fold(throw _, identity)` tacked on. The function technically can throw a `ParseFailure`, but I tested it locally in Docker and the String `"application/jsonl"` does get parsed into a proper `MediaType`—so I'm ignoring the error by using `unsafeParse`.

