### PR TITLE
Parse invalid value as missing value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.bsp/

--- a/core/src/main/scala/latis/input/TextAdapter.scala
+++ b/core/src/main/scala/latis/input/TextAdapter.scala
@@ -3,6 +3,7 @@ package latis.input
 import java.net.URI
 
 import cats.effect.IO
+import cats.syntax.all._
 import fs2.Pipe
 import fs2.Stream
 import fs2.text
@@ -10,6 +11,7 @@ import fs2.text
 import latis.data.Sample
 import latis.model.DataType
 import latis.model.Function
+import latis.model.Scalar
 import latis.util.ConfigLike
 
 /**
@@ -73,10 +75,10 @@ class TextAdapter(model: DataType, config: TextAdapter.Config = new TextAdapter.
      * curry should be cheap for ordered data
      */
 
-    // Get Vectors of domain and range Scalar types.
+    // Get Lists of domain and range Scalar types.
     val (dtypes, rtypes) = model match {
       case Function(d, r) => (d.getScalars, r.getScalars)
-      case _ => (Vector.empty, model.getScalars)
+      case _ => (List[Scalar](), model.getScalars)
     }
 
     // Extract the data values from the record
@@ -88,8 +90,7 @@ class TextAdapter(model: DataType, config: TextAdapter.Config = new TextAdapter.
     // from the parsed domain and range values.
     if (rtypes.length != rvals.length) None //invalid record
     else {
-      import cats.syntax.all._
-      val eds = dtypes.zip(dvals).toList.map(p => p._1.parseValue(p._2)).sequence
+      val eds = dtypes.zip(dvals).map(p => p._1.parseValue(p._2)).sequence
       val ers = rtypes.zip(rvals).map(p => p._1.parseValue(p._2)).sequence
       val esample = for {
         ds <- eds

--- a/core/src/test/scala/latis/model/DataTypeSuite.scala
+++ b/core/src/test/scala/latis/model/DataTypeSuite.scala
@@ -1,10 +1,9 @@
 package latis.model
 
-import latis.data.DomainPosition
-import latis.data.RangePosition
-import latis.metadata.Metadata
 import org.scalatest.funsuite.AnyFunSuite
 
+import latis.data._
+import latis.metadata.Metadata
 import latis.util.Identifier.IdentifierStringContext
 
 class GetPathSuite extends AnyFunSuite {
@@ -213,6 +212,21 @@ class TupleFlattenSuite extends AnyFunSuite {
         assert(r.toString == expectedTuple2.toString)
         assert(d.id == expectedTuple1.id)
         assert(r.id == expectedTuple2.id)
+    }
+  }
+}
+
+class ParseValueSuite extends AnyFunSuite {
+
+  test("Replace invalid value with missing value") {
+    val s = Scalar(Metadata(
+      "id" -> "a",
+      "type" -> "double",
+      "missingValue" -> "NaN"
+    ))
+    s.parseValue("word") match {
+      case Right(d: Data.DoubleValue) =>
+        assert(d.value.isNaN)
     }
   }
 }


### PR DESCRIPTION
This will allow us to replace invalid values in text data with a missing value.
There's more thought to be had about the use of `fillValue` and `NullDatum` (#146).