### PR TITLE
Skip samples that throw exception

### DIFF
--- a/core/src/main/scala/latis/ops/MapOperation.scala
+++ b/core/src/main/scala/latis/ops/MapOperation.scala
@@ -1,6 +1,10 @@
 package latis.ops
 
+import scala.util.Success
+import scala.util.Try
+
 import cats.effect.IO
+import cats.syntax.all._
 import fs2.Pipe
 import fs2.Stream
 
@@ -24,9 +28,17 @@ trait MapOperation extends StreamOperation { self =>
 
   /**
    * Implements a Pipe in terms of the mapFunction.
+   * Drop any Sample that results in an exception.
    */
-  def pipe(model: DataType): Pipe[IO, Sample, Sample] =
-    (stream: Stream[IO, Sample]) => stream.map(mapFunction(model))
+  def pipe(model: DataType): Pipe[IO, Sample, Sample] = {
+    val f = mapFunction(model)
+    (stream: Stream[IO, Sample]) =>
+      stream.map { sample =>
+        Either.catchNonFatal(f(sample))
+      }.collect {
+        case Right(s) => s
+      }
+  }
 
   /**
    * Composes this operation with the given MapOperation.

--- a/core/src/main/scala/latis/ops/MapOperation.scala
+++ b/core/src/main/scala/latis/ops/MapOperation.scala
@@ -1,8 +1,5 @@
 package latis.ops
 
-import scala.util.Success
-import scala.util.Try
-
 import cats.effect.IO
 import cats.syntax.all._
 import fs2.Pipe

--- a/core/src/test/scala/latis/ops/MapOperationSuite.scala
+++ b/core/src/test/scala/latis/ops/MapOperationSuite.scala
@@ -1,0 +1,31 @@
+package latis.ops
+
+import cats.syntax.all._
+import org.scalatest.funsuite.AnyFunSuite
+
+import latis.data.RangeData
+import latis.data._
+import latis.model.DataType
+import latis.model.ModelParser
+import latis.output.TextWriter
+import latis.util.DatasetGenerator
+import latis.util.LatisException
+
+class MapOperationSuite extends AnyFunSuite {
+
+  test("Skip sample that throws") {
+    // Apply operation that throws if a = 1 (2nd sample of 3)
+    val ds = DatasetGenerator("a -> b").withOperation {
+      new MapOperation {
+        def mapFunction(model: DataType): Sample => Sample =
+          (sample: Sample) => sample match {
+            case s@Sample(DomainData(Integer(a)), _) =>
+              if (a != 1) s else throw new LatisException("skip")
+          }
+        def applyToModel(model: DataType) = model.asRight
+      }
+    }
+    //TextWriter().write(ds)
+    assert(2 == ds.samples.compile.toList.unsafeRunSync().length)
+  }
+}


### PR DESCRIPTION
I think we decided it would be less than ideal to have the map function for a `MapOperation` be anything other than `Sample => Sample` and thus allow throwing exceptions in that context. This change will drop any samples that cause the map function to fail. I included a `TODO` to log a warning when we take on library logging.

I worry about silent failures (from the user's perspective) where all samples are dropped and they get an empty dataset due to a mis-modeled data source. Some day we will beef up operations to inspect the model and fail more eagerly.