### PR TITLE
Add support for Julian Date and refactor time package

### DIFF
--- a/core/src/main/scala/latis/ops/ConvertTime.scala
+++ b/core/src/main/scala/latis/ops/ConvertTime.scala
@@ -60,9 +60,9 @@ case class ConvertTime(scale: TimeScale) extends TimeOperation {
 }
 
 object ConvertTime {
+
   def fromArgs(args: List[String]): Either[LatisException, ConvertTime] = args match {
-    case units :: Nil => Either.catchNonFatal(ConvertTime(TimeScale(units)))
-      .leftMap(LatisException(_))
+    case units :: Nil => TimeScale.fromExpression(units).map(ConvertTime(_))
     case _ => Left(LatisException("ConvertTime requires one argument"))
   }
 }

--- a/core/src/main/scala/latis/ops/FormatTime.scala
+++ b/core/src/main/scala/latis/ops/FormatTime.scala
@@ -61,9 +61,10 @@ case class FormatTime(format: TimeFormat) extends TimeOperation {
 }
 
 object FormatTime {
+
   def fromArgs(args: List[String]): Either[LatisException, FormatTime] = args match {
-    case format :: Nil => Either.catchNonFatal(FormatTime(TimeFormat(format)))
-      .leftMap(LatisException(_))
-    case _ => Left(LatisException("FormatTime requires one argument"))
+    case format :: Nil =>
+      TimeFormat.fromExpression(format).map(FormatTime(_))
+    case _ => LatisException("FormatTime requires one argument").asLeft
   }
 }

--- a/core/src/main/scala/latis/time/Time.scala
+++ b/core/src/main/scala/latis/time/Time.scala
@@ -13,6 +13,7 @@ import latis.units.UnitConverter
  */
 class Time(metadata: Metadata) extends Scalar(metadata) {
   //TODO: make sure this has the id or alias "time"
+  //TODO: validate units eagerly
 
   /**
    * Returns the units from the metadata.
@@ -27,7 +28,7 @@ class Time(metadata: Metadata) extends Scalar(metadata) {
    * as a string. Otherwise returns None.
    */
   val timeFormat: Option[TimeFormat] = valueType match {
-    case StringValueType => Option(TimeFormat(units))
+    case StringValueType => TimeFormat.fromExpression(units).toOption
     case _               => None
   }
 
@@ -42,7 +43,7 @@ class Time(metadata: Metadata) extends Scalar(metadata) {
    */
   val timeScale: TimeScale =
     if (isFormatted) TimeScale.Default
-    else TimeScale(units)
+    else TimeScale.fromExpression(units).fold(throw _, identity)
 
   /**
    * Overrides the basic Scalar PartialOrdering to provide

--- a/core/src/main/scala/latis/time/TimeFormat.scala
+++ b/core/src/main/scala/latis/time/TimeFormat.scala
@@ -68,6 +68,8 @@ object TimeFormat {
       LatisException(msg, _)
     }
 
+  def isValid(format: String): Boolean = fromExpression(format).isRight
+
   /**
    * Provides a TimeFormat for the default ISO 8601 format.
    */

--- a/core/src/main/scala/latis/time/TimeFormat.scala
+++ b/core/src/main/scala/latis/time/TimeFormat.scala
@@ -7,35 +7,26 @@ import java.util.TimeZone
 
 import scala.util._
 
+import cats.syntax.all._
+
+import latis.util.LatisException
+
 /**
  * TimeFormat support that is thread safe and assumes GMT time zone.
  */
-class TimeFormat(format: String) {
-
-  private val sdf: SimpleDateFormat = {
-    val sdf = try {
-      new SimpleDateFormat(format, Locale.ENGLISH)
-    } catch {
-      case e: Exception =>
-        val msg = s"Could not parse '$format' as a time format."
-        throw new IllegalArgumentException(msg, e)
-    }
-    sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
-    sdf
-  }
+class TimeFormat(sdf: SimpleDateFormat) {
+  //TODO: look into java.time.format.DateTimeFormatter
 
   def format(millis: Long): String = this.synchronized {
     sdf.format(new Date(millis))
   }
 
-  def parse(string: String): Either[Exception, Long] = this.synchronized {
-    Try {
-      sdf.parse(string).getTime
-    } match {
-      case Success(v) => Right(v)
-      case Failure(t) =>
-        val msg = s"Could not parse '$string' with the format $format"
-        Left(new IllegalArgumentException(msg, t))
+  def parse(string: String): Either[LatisException, Long] = this.synchronized {
+    Either.catchNonFatal(sdf.parse(string))
+      .map(_.getTime)
+      .leftMap {
+        val msg = s"Could not parse '$string' with the format $sdf"
+        LatisException(msg, _)
     }
   }
 
@@ -44,7 +35,7 @@ class TimeFormat(format: String) {
    * This time is expected to be an ISO 8601 time string
    * representing the start of the 100-year period.
    */
-  //TODO: can this be passed in as an optional constructor arg?
+  //TODO: pass as an optional constructor arg
   def setCenturyStart(start: String): TimeFormat = {
     TimeFormat.parseIso(start) match {
       case Right(t) =>
@@ -58,19 +49,30 @@ class TimeFormat(format: String) {
   /**
    * Overrides toString to return the format string.
    */
-  override def toString: String = format
+  override def toString: String = sdf.toPattern
 }
 
 //==============================================================================
 
 object TimeFormat {
 
-  def apply(format: String) = new TimeFormat(format)
+  def fromExpression(format: String): Either[LatisException, TimeFormat] =
+    Either.catchNonFatal {
+      val sdf = new SimpleDateFormat(format, Locale.ENGLISH)
+      sdf.setTimeZone(TimeZone.getTimeZone("GMT"))
+      sdf
+    }.map {
+      new TimeFormat(_)
+    }.leftMap {
+      val msg = s"Could not parse '$format' as a time format."
+      LatisException(msg, _)
+    }
 
   /**
    * Provides a TimeFormat for the default ISO 8601 format.
    */
-  val Iso: TimeFormat = TimeFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  val Iso: TimeFormat = TimeFormat.fromExpression("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    .fold(throw _, identity) //Should be safe
 
   /**
    * Represents the given time in milliseconds as the
@@ -84,7 +86,7 @@ object TimeFormat {
    * e.g. for each sample of a dataset, it is recommended that a
    * TimeFormat object be created with fromIsoValue and reused.
    */
-  def parseIso(time: String): Either[Exception, Long] =
+  def parseIso(time: String): Either[LatisException, Long] =
     for {
       formatter <- fromIsoValue(time)
       tvalue    <- formatter.parse(time)
@@ -95,8 +97,8 @@ object TimeFormat {
    * This supports most common ISO 8601 representations
    * not including weeks or time zones other than "Z".
    */
-  def fromIsoValue(value: String): Either[Exception, TimeFormat] = {
-    val format = value.split("T") match {
+  def fromIsoValue(value: String): Either[LatisException, TimeFormat] = {
+    (value.split("T") match {
       case Array(date) =>
         // No time component
         getDateFormatString(date)
@@ -105,9 +107,10 @@ object TimeFormat {
           d <- getDateFormatString(date)
           t <- getTimeFormatString(time)
         } yield List(d, t).mkString("'T'")
-    }
-    format.map {
-      TimeFormat(_)
+      case _ =>
+        LatisException(s"Invalid TimeFormat: $value").asLeft
+    }).flatMap {
+      TimeFormat.fromExpression(_)
     }
     //TODO: combine error messages if both time and date part fail
   }
@@ -115,7 +118,7 @@ object TimeFormat {
   /**
    * Matches the date portion of an ISO time to a format string.
    */
-  private def getDateFormatString(s: String): Either[Exception, String] =
+  private def getDateFormatString(s: String): Either[LatisException, String] =
     s.length match {
       case 4 => Right("yyyy")
       case 6 => Right("yyMMdd") //Note, yyyyMM is not ISO compliant
@@ -128,13 +131,13 @@ object TimeFormat {
       case 10 => Right("yyyy-MM-dd")
       case _ =>
         val msg = s"Failed to determine a date format for $s"
-        Left(new IllegalArgumentException(msg))
+        Left(new LatisException(msg))
     }
 
   /**
    * Matches the time portion of an ISO time to a format string.
    */
-  private def getTimeFormatString(s: String): Either[Exception, String] = {
+  private def getTimeFormatString(s: String): Either[LatisException, String] = {
     // Handle the "Z" time zone designation
     val length = s.indexOf("Z") match {
       case n: Int if (n != -1) => n
@@ -151,7 +154,7 @@ object TimeFormat {
       case 12 => Right("HH:mm:ss.SSS")
       case _ =>
         val msg = s"Failed to determine a time format for $s"
-        Left(new IllegalArgumentException(msg))
+        Left(new LatisException(msg))
     }
   }
 

--- a/core/src/main/scala/latis/time/TimeScale.scala
+++ b/core/src/main/scala/latis/time/TimeScale.scala
@@ -1,8 +1,15 @@
 package latis.time
 
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+import cats.syntax.all._
+
 import latis.units.{Time => TimeType}
 import latis.units.MeasurementScale
 import latis.units.MeasurementType
+import latis.util.LatisException
 
 /**
  * Defines the MeasurementScale for time instances.
@@ -10,24 +17,21 @@ import latis.units.MeasurementType
  * The timeUnit specifies the duration of each unit.
  *
  * Since there is no absolute zero for time scales, this uses the
- * Java time scale (milliseconds since 1970-01-01T00:00:00) as the standard.
+ * Java time scale (milliseconds since 1970-01-01T00:00:00) as the default.
  * The zero of a time scale is the offset of its epoch from the default epoch
  * in its units. For example, "hours since 1970-01-02" would be at the standard
  * time scale's zero (1970-01-01) one day before it's own zero (i.e. epoch). In
  * it's units (hours) the zero (one day ago) would be -24.
  */
-case class TimeScale(timeUnit: TimeUnit, epoch: String) extends MeasurementScale {
+case class TimeScale(timeUnit: TimeUnit, epoch: Date) extends MeasurementScale {
 
   def unitType: MeasurementType = TimeType
 
   override def baseMultiplier: Double = timeUnit.baseMultiplier
 
-  override def zero: Double =
-    -TimeFormat.parseIso(epoch)
-      .map(_ / 1000 / baseMultiplier)
-      .getOrElse { ??? }
+  override def zero: Double = -epoch.getTime / 1000 / baseMultiplier
 
-  override def toString() = s"$timeUnit since $epoch"
+  override def toString() = s"$timeUnit since ${TimeFormat.formatIso(epoch.getTime)}"
 }
 
 object TimeScale {
@@ -36,22 +40,53 @@ object TimeScale {
    * Defines the default time scale as Java's default:
    * milliseconds since 1970.
    */
-  val Default: TimeScale = TimeScale(TimeUnit(0.001), "1970-01-01")
+  val Default: TimeScale = TimeScale(TimeUnit(0.001), new Date(0))
+
+  /**
+   * Defines a TimeScale for Julian Date: days since noon UT on Jan 1, 4713 BC.
+   *
+   * Although the epoch is "Julian", this special case is here solely to
+   * represent the unique epoch. This simply represents the number of 24-hour
+   * days since this epoch in a manner consistent with the proleptic
+   * Gregorian calendar which is appropriate for modern scientific data.
+   *
+   * Note that this overrides the usual "units since epoch" form of toString
+   * with "Julian Date".
+   */
+  lazy val Julian = {
+    // Java's default calendar jumps from 1 BC to 1 AD, we need to use year -4712
+    val cal = new GregorianCalendar(-4712, 0, 1, 12, 0)
+    cal.setTimeZone(TimeZone.getTimeZone("GMT"))
+    new TimeScale(TimeUnit(86400), cal.getTime) {
+      override def toString() = "Julian Date"
+    }
+  }
 
   /**
    * Constructs a TimeScale from a "units" expression of the form:
    *   <time unit> since <epoch>
+   *   or "Julian Date" (and similar forms starting with "julian")
    *   or a TimeFormat expression.
-   * A formatted time expression will translate to the default
-   * TimeScale.
+   * A formatted time expression will be handled with the default
+   * numeric TimeScale.
    */
-  def apply(exp: String): TimeScale = exp.split(" since ") match {
-    case Array(s, epoch) =>
-      val unit = TimeUnit.fromName(s)
-      TimeScale(unit, epoch)
-    case Array(_) =>
-      // Assumes a TimeFormat expression which
-      // translates to the default numeric TimeScale
-      TimeScale.Default
-  }
+  def fromExpression(units: String): Either[LatisException, TimeScale] =
+    units.split("""\s+since\s+""") match {
+      case Array(u, e) =>
+        for {
+          unit <- TimeUnit.fromName(u)
+          epoch <- TimeFormat.parseIso(e)
+          date = new Date(epoch)
+        } yield TimeScale(unit, date)
+      case Array(s) =>
+        // Check if some form of "Julian Date"
+        if (s.toLowerCase.startsWith("julian")) TimeScale.Julian.asRight
+        // Otherwise assumes a TimeFormat expression which
+        // is handled with the default numeric TimeScale
+        //TODO: fail if not a valid time format?
+        else TimeScale.Default.asRight
+      case _ =>
+        //Only if "since" appears more than once?
+        LatisException(s"Invalid TimeScale expression: $units").asLeft
+    }
 }

--- a/core/src/main/scala/latis/time/TimeUnit.scala
+++ b/core/src/main/scala/latis/time/TimeUnit.scala
@@ -1,5 +1,9 @@
 package latis.time
 
+import cats.syntax.all._
+
+import latis.util.LatisException
+
 /**
  * Defines a time duration unit in terms of a
  * multiplier of the base unit "seconds".
@@ -31,15 +35,18 @@ object TimeUnit {
   /**
    * Returns a TimeUnit given the unit's name.
    */
-  def fromName(unit: String): TimeUnit = unit match {
-    case "nanoseconds"  => TimeUnit(1e-9)
-    case "microseconds" => TimeUnit(1e-6)
-    case "milliseconds" => TimeUnit(0.001)
-    case "seconds"      => Base
-    case "minutes"      => TimeUnit(60)
-    case "hours"        => TimeUnit(3600)
-    case "days"         => TimeUnit(86400)
-    case "weeks"        => TimeUnit(7 * 86400)
-    case "years"        => TimeUnit(365 * 86400)
+  def fromName(unit: String): Either[LatisException, TimeUnit] = unit match {
+    case "nanoseconds"  => TimeUnit(1e-9).asRight
+    case "microseconds" => TimeUnit(1e-6).asRight
+    case "milliseconds" => TimeUnit(0.001).asRight
+    case "seconds"      => Base.asRight
+    case "minutes"      => TimeUnit(60).asRight
+    case "hours"        => TimeUnit(3600).asRight
+    case "days"         => TimeUnit(86400).asRight
+    case "weeks"        => TimeUnit(7 * 86400).asRight
+    case "years"        => TimeUnit(365 * 86400).asRight
+    case _ => LatisException(s"Invalid TimeUnit: $unit").asLeft
   }
+
+  //TODO: make enumeration of units for safer general usage
 }

--- a/core/src/test/scala/latis/ops/ConvertTimeSpec.scala
+++ b/core/src/test/scala/latis/ops/ConvertTimeSpec.scala
@@ -29,13 +29,15 @@ class ConvertTimeSpec extends AnyFlatSpec {
     )
   )
 
-  val convertTime = ConvertTime(TimeScale("weeks since 2020-01-08"))
+  val convertTime = TimeScale.fromExpression("weeks since 2020-01-08")
+    .map(ConvertTime(_)).toTry.get
 
   "The ConvertTime Operation" should "update the metadata of the time variable" in {
     val newModel = convertTime.applyToModel(numericTime).toTry.get
     //println(newModel.metadata.properties)
     newModel("type") should be(Some("double"))
-    newModel("units") should be(Some("weeks since 2020-01-08"))
+    //Note TimeScale.toString uses default ISO format
+    newModel("units") should be(Some("weeks since 2020-01-08T00:00:00.000Z"))
   }
 
   it should "convert a numeric time variable" in {

--- a/core/src/test/scala/latis/ops/FormatTimeSpec.scala
+++ b/core/src/test/scala/latis/ops/FormatTimeSpec.scala
@@ -29,7 +29,7 @@ class FormatTimeSpec extends AnyFlatSpec {
     )
   )
 
-  val formatTime = FormatTime(TimeFormat("yyyy-DDD"))
+  val formatTime = FormatTime(TimeFormat.fromExpression("yyyy-DDD").toTry.get)
 
   "The FormatTime Operation" should "update the metadata of the time variable" in {
     val newModel = formatTime.applyToModel(numericTime).toTry.get

--- a/core/src/test/scala/latis/time/TimeFormatSpec.scala
+++ b/core/src/test/scala/latis/time/TimeFormatSpec.scala
@@ -1,6 +1,7 @@
 package latis.time
 
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
 import org.scalatest.matchers.should.Matchers._
 
 class TimeFormatSpec extends AnyFlatSpec {
@@ -15,15 +16,21 @@ class TimeFormatSpec extends AnyFlatSpec {
   }
   
   it should "parse a formatted time string" in {
-    TimeFormat("yyyyDDD").parse("1970002") should be (Right(86400000))
+    TimeFormat.fromExpression("yyyyDDD").flatMap( _.parse("1970002")) should be (Right(86400000))
+
   }
   
   it should "format a time value" in {
-    TimeFormat("yyyy MMM dd HH:mm").format(3600000) should be ("1970 Jan 01 01:00")
+    TimeFormat.fromExpression("yyyy MMM dd HH:mm").map(_.format(3600000)) should be (Right("1970 Jan 01 01:00"))
   }
   
   it should "use a specified century for 2-digit years" in {
-    val time = TimeFormat("yyMMdd").setCenturyStart("2100").parse("330501").getOrElse(0l)
-    TimeFormat("yyyy-MM-dd").format(time) should be ("2133-05-01")
+    val time: Long =  TimeFormat.fromExpression("yyMMdd")
+      .flatMap(_.setCenturyStart("3000").parse("330501")).getOrElse(0l)
+    TimeFormat.fromExpression("yyyy-MM-dd").map(_.format(time)) should be (Right("3033-05-01"))
+  }
+
+  it should "have a string representation" in {
+    TimeFormat.Iso.toString should be ("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   }
 }

--- a/core/src/test/scala/latis/time/TimeScaleSpec.scala
+++ b/core/src/test/scala/latis/time/TimeScaleSpec.scala
@@ -1,15 +1,18 @@
 package latis.time
 
+import java.util.Date
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
+
 import latis.units.UnitConverter
 
 class TimeScaleSpec extends AnyFlatSpec {
   
-  val timeScaleFromFormat = TimeScale("yyyy-MM-dd")
+  val timeScaleFromFormat = TimeScale.fromExpression("yyyy-MM-dd").toTry.get
   
   "A time scale from a format" should "have the default epoch" in {
-    timeScaleFromFormat.epoch should be ("1970-01-01")
+    timeScaleFromFormat.epoch should be (new Date(0l))
   }
   
   it should "have the default time unit" in {
@@ -21,7 +24,7 @@ class TimeScaleSpec extends AnyFlatSpec {
   }
   
   
-  val numericTimeScale = TimeScale("hours since 1970-002")
+  val numericTimeScale = TimeScale.fromExpression("hours since 1970-002").toTry.get
   
   "A numeric time scale" should "have the correct units" in {
     numericTimeScale.timeUnit should be (TimeUnit(3600))
@@ -33,12 +36,31 @@ class TimeScaleSpec extends AnyFlatSpec {
   
   
   val timeConverter = UnitConverter(
-    TimeScale("seconds since 2000-01-01T00:00:01"),
-    TimeScale("milliseconds since 2000-01-01")
+    TimeScale.fromExpression("seconds since 2000-01-01T00:00:01").toTry.get,
+    TimeScale.fromExpression("milliseconds since 2000-01-01").toTry.get
   )
   
   "A time converter" should "convert between numeric time scales" in {
     val z = timeConverter.convert(1) 
     z should be (2000.0)
+  }
+
+  "A Julian TimeScale" should "support conversion to Java time" in {
+    val tc = UnitConverter(TimeScale.Julian, TimeScale.Default)
+    tc.convert(2440587.5) should be (0) // 1970-01-01
+  }
+
+  it should "support conversion from Java time" in {
+    val tc = UnitConverter(TimeScale.Default, TimeScale.Julian)
+    tc.convert(0) should be (2440587.5) // 1970-01-01
+  }
+
+  it should "be constructed from Julian units" in {
+    TimeScale.fromExpression("julian").fold(fail(_), identity) should be (TimeScale.Julian)
+    TimeScale.fromExpression("Julian Date").fold(fail(_), identity) should be (TimeScale.Julian)
+  }
+
+  it should "have the correct string representation" in {
+    TimeScale.Julian.toString should be ("Julian Date")
   }
 }

--- a/core/src/test/scala/latis/time/TimeScaleSpec.scala
+++ b/core/src/test/scala/latis/time/TimeScaleSpec.scala
@@ -46,21 +46,21 @@ class TimeScaleSpec extends AnyFlatSpec {
   }
 
   "A Julian TimeScale" should "support conversion to Java time" in {
-    val tc = UnitConverter(TimeScale.Julian, TimeScale.Default)
+    val tc = UnitConverter(TimeScale.JulianDate, TimeScale.Default)
     tc.convert(2440587.5) should be (0) // 1970-01-01
   }
 
   it should "support conversion from Java time" in {
-    val tc = UnitConverter(TimeScale.Default, TimeScale.Julian)
+    val tc = UnitConverter(TimeScale.Default, TimeScale.JulianDate)
     tc.convert(0) should be (2440587.5) // 1970-01-01
   }
 
-  it should "be constructed from Julian units" in {
-    TimeScale.fromExpression("julian").fold(fail(_), identity) should be (TimeScale.Julian)
-    TimeScale.fromExpression("Julian Date").fold(fail(_), identity) should be (TimeScale.Julian)
+  it should "be constructed from JD units" in {
+    TimeScale.fromExpression("JD").fold(fail(_), identity) should be (TimeScale.JulianDate)
+    assert(TimeScale.fromExpression("Julian Date").isLeft)
   }
 
   it should "have the correct string representation" in {
-    TimeScale.Julian.toString should be ("Julian Date")
+    TimeScale.JulianDate.toString should be ("JD")
   }
 }

--- a/core/src/test/scala/latis/units/UnitConverterSpec.scala
+++ b/core/src/test/scala/latis/units/UnitConverterSpec.scala
@@ -8,7 +8,7 @@ class UnitConverterSpec extends AnyFlatSpec {
 
   "A UnitConverter" should "convert time units" in {
     val ts1 = TimeScale.Default
-    val ts2 = TimeScale("seconds since 1970")
+    val ts2 = TimeScale.fromExpression("seconds since 1970").fold(fail(_), identity)
     UnitConverter(ts1, ts2).convert(1000) should be (1.0)
   }
 }


### PR DESCRIPTION
TimeScale now has a Julian Date instance. It was refactored to wrap java.util.Date since the Julian epoch can not be represented with our default ISO format. This led to broader clean up of the time package, handling exceptions with Either.
Another significant refactoring changed TimeFormat to wrap a SimpleDateFormat so we could more eagerly fail with invalid format strings.

Fixes #205 