### PR TITLE
Add LaTiS server builder

### DIFF
--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -1,84 +1,40 @@
 package latis.server
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.Blocker
 import cats.effect.ExitCode
 import cats.effect.IO
 import cats.effect.IOApp
-import org.http4s.HttpRoutes
-import org.http4s.implicits._
-import org.http4s.server.Router
-import org.http4s.server.blaze._
-import org.http4s.server.middleware.CORS
-import org.http4s.server.middleware.CORS.DefaultCORSConfig
-import org.typelevel.log4cats.StructuredLogger
+import cats.effect.Resource
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import pureconfig.ConfigSource
 import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
 
 import latis.catalog.FdmlCatalog
+
+import Latis3ServerBuilder._
 
 object Latis3Server extends IOApp {
 
   private val loader: ServiceInterfaceLoader =
     new ServiceInterfaceLoader()
 
-  private val latisConfigSource: ConfigSource =
-    ConfigSource.default.at("latis")
-
-  private def getCatalogConf(blocker: Blocker): IO[CatalogConf] =
-    latisConfigSource.at("fdml").loadF[IO, CatalogConf](blocker)
-
-  private def getServerConf(blocker: Blocker): IO[ServerConf] =
-    latisConfigSource.loadF[IO, ServerConf](blocker)
-
   private def getServiceConf(blocker: Blocker): IO[ServiceConf] =
     latisConfigSource.loadF[IO, ServiceConf](blocker)
 
-  private def constructRoutes(
-    services: List[(ServiceSpec, ServiceInterface)]
-  ): HttpRoutes[IO] = {
-    val routes: List[(String, HttpRoutes[IO])] = services.map {
-      case (spec, service) => (spec.mapping, service.routes)
-    }
-    Router(routes:_*)
-  }
-
-  private def startServer(
-    routes: HttpRoutes[IO],
-    conf: ServerConf,
-    logger: StructuredLogger[IO]
-  ): IO[Unit] = conf match {
-    case ServerConf(port, mapping) =>
-      BlazeServerBuilder[IO](ExecutionContext.global)
-        .bindHttp(port, "0.0.0.0")
-        .withHttpApp {
-          LatisServiceLogger(Router(mapping ->
-            CORS(routes, DefaultCORSConfig)
-          ).orNotFound, logger)
-        }
-        .withoutBanner
-        .serve
-        .compile
-        .drain
-  }
-
   def run(args: List[String]): IO[ExitCode] =
-    Blocker[IO].use { blocker =>
-      for {
-        logger      <- Slf4jLogger.create[IO]
-        catalogConf <- getCatalogConf(blocker)
-        catalog      = FdmlCatalog.fromDirectory(
-          catalogConf.dir,
-          catalogConf.validate
-        )
-        serverConf  <- getServerConf(blocker)
-        serviceConf <- getServiceConf(blocker)
-        services    <- loader.loadServices(serviceConf, catalog)
-        routes       = constructRoutes(services)
-        _           <- startServer(routes, serverConf, logger)
-      } yield ExitCode.Success
-    }
+    (for {
+      logger      <- Resource.eval(Slf4jLogger.create[IO])
+      blocker     <- Blocker[IO]
+      serverConf  <- Resource.eval(getServerConf(blocker))
+      catalogConf <- Resource.eval(getCatalogConf(blocker))
+      catalog      = FdmlCatalog.fromDirectory(
+        catalogConf.dir,
+        catalogConf.validate
+      )
+      serviceConf <- Resource.eval(getServiceConf(blocker))
+      interfaces  <- Resource.eval(loader.loadServices(serviceConf, catalog))
+      server      <- mkServer(serverConf, interfaces, logger)
+    } yield server)
+      .use(_ => IO.never)
+      .as(ExitCode.Success)
 }

--- a/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
+++ b/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
@@ -1,0 +1,66 @@
+package latis.server
+
+import scala.concurrent.ExecutionContext
+
+import cats.effect.Blocker
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.Timer
+import org.http4s.HttpRoutes
+import org.http4s.implicits._
+import org.http4s.server.Router
+import org.http4s.server.Server
+import org.http4s.server.blaze._
+import org.http4s.server.middleware.CORS
+import org.http4s.server.middleware.CORS.DefaultCORSConfig
+import org.typelevel.log4cats.StructuredLogger
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+import pureconfig.module.catseffect.syntax._
+
+object Latis3ServerBuilder {
+
+  val latisConfigSource: ConfigSource =
+    ConfigSource.default.at("latis")
+
+  def getCatalogConf(blocker: Blocker)(implicit cs: ContextShift[IO]): IO[CatalogConf] =
+    latisConfigSource.at("fdml").loadF[IO, CatalogConf](blocker)
+
+  def getServerConf(blocker: Blocker)(implicit cs: ContextShift[IO]): IO[ServerConf] =
+    latisConfigSource.loadF[IO, ServerConf](blocker)
+
+  def mkServer(
+    conf: ServerConf,
+    interfaces: List[(String, ServiceInterface)],
+    logger: StructuredLogger[IO],
+    executionContext: ExecutionContext = ExecutionContext.global
+  )(
+    implicit cs: ContextShift[IO],
+    timer: Timer[IO]
+  ): Resource[IO, Server[IO]] = {
+
+    def constructRoutes(
+      interfaces: List[(String, ServiceInterface)]
+    ): HttpRoutes[IO] = {
+      val routes = interfaces.map {
+        case (mapping, service) => (mapping, service.routes)
+      }
+      Router(routes:_*)
+    }
+
+    BlazeServerBuilder[IO](executionContext)
+      .bindHttp(conf.port, "0.0.0.0")
+      .withHttpApp {
+        LatisServiceLogger(
+          Router(conf.mapping -> CORS(
+            constructRoutes(interfaces),
+            DefaultCORSConfig
+          )).orNotFound,
+          logger
+        )
+      }
+      .withoutBanner
+      .resource
+  }
+}

--- a/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
+++ b/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
@@ -33,12 +33,12 @@ final class ServiceInterfaceLoader(implicit cs: ContextShift[IO]) {
   def loadServices(
     conf: ServiceConf,
     catalog: Catalog
-  ): IO[List[(ServiceSpec, ServiceInterface)]] =
+  ): IO[List[(String, ServiceInterface)]] =
     conf.services.traverse { spec =>
       for {
         loader  <- getClassLoader(spec)
         service <- loadService(loader, spec, catalog)
-      } yield (spec, service)
+      } yield (spec.mapping, service)
     }
 
   private def loadService(


### PR DESCRIPTION
Abstracts the process of building a LaTiS 3 instance so we can customize instances without relying on configuration and reflection.

I'd like to eventually support at least the most common use cases through configuration alone, but this allows us to make progress without having the configuration/reflection mechanism be a blocker.