### PR TITLE
Allow naming datasets made by dataset generator

### DIFF
--- a/core/src/main/scala/latis/dsl/datasetGenerator.scala
+++ b/core/src/main/scala/latis/dsl/datasetGenerator.scala
@@ -41,15 +41,18 @@ object DatasetGenerator {
    * ("b", 2) -> (10.0, 11.0)
    *
    */
-  def apply(typeSig: String): MemoizedDataset = {
+  def apply(typeSig: String, name: Identifier): MemoizedDataset = {
     val model = modelFromString(typeSig)
     val ds = new MemoizedDataset(
-      Metadata(makeDatasetID()),
+      Metadata(name),
       model,
       generateData(model)
     )
     ds
   }
+
+  def apply(typeSig: String): MemoizedDataset =
+    DatasetGenerator(typeSig, makeDatasetID())
 
   private def modelFromString(s: String): DataType =
     ModelParser.parse(s).fold(throw _, identity)


### PR DESCRIPTION
This will allow you to specify the name of a generated dataset and will fall back to the existing method of generating a name if you don't provide a name.