### PR TITLE
Fix findDataset for combined catalogs

### DIFF
--- a/core/src/main/scala/latis/catalog/Catalog.scala
+++ b/core/src/main/scala/latis/catalog/Catalog.scala
@@ -1,6 +1,7 @@
 package latis.catalog
 
 import cats.Monoid
+import cats.data.OptionT
 import cats.effect.IO
 import cats.syntax.all._
 import fs2.Stream
@@ -39,7 +40,7 @@ object Catalog {
       override val datasets: Stream[IO, Dataset] = x.datasets ++ y.datasets
 
       override def findDataset(name: Identifier): IO[Option[Dataset]] =
-        x.findDataset(name) <+> y.findDataset(name)
+        (OptionT(x.findDataset(name)) <+> OptionT(y.findDataset(name))).value
     }
   }
 }

--- a/core/src/test/scala/latis/catalog/CatalogSuite.scala
+++ b/core/src/test/scala/latis/catalog/CatalogSuite.scala
@@ -1,0 +1,58 @@
+package latis.catalog
+
+import cats.syntax.all._
+import org.scalatest.funsuite.AnyFunSuite
+
+import latis.dsl.DatasetGenerator
+import latis.util.Identifier._
+
+class CatalogSuite extends AnyFunSuite {
+
+  val ds1 = DatasetGenerator("a: double -> b: double", id"ds1")
+  val ds2 = DatasetGenerator("a: double -> b: double", id"ds2")
+  val ds3 = DatasetGenerator("a: double -> b: double", id"ds3")
+
+  val c1 = Catalog(ds1, ds2)
+  val c2 = Catalog(ds3)
+  val combined = c1 |+| c2
+
+  test("list datasets in a single catalog") {
+    val expected = List("ds1", "ds2")
+
+    assertResult(expected) {
+      c1.datasets.map(_.id.get.asString).compile.toList.unsafeRunSync()
+    }
+  }
+
+  test("find datasets in a single catalog") {
+    val expected = Option("ds2")
+
+    assertResult(expected) {
+      c1.findDataset(id"ds2").unsafeRunSync().map(_.id.get.asString)
+    }
+  }
+
+  test("list datasets in a combined catalog") {
+    val expected = List("ds1", "ds2", "ds3")
+
+    assertResult(expected) {
+      combined.datasets.map(_.id.get.asString).compile.toList.unsafeRunSync()
+    }
+  }
+
+  test("find datasets on the left side of a combined catalog") {
+    val expected = Option("ds2")
+
+    assertResult(expected) {
+      combined.findDataset(id"ds2").unsafeRunSync().map(_.id.get.asString)
+    }
+  }
+
+  test("find datasets on the right side of a combined catalog") {
+    val expected = Option("ds3")
+
+    assertResult(expected) {
+      combined.findDataset(id"ds3").unsafeRunSync().map(_.id.get.asString)
+    }
+  }
+}


### PR DESCRIPTION
I guess I must not have tested this? The issue was that `findDataset` was using the [`SemigroupK`](https://typelevel.org/cats/typeclasses/semigroupk.html) instance for `IO`, which [returns the first `IO` that succeeds](https://github.com/typelevel/cats-effect/blob/v2.5.1/core/shared/src/main/scala/cats/effect/IO.scala#L994-L998). The `IO` from `findDataset` on the first catalog would only fail if there was an unexpected issue, so it was effectively only ever looking for datasets in the first catalog.

What we really want is the `SemigroupK` instance for [`OptionT`](https://typelevel.org/cats/datatypes/optiont.html), which will [return the first `Some`](https://github.com/typelevel/cats/blob/v2.6.1/core/src/main/scala/cats/data/OptionT.scala#L549) and [handle the `IO` bits](https://github.com/typelevel/cats/blob/v2.6.1/core/src/main/scala/cats/data/OptionT.scala#L128-L135) for us.

I also added some basic tests.