### PR TITLE
Add rename method to Dataset

### DIFF
--- a/core/src/main/scala/latis/dataset/AdaptedDataset.scala
+++ b/core/src/main/scala/latis/dataset/AdaptedDataset.scala
@@ -11,6 +11,7 @@ import latis.input.Adapter
 import latis.metadata.Metadata
 import latis.model.DataType
 import latis.ops.UnaryOperation
+import latis.util.Identifier
 import latis.util.LatisException
 
 /**
@@ -39,6 +40,15 @@ class AdaptedDataset(
       adapter: Adapter,
       uri: URI,
       operations :+ operation
+    )
+
+  def rename(newId: Identifier): Dataset =
+    new AdaptedDataset(
+      _metadata + ("id" -> newId.asString),
+      _model,
+      adapter: Adapter,
+      uri: URI,
+      operations
     )
 
   /**

--- a/core/src/main/scala/latis/dataset/CompositeDataset.scala
+++ b/core/src/main/scala/latis/dataset/CompositeDataset.scala
@@ -14,6 +14,7 @@ import latis.model.DataType
 import latis.ops.Append
 import latis.ops.BinaryOperation
 import latis.ops.UnaryOperation
+import latis.util.Identifier
 import latis.util.LatisException
 
 /**
@@ -50,6 +51,13 @@ class CompositeDataset(
       _metadata,
       datasets,
       operations :+ op
+    )
+
+  def rename(newId: Identifier): Dataset =
+    new CompositeDataset(
+      _metadata + ("id" -> newId.asString),
+      datasets,
+      operations
     )
 
   /**

--- a/core/src/main/scala/latis/dataset/ComputationalDataset.scala
+++ b/core/src/main/scala/latis/dataset/ComputationalDataset.scala
@@ -6,6 +6,7 @@ import latis.data._
 import latis.metadata._
 import latis.model._
 import latis.ops.UnaryOperation
+import latis.util.Identifier
 import latis.util.LatisException
 
 /**
@@ -35,5 +36,6 @@ case class ComputationalDataset(
   //TODO: need SampledDataset to do things this can't
   def samples: fs2.Stream[IO, (DomainData, RangeData)] = ???
   def withOperation(op: UnaryOperation): Dataset = ???
+  def rename(id: Identifier): Dataset = ???
   def unsafeForce(): MemoizedDataset = ???
 }

--- a/core/src/main/scala/latis/dataset/Dataset.scala
+++ b/core/src/main/scala/latis/dataset/Dataset.scala
@@ -12,6 +12,7 @@ import latis.metadata.MetadataLike
 import latis.model.DataType
 import latis.ops.UnaryOperation
 import latis.util.CacheManager
+import latis.util.Identifier
 
 /**
  * Defines the interface for a LaTiS Dataset.
@@ -40,6 +41,11 @@ trait Dataset extends MetadataLike {
    * applied to this one.
    */
   def withOperation(op: UnaryOperation): Dataset
+
+  /**
+   * Makes a copy of this dataset with a new name.
+   */
+  def rename(id: Identifier): Dataset
 
   /**
    * Returns a new Dataset with the given Operations *logically*

--- a/core/src/main/scala/latis/dataset/MemoizedDataset.scala
+++ b/core/src/main/scala/latis/dataset/MemoizedDataset.scala
@@ -4,6 +4,7 @@ import latis.data._
 import latis.metadata.Metadata
 import latis.model.DataType
 import latis.ops.UnaryOperation
+import latis.util.Identifier
 
 /**
  * Defines a Dataset whose data is not connected
@@ -26,6 +27,14 @@ class MemoizedDataset(
       _model,
       _data,
       operations :+ operation
+    )
+
+  override def rename(newId: Identifier): Dataset =
+    new MemoizedDataset(
+      _metadata + ("id" -> newId.asString),
+      _model,
+      _data,
+      operations
     )
 
   /**

--- a/core/src/main/scala/latis/dataset/TappedDataset.scala
+++ b/core/src/main/scala/latis/dataset/TappedDataset.scala
@@ -9,6 +9,7 @@ import latis.data._
 import latis.metadata.Metadata
 import latis.model.DataType
 import latis.ops.UnaryOperation
+import latis.util.Identifier
 import latis.util.LatisException
 
 /**
@@ -46,6 +47,14 @@ class TappedDataset(
       _model,
       _data,
       operations :+ operation
+    )
+
+  def rename(newId: Identifier): Dataset =
+    new TappedDataset(
+      _metadata + ("id" -> newId.asString),
+      _model,
+      _data,
+      operations
     )
 
   /**

--- a/core/src/test/scala/latis/dataset/DatasetSpec.scala
+++ b/core/src/test/scala/latis/dataset/DatasetSpec.scala
@@ -77,5 +77,9 @@ class DatasetSpec extends AnyFlatSpec {
     }
     matrixDs shouldBe a [Dataset]
   }
+
+  it should "support rename" in {
+    assert(dataset.rename(id"newName").id.get.asString == "newName")
+  }
   
 }


### PR DESCRIPTION
Note that Operations do not have the power to modify Dataset metadata. I'm thinking about letting the top level DataType (i.e. the model) own the dataset id, but that's a bigger design issue.

For now, this just copies a dataset with the new Id.

