### PR TITLE
Upgrade to Cats Effect 3

### DIFF
--- a/aws-lambda/src/main/scala/latis/lambda/LatisLambdaHandler.scala
+++ b/aws-lambda/src/main/scala/latis/lambda/LatisLambdaHandler.scala
@@ -1,13 +1,11 @@
 package latis.lambda
 
 import java.net.URLDecoder
-import java.util.concurrent.Executors
 
-import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
-import cats.effect.ContextShift
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.RequestHandler
@@ -34,11 +32,6 @@ import latis.util.dap2.parser.ast.ConstraintExpression
 final class LatisLambdaHandler extends RequestHandler[APIGatewayV2HTTPEvent, APIGatewayV2HTTPResponse] {
 
   private val catalog: Catalog = Catalog.empty
-
-  private implicit val cs: ContextShift[IO] = {
-    val ec = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
-    IO.contextShift(ec)
-  }
 
   def handleRequest(
     req: APIGatewayV2HTTPEvent,

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,13 @@ ThisBuild / scalaVersion := "2.13.6"
 
 val attoVersion       = "0.9.5"
 val catsVersion       = "2.6.1"
-val catsEffectVersion = "2.5.1"
-val fs2Version        = "2.5.6"
-val http4sVersion     = "0.21.24"
-val log4catsVersion   = "1.3.1"
+val catsEffectVersion = "3.1.1"
+val fs2Version        = "3.0.4"
+val http4sVersion     = "0.23.0-RC1"
+val log4catsVersion   = "2.1.1"
 val log4jVersion      = "2.14.1"
 val netcdfVersion     = "5.4.1"
-val pureconfigVersion = "0.14.1"
+val pureconfigVersion = "0.15.0"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
@@ -90,9 +90,9 @@ lazy val core = project
       "org.scala-lang.modules" %% "scala-xml"           % "1.3.0",
       "io.circe"               %% "circe-core"          % "0.14.1",
       "org.scodec"             %% "scodec-core"         % "1.11.8",
-      "org.scodec"             %% "scodec-stream"       % "2.0.2",
+      "org.scodec"             %% "scodec-stream"       % "3.0.1",
       "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
-      "com.github.regis-leray" %% "fs2-ftp"             % "0.7.0",
+      "com.github.regis-leray" %% "fs2-ftp"             % "0.8.0",
       "junit"                   % "junit"               % "4.13.2"  % Test,
       "org.scalatestplus"      %% "junit-4-13"          % "3.2.9.0" % Test
     )
@@ -204,7 +204,7 @@ lazy val jdbc = project
   .settings(
     name := "latis3-jdbc",
     libraryDependencies ++= Seq(
-      "org.tpolecat"             %% "doobie-core" % "0.13.4",
+      "org.tpolecat"             %% "doobie-core" % "1.0.0-M5",
       "com.h2database"            % "h2"          % "1.4.200" % Test,
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ ThisBuild / scalaVersion := "2.13.6"
 val attoVersion       = "0.9.5"
 val catsVersion       = "2.6.1"
 val catsEffectVersion = "2.5.1"
-val coursierVersion   = "2.0.16"
 val fs2Version        = "2.5.6"
 val http4sVersion     = "0.21.24"
 val log4catsVersion   = "1.3.1"
@@ -152,8 +151,6 @@ lazy val server = project
   .settings(
     name := "latis3-server",
     libraryDependencies ++= Seq(
-      "io.get-coursier"       %% "coursier"               % coursierVersion,
-      "io.get-coursier"       %% "coursier-cats-interop"  % coursierVersion,
       "org.http4s"            %% "http4s-blaze-server"    % http4sVersion,
       "org.http4s"            %% "http4s-core"            % http4sVersion,
       "org.http4s"            %% "http4s-dsl"             % http4sVersion,

--- a/core/src/main/scala/latis/catalog/FdmlCatalog.scala
+++ b/core/src/main/scala/latis/catalog/FdmlCatalog.scala
@@ -7,13 +7,10 @@ import java.nio.file.Paths
 import cats.effect.IO
 import cats.syntax.all._
 import fs2.Stream
-import fs2.io.file.directoryStream
+import fs2.io.file.Files
 
 import latis.dataset.Dataset
 import latis.input.fdml.FdmlReader
-import latis.util.StreamUtils
-
-import StreamUtils.contextShift
 
 object FdmlCatalog {
 
@@ -55,7 +52,7 @@ object FdmlCatalog {
   }
 
   private def dirDatasetStream(dir: Path, validate: Boolean): Stream[IO, Dataset] =
-    directoryStream[IO](StreamUtils.blocker, dir, "*.fdml").flatMap { f =>
+    Files[IO].directoryStream(dir, "*.fdml").flatMap { f =>
       // TODO: Log failures to read datasets.
       pathToDataset(f, validate).fold(_ => Stream.empty, Stream.emit)
     }

--- a/core/src/main/scala/latis/dsl/package.scala
+++ b/core/src/main/scala/latis/dsl/package.scala
@@ -3,6 +3,7 @@ package latis
 import java.nio.file.Paths
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import fs2.text
 
 import latis.data.DomainSet
@@ -15,7 +16,6 @@ import latis.output.OutputStreamWriter
 import latis.output.TextEncoder
 import latis.util.FileUtils
 import latis.util.Identifier
-import latis.util.StreamUtils._
 
 package object dsl {
 
@@ -77,7 +77,7 @@ package object dsl {
       case Some("csv") => CsvEncoder()
         .encode(dataset)
         .through(text.utf8Encode)
-        .through(fs2.io.file.writeAll(Paths.get(file), blocker))
+        .through(fs2.io.file.writeAll(Paths.get(file)))
         .compile
         .drain
         .unsafeRunSync()

--- a/core/src/main/scala/latis/input/FileStreamSource.scala
+++ b/core/src/main/scala/latis/input/FileStreamSource.scala
@@ -9,8 +9,6 @@ import fs2.Stream
 
 import latis.util.LatisException
 import latis.util.NetUtils
-import latis.util.StreamUtils.blocker
-import latis.util.StreamUtils.contextShift
 
 /**
  * Creates a StreamSource from a relative or absolute file URI.
@@ -34,7 +32,7 @@ class FileStreamSource extends StreamSource {
         case Right(u) =>
           val fis: IO[InputStream] = IO(u.toURL.openStream) //TODO: handle exception, wrap as LatisException
           val chunkSize: Int = 4096 //TODO: tune? config option?
-          Option(readInputStream[IO](fis, chunkSize, blocker))
+          Option(readInputStream[IO](fis, chunkSize))
       }
 
 }

--- a/core/src/main/scala/latis/input/FtpStreamSource.scala
+++ b/core/src/main/scala/latis/input/FtpStreamSource.scala
@@ -9,7 +9,6 @@ import fs2.ftp.UnsecureFtp._
 
 import latis.util.LatisException
 import latis.util.NetUtils._
-import latis.util.StreamUtils._
 
 /**
  * Creates an StreamSource from a "ftp" or "ftps" URI.

--- a/core/src/main/scala/latis/input/HttpStreamSource.scala
+++ b/core/src/main/scala/latis/input/HttpStreamSource.scala
@@ -8,9 +8,7 @@ import cats.effect.IO
 import fs2.Stream
 import org.http4s.Request
 import org.http4s.Uri
-import org.http4s.client.blaze.BlazeClientBuilder
-
-import latis.util.StreamUtils.contextShift
+import org.http4s.blaze.client.BlazeClientBuilder
 
 /**
  * Creates an StreamSource from a "http" or "https" URI.

--- a/core/src/main/scala/latis/input/MatrixTextAdapter.scala
+++ b/core/src/main/scala/latis/input/MatrixTextAdapter.scala
@@ -2,6 +2,8 @@ package latis.input
 
 import java.net.URI
 
+import cats.effect.unsafe.implicits.global
+
 import latis.data._
 import latis.model._
 import latis.ops.Operation

--- a/core/src/main/scala/latis/ops/GroupOperation.scala
+++ b/core/src/main/scala/latis/ops/GroupOperation.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import fs2.Pipe
 import fs2.Stream
 

--- a/core/src/main/scala/latis/output/OutputStreamWriter.scala
+++ b/core/src/main/scala/latis/output/OutputStreamWriter.scala
@@ -2,37 +2,28 @@ package latis.output
 
 import java.io.OutputStream
 
-import cats.Applicative
-import cats.effect.Blocker
-import cats.effect.ContextShift
 import cats.effect.Sync
 import cats.syntax.all._
 import fs2.Pipe
 
-import latis.util.StreamUtils
-
 /**
  * Write to an output stream.
  */
-class OutputStreamWriter[F[_]: ContextShift: Sync](
-  outputStream: F[OutputStream],
-  blocker: Blocker
+class OutputStreamWriter[F[_]: Sync](
+  outputStream: F[OutputStream]
 ) extends Writer[F, Byte] {
 
   override val write: Pipe[F, Byte, Unit] =
-    fs2.io.writeOutputStream(outputStream, blocker)
+    fs2.io.writeOutputStream(outputStream)
 }
 
 object OutputStreamWriter {
 
   /**
    * Create a writer from an impure output stream.
-   *
-   * This method uses the default blocking execution context in
-   * `latis.util.StreamUtils`.
    */
-  def unsafeFromOutputStream[F[_]: Applicative: ContextShift: Sync](
+  def unsafeFromOutputStream[F[_]: Sync](
     os: OutputStream
   ): OutputStreamWriter[F] =
-    new OutputStreamWriter(os.pure[F], StreamUtils.blocker)
+    new OutputStreamWriter(os.pure[F])
 }

--- a/core/src/main/scala/latis/util/NetUtils.scala
+++ b/core/src/main/scala/latis/util/NetUtils.scala
@@ -5,6 +5,7 @@ import java.net.URLDecoder
 import java.nio.file.Path
 import java.nio.file.Paths
 
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import fs2.text
 

--- a/core/src/main/scala/latis/util/StreamUtils.scala
+++ b/core/src/main/scala/latis/util/StreamUtils.scala
@@ -1,31 +1,13 @@
 package latis.util
 
-import java.util.concurrent.Executors
-
-import scala.concurrent.ExecutionContext
-
-import cats.effect.Blocker
-import cats.effect.ContextShift
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import fs2.Stream
 
 /**
  * Utilities for working with fs2 Streams.
  */
 object StreamUtils {
-
-  /**
-   * An execution context for blocking operations.
-   */
-  val blocker: Blocker =
-    Blocker.liftExecutorService(Executors.newCachedThreadPool())
-
-  /**
-   * Provide an implicit ContextShift for use with
-   * fs2.io.readInputStream (e.g. UrlStreamSource).
-   */
-  implicit val contextShift: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
 
   /**
    * Put a Seq of some type into a Stream (in IO).

--- a/core/src/test/scala/latis/catalog/CatalogSuite.scala
+++ b/core/src/test/scala/latis/catalog/CatalogSuite.scala
@@ -1,5 +1,6 @@
 package latis.catalog
 
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/latis/dataset/DatasetSpec.scala
+++ b/core/src/test/scala/latis/dataset/DatasetSpec.scala
@@ -2,6 +2,7 @@ package latis.dataset
 
 import java.nio.file.Paths
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/input/FileListAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/FileListAdapterSpec.scala
@@ -8,6 +8,7 @@ import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 
+import cats.effect.unsafe.implicits.global
 import org.scalactic.Equality
 import org.scalatest.EitherValues._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -17,7 +18,6 @@ import latis.data._
 import latis.metadata.Metadata
 import latis.model._
 import latis.util.LatisException
-import latis.util.StreamUtils
 import FileListAdapter.Config
 
 class FileListAdapterSpec extends AnyFlatSpec {

--- a/core/src/test/scala/latis/input/GranuleListAppendAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/GranuleListAppendAdapterSpec.scala
@@ -2,6 +2,7 @@ package latis.input
 
 import java.net.URI
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/input/MatrixTextAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/MatrixTextAdapterSpec.scala
@@ -11,6 +11,7 @@ import latis.data.{DomainData, RangeData, Sample}
 import latis.dataset.AdaptedDataset
 import latis.input
 import latis.util.NetUtils.resolveUri
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/input/StreamSourceSpec.scala
+++ b/core/src/test/scala/latis/input/StreamSourceSpec.scala
@@ -3,6 +3,7 @@ package latis.input
 import java.io.FileNotFoundException
 import java.net.URI
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 
 import latis.util.LatisException

--- a/core/src/test/scala/latis/input/TextAdapterSpec.scala
+++ b/core/src/test/scala/latis/input/TextAdapterSpec.scala
@@ -7,6 +7,7 @@ import java.net.URI
 
 import latis.data.{DomainData, RangeData, Sample}
 import latis.dataset.AdaptedDataset
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/CurrySuite.scala
+++ b/core/src/test/scala/latis/ops/CurrySuite.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.Inside._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._

--- a/core/src/test/scala/latis/ops/DropLastSpec.scala
+++ b/core/src/test/scala/latis/ops/DropLastSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/DropRightSpec.scala
+++ b/core/src/test/scala/latis/ops/DropRightSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/DropSpec.scala
+++ b/core/src/test/scala/latis/ops/DropSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/HeadSpec.scala
+++ b/core/src/test/scala/latis/ops/HeadSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/LastSpec.scala
+++ b/core/src/test/scala/latis/ops/LastSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/MapOperationSuite.scala
+++ b/core/src/test/scala/latis/ops/MapOperationSuite.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/latis/ops/PivotSuite.scala
+++ b/core/src/test/scala/latis/ops/PivotSuite.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.Inside._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._

--- a/core/src/test/scala/latis/ops/ProjectionSuite.scala
+++ b/core/src/test/scala/latis/ops/ProjectionSuite.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.Inside

--- a/core/src/test/scala/latis/ops/TailSpec.scala
+++ b/core/src/test/scala/latis/ops/TailSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/TakeRightSpec.scala
+++ b/core/src/test/scala/latis/ops/TakeRightSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/TakeSpec.scala
+++ b/core/src/test/scala/latis/ops/TakeSpec.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/ops/TransposeSuite.scala
+++ b/core/src/test/scala/latis/ops/TransposeSuite.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.Inside.inside
 

--- a/core/src/test/scala/latis/ops/UncurrySuite.scala
+++ b/core/src/test/scala/latis/ops/UncurrySuite.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.Inside._
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
@@ -2,14 +2,15 @@ package latis.output
 
 import java.nio.file.Paths
 
+import cats.effect.unsafe.implicits.global
+import org.scalatest.Inside.inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 import scodec._
+import scodec.bits.BitVector
 import scodec.bits._
 import scodec.codecs.implicits._
 import scodec.{Encoder => SEncoder}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers._
-import org.scalatest.Inside.inside
-import scodec.bits.BitVector
 
 import latis.catalog.FdmlCatalog
 import latis.data.Data._

--- a/core/src/test/scala/latis/output/CsvEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/CsvEncoderSpec.scala
@@ -4,6 +4,7 @@ import java.nio.file.Paths
 
 import scala.util.Properties.lineSeparator
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/output/JsonEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/JsonEncoderSpec.scala
@@ -2,9 +2,9 @@ package latis.output
 
 import java.nio.file.Paths
 
+import cats.effect.unsafe.implicits.global
 import io.circe._
 import io.circe.syntax._
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 

--- a/core/src/test/scala/latis/output/MetadataEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/MetadataEncoderSpec.scala
@@ -1,5 +1,6 @@
 package latis.output
 
+import cats.effect.unsafe.implicits.global
 import io.circe.Json
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._

--- a/core/src/test/scala/latis/output/TextEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/TextEncoderSpec.scala
@@ -2,9 +2,11 @@ package latis.output
 
 import java.nio.file.Paths
 
+import scala.util.Properties.lineSeparator
+
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
-import scala.util.Properties.lineSeparator
 
 import latis.catalog.FdmlCatalog
 import latis.dataset.Dataset

--- a/jdbc/src/main/scala/latis/input/JdbcAdapter.scala
+++ b/jdbc/src/main/scala/latis/input/JdbcAdapter.scala
@@ -19,8 +19,6 @@ import latis.model._
 import latis.ops._
 import latis.util.ConfigLike
 import latis.util.LatisException
-import latis.util.StreamUtils
-import latis.util.StreamUtils.contextShift
 import latis.util.dap2.parser.ast
 import latis.util.SqlBuilder
 
@@ -216,8 +214,7 @@ case class JdbcAdapter(
       config.driver,
       baseUri.toString,
       config.user,
-      config.password,
-      StreamUtils.blocker
+      config.password
     )
 
     val sql = SqlBuilder.buildQuery(config.table, model, uops, config.predicate)

--- a/jdbc/src/test/scala/latis/input/JdbcAdapterSpec.scala
+++ b/jdbc/src/test/scala/latis/input/JdbcAdapterSpec.scala
@@ -3,8 +3,8 @@ package latis.input
 import java.io.File
 import java.net.URI
 
-import cats.effect.ContextShift
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import doobie._
 import doobie.implicits._
@@ -18,8 +18,6 @@ import latis.ops._
 import latis.util.Identifier.IdentifierStringContext
 
 class JdbcAdapterSpec extends AnyFlatSpec {
-
-  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContexts.synchronous)
 
   "The JdbcAdapter" should "read data from a database table" in
     withDatabase { uri =>

--- a/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfAdapter.scala
@@ -8,6 +8,7 @@ import scala.math.max
 import scala.math.min
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import fs2.Stream
 import ucar.ma2.Section

--- a/netcdf/src/test/scala/latis/input/NetcdfWrapperSpec.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfWrapperSpec.scala
@@ -2,6 +2,7 @@ package latis.input
 
 import java.io.File
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import ucar.ma2.Section

--- a/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
+++ b/netcdf/src/test/scala/latis/output/NetcdfEncoderSpec.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.DoubleBuffer
 import java.nio.IntBuffer
 
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import ucar.ma2.{DataType => NcDataType}

--- a/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
+++ b/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
@@ -2,33 +2,31 @@ package latis.server
 
 import scala.concurrent.ExecutionContext
 
-import cats.effect.Blocker
-import cats.effect.ContextShift
 import cats.effect.IO
 import cats.effect.Resource
-import cats.effect.Timer
 import org.http4s.HttpRoutes
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.Server
-import org.http4s.server.blaze._
+import org.http4s.blaze.server._
 import org.http4s.server.middleware.CORS
-import org.http4s.server.middleware.CORS.DefaultCORSConfig
+import org.http4s.server.middleware.CORSConfig
 import org.typelevel.log4cats.StructuredLogger
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
+import cats.effect.Temporal
 
 object Latis3ServerBuilder {
 
   val latisConfigSource: ConfigSource =
     ConfigSource.default.at("latis")
 
-  def getCatalogConf(blocker: Blocker)(implicit cs: ContextShift[IO]): IO[CatalogConf] =
-    latisConfigSource.at("fdml").loadF[IO, CatalogConf](blocker)
+  val getCatalogConf: IO[CatalogConf] =
+    latisConfigSource.at("fdml").loadF[IO, CatalogConf]()
 
-  def getServerConf(blocker: Blocker)(implicit cs: ContextShift[IO]): IO[ServerConf] =
-    latisConfigSource.loadF[IO, ServerConf](blocker)
+  val getServerConf: IO[ServerConf] =
+    latisConfigSource.loadF[IO, ServerConf]()
 
   def mkServer(
     conf: ServerConf,
@@ -36,9 +34,8 @@ object Latis3ServerBuilder {
     logger: StructuredLogger[IO],
     executionContext: ExecutionContext = ExecutionContext.global
   )(
-    implicit cs: ContextShift[IO],
-    timer: Timer[IO]
-  ): Resource[IO, Server[IO]] = {
+    implicit timer: Temporal[IO]
+  ): Resource[IO, Server] = {
 
     def constructRoutes(
       interfaces: List[(String, ServiceInterface)]
@@ -55,7 +52,7 @@ object Latis3ServerBuilder {
         LatisServiceLogger(
           Router(conf.mapping -> CORS(
             constructRoutes(interfaces),
-            DefaultCORSConfig
+            CORSConfig.default
           )).orNotFound,
           logger
         )

--- a/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
+++ b/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
@@ -6,13 +6,12 @@ import java.net.URLClassLoader
 
 import scala.reflect.runtime.{ universe => ru }
 
-import cats.effect.ContextShift
 import cats.effect.IO
 import cats.syntax.all._
 
 import latis.catalog.Catalog
 
-final class ServiceInterfaceLoader(implicit cs: ContextShift[IO]) {
+final class ServiceInterfaceLoader {
 
   /**
    * Load service interfaces described in the service interface

--- a/server/src/main/scala/latis/server/conf.scala
+++ b/server/src/main/scala/latis/server/conf.scala
@@ -29,13 +29,6 @@ sealed trait ServiceSpec {
   val clss: String
 }
 
-final case class MavenServiceSpec(
-  name: String,
-  version: String,
-  mapping: String,
-  clss: String
-) extends ServiceSpec
-
 final case class JarServiceSpec(
   path: URL,
   mapping: String,
@@ -48,13 +41,6 @@ final case class ClassPathServiceSpec(
 ) extends ServiceSpec
 
 object ServiceSpec {
-  implicit val mssHint: ProductHint[MavenServiceSpec] =
-    ProductHint(
-      ConfigFieldMapping(CamelCase, KebabCase).withOverrides(
-        "clss" -> "class"
-      )
-    )
-
   implicit val jssHint: ProductHint[JarServiceSpec] =
     ProductHint(
       ConfigFieldMapping(CamelCase, KebabCase).withOverrides(
@@ -72,7 +58,6 @@ object ServiceSpec {
   implicit val coproductHint: CoproductHint[ServiceSpec] =
     new FieldCoproductHint[ServiceSpec]("type") {
       override def fieldValue(name: String): String = name match {
-        case "MavenServiceSpec"     => "maven"
         case "JarServiceSpec"       => "jar"
         case "ClassPathServiceSpec" => "class"
       }


### PR DESCRIPTION
Check out the links below for a more comprehensive idea of what the new releases mean. Here's a brief overview of what they mean for us:

- No more `Blocker` or `ContextShift`. Instead, running an `IO` requires an implicit `IORuntime`, which includes blocking and compute pools. This would usually be provided by `IOApp`, but because we use `unsafeRunSync` we either need to thread the `IORuntime` around or use the global `cats.effect.unsafe.implicits.global` instance. The right thing to do is to get rid of `unsafeRunSync`, but that's a larger refactoring.

- FS2 now has a `Files` capability trait and the `fs.io.file` methods are deprecated.

- Coursier didn't seem to be updating to Cats Effect 3 any time soon, and rather than wait I decided to remove the code that depended on it. We used it to load service interfaces from Maven repositories, but that's not a feature we use, especially since we don't publish artifacts yet. We can get it back once Coursier updates. If we really want, we could write our own typeclass instances for Cats Effect 3.

Relevant reading:
- [Migration guide](https://typelevel.org/cats-effect/docs/migration-guide)
- [Cats Effect 3 release notes](https://github.com/typelevel/cats-effect/releases/tag/v3.0.0)
- [FS2 3 release notes](https://github.com/typelevel/fs2/releases/tag/v3.0.0)