### PR TITLE
New encoder mappings

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -96,7 +96,7 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
         file    <- new NetcdfEncoder(tmpFile.toFile()).encode(ds)
         bytes   <- Files[IO].readAll(file.toPath(), 4096)
       } yield bytes).asRight.map((_, `Content-Type`(MediaType.application.`x-netcdf`)))
-    case "txt"   => new CsvEncoder(_ => Stream()).encode(ds).through(text.utf8Encode).asRight
+    case "txt"   => CsvEncoder().encode(ds).through(text.utf8Encode).asRight
       .map((_, `Content-Type`(MediaType.text.plain)))
     case _       => UnknownExtension(s"Unknown extension: $ext").asLeft
   }

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -78,26 +78,27 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
     str.stripPrefix("\"").stripSuffix("\"")
 
   private def encode(ext: String, ds: Dataset): Either[Dap2Error, (Stream[IO, Byte], `Content-Type`)] = ext match {
-    case ""     => encode("html", ds)
-    case "asc"  => new TextEncoder().encode(ds).through(text.utf8Encode).asRight
+    case ""      => encode("html", ds)
+    case "asc"   => new TextEncoder().encode(ds).through(text.utf8Encode).asRight
       .map((_,`Content-Type`(MediaType.text.plain)))
-    case "bin"  => new BinaryEncoder().encode(ds).flatMap {
+    case "bin"   => new BinaryEncoder().encode(ds).flatMap {
       bits => Stream.emits(bits.toByteArray)
     }.asRight.map((_, `Content-Type`(MediaType.application.`octet-stream`)))
-    case "csv"  => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
+    case "csv"   => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
       .map((_, `Content-Type`(MediaType.text.csv)))
     case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8Encode).asRight
       .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl"))))
-    case "meta" => new MetadataEncoder().encode(ds).map(_.noSpaces).through(text.utf8Encode).asRight
+    case "meta"  => new MetadataEncoder().encode(ds).map(_.noSpaces).through(text.utf8Encode).asRight
       .map((_,`Content-Type`(MediaType.application.json)))
-    case "nc"   =>
+    case "nc"    =>
       (for {
         tmpFile <- Stream.resource(Files[IO].tempFile(None))
         file    <- new NetcdfEncoder(tmpFile.toFile()).encode(ds)
         bytes   <- Files[IO].readAll(file.toPath(), 4096)
       } yield bytes).asRight.map((_, `Content-Type`(MediaType.application.`x-netcdf`)))
-    //TODO: "txt" => headerless CSV
-    case _      => UnknownExtension(s"Unknown extension: $ext").asLeft
+    case "txt"   => new CsvEncoder(_ => Stream()).encode(ds).through(text.utf8Encode).asRight
+      .map((_, `Content-Type`(MediaType.text.plain)))
+    case _       => UnknownExtension(s"Unknown extension: $ext").asLeft
   }
 
   private def handleDap2Error(err: Dap2Error): IO[Response[IO]] =


### PR DESCRIPTION
Short PR to rewire our encoders like we talked about.

- `"asc"` now maps to the `TextEncoder` (replacing `"txt"`)
- `"txt"` now maps to the `CsvEncoder` but with no header

While I was in there, I reordered the case statements in our pattern match alphabetically—because why not. And I vertically aligned our `=>` arrows again (the extra character in `"jsonl"` made them off by one space).