### PR TITLE
Improved error handling

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -42,9 +42,8 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
           bytes     = encoding._1
           content   = encoding._2
           response <- Ok(bytes).map(_.withContentType(content))
-        } yield response).handleErrorWith {
+        } yield response).recoverWith {
           case err: Dap2Error => handleDap2Error(err)
-          case _              => InternalServerError()
         }
     }
 

--- a/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
+++ b/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
@@ -49,11 +49,14 @@ object Latis3ServerBuilder {
     BlazeServerBuilder[IO](executionContext)
       .bindHttp(conf.port, "0.0.0.0")
       .withHttpApp {
-        LatisServiceLogger(
-          Router(conf.mapping -> CORS(
-            constructRoutes(interfaces),
-            CORSConfig.default
-          )).orNotFound,
+        LatisErrorHandler(
+          LatisServiceLogger(
+            Router(conf.mapping -> CORS(
+              constructRoutes(interfaces),
+              CORSConfig.default
+            )).orNotFound,
+            logger
+          ),
           logger
         )
       }

--- a/server/src/main/scala/latis/server/LatisErrorHandler.scala
+++ b/server/src/main/scala/latis/server/LatisErrorHandler.scala
@@ -1,0 +1,43 @@
+package latis.server
+
+import scala.util.control.NonFatal
+
+import cats.MonadThrow
+import cats.data.Kleisli
+import cats.syntax.all._
+import org.http4s.EntityEncoder
+import org.http4s.Headers
+import org.http4s.HttpApp
+import org.http4s.Response
+import org.http4s.Status
+import org.http4s.headers.Connection
+import org.typelevel.ci._
+import org.typelevel.log4cats.StructuredLogger
+
+/**
+ * Catches otherwise unhandled non-fatal exceptions, logs them, and
+ * returns a 500 response with the message in the body.
+ *
+ * This only handles errors raised in the process of constructing the
+ * response, not errors raised while streaming the response.
+ */
+object LatisErrorHandler {
+
+  def apply[F[_]](
+    app: HttpApp[F],
+    logger: StructuredLogger[F]
+  )(implicit F: MonadThrow[F]): HttpApp[F] = Kleisli { req =>
+    app.run(req).recoverWith {
+      case NonFatal(err) =>
+        logger.error(err)("Request failed") *>
+        F.pure(
+          Response(
+            Status.InternalServerError,
+            req.httpVersion,
+            Headers(Connection(ci"close")),
+            EntityEncoder[F, String].toEntity(err.getMessage()).body
+          )
+        )
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an error handler that will log unhandled errors and return a 500 with a message. It also changes the DAP 2 service so it doesn't try to handle every error, and instead only handles domain error and lets everything else be handled at a different level.

I'm not thrilled about putting the exception message (just the message, not the stack trace) in the 500 response. I believe I was asked to include it temporarily, but I don't recall why we need it now (logs with the full stack trace will be available on STDOUT, Portainer, and Splunk) and what needs to be changed so we won't need it later. The only reason we need a custom error handler is to put the message in the 500 response. Without that requirement, the http4s default works fine.