### PR TITLE
Construct FDML catalogs eagerly

### DIFF
--- a/core/src/main/scala/latis/catalog/Catalog.scala
+++ b/core/src/main/scala/latis/catalog/Catalog.scala
@@ -1,5 +1,6 @@
 package latis.catalog
 
+import cats.Foldable
 import cats.Monoid
 import cats.data.OptionT
 import cats.effect.IO
@@ -32,6 +33,11 @@ object Catalog {
 
   /** A [[Catalog]] that contains no datasets. */
   def empty: Catalog = Catalog()
+
+  def fromFoldable[F[_]: Foldable](dss: F[Dataset]): Catalog =
+    new Catalog {
+      override val datasets: Stream[IO, Dataset] = Stream.foldable(dss)
+    }
 
   implicit def monoid: Monoid[Catalog] = new Monoid[Catalog] {
     def empty: Catalog = Catalog.empty

--- a/core/src/test/scala/latis/dataset/DatasetSpec.scala
+++ b/core/src/test/scala/latis/dataset/DatasetSpec.scala
@@ -23,7 +23,7 @@ class DatasetSpec extends AnyFlatSpec {
     getClass().getClassLoader(),
     Paths.get("datasets"),
     validate = false
-  )
+  ).unsafeRunSync()
 
   val dataset = {
     val metadata = Metadata(id"test")

--- a/server/src/main/scala/latis/server/Latis3Server.scala
+++ b/server/src/main/scala/latis/server/Latis3Server.scala
@@ -25,9 +25,8 @@ object Latis3Server extends IOApp {
       logger      <- Resource.eval(Slf4jLogger.create[IO])
       serverConf  <- Resource.eval(getServerConf)
       catalogConf <- Resource.eval(getCatalogConf)
-      catalog      = FdmlCatalog.fromDirectory(
-        catalogConf.dir,
-        catalogConf.validate
+      catalog     <- Resource.eval(
+        FdmlCatalog.fromDirectory(catalogConf.dir, catalogConf.validate)
       )
       serviceConf <- Resource.eval(getServiceConf)
       interfaces  <- Resource.eval(loader.loadServices(serviceConf, catalog))


### PR DESCRIPTION
Finds and parses FDML once when the catalog is constructed, rather than every time the catalog is queried. This is both faster and lets us fail early and once if there are issues with the FDML directory or the FDML files.

Main change is that the FDML catalog constructors now return `IO[Catalog]` instead of `Catalog` because we're doing the `IO` when the catalogs are constructed. Datasets are still returned as `Stream[IO, Dataset]` to make the PR smaller and because I'm not sure what would be better yet.

I also added a `fromFoldable` constructor that will make a pure catalog from any [`Foldable`](https://typelevel.org/cats/typeclasses/foldable.html) thing.