### PR TITLE
Make warnings (except deprecations) fatal in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,11 @@ lazy val commonSettings = Seq(
   ),
   Test / fork := true,
   scalacOptions -= "-Xfatal-warnings",
+  scalacOptions += {
+    // Keep deprecation warnings as warnings, but make everything
+    // else errors.
+    if (insideCI.value) "-Wconf:cat=deprecation:w,any:e" else ""
+  },
   addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.0" cross CrossVersion.full)
 )
 
@@ -171,7 +176,12 @@ lazy val `service-interface` = project
       "org.typelevel" %% "cats-core"   % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion
     ),
-    scalacOptions -= "-Xfatal-warnings"
+    scalacOptions -= "-Xfatal-warnings",
+    scalacOptions += {
+      // Keep deprecation warnings as warnings, but make everything
+      // else errors.
+      if (insideCI.value) "-Wconf:cat=deprecation:w,any:e" else ""
+    }
   )
 
 lazy val macros = project

--- a/core/src/main/scala/latis/util/FileUtils.scala
+++ b/core/src/main/scala/latis/util/FileUtils.scala
@@ -1,6 +1,5 @@
 package latis.util
 
-import java.io.File
 import java.net.URI
 import java.net.URL
 import java.nio.file._


### PR DESCRIPTION
This will give us fatal warnings (except deprecation warnings) in CI.

My original plan was to only exclude deprecation warnings for the NetCDF subproject because we can't fix those yet, but FS2 recently added their own `Path` and deprecated the methods using `java.nio.file.Path`. Fixing everywhere we use `Path` was more than I wanted to take on right now, and I think it's more important to set up fatal warnings now and maybe eventually remove the deprecation warning exception rather than wait to fix all the deprecation warnings first while new warnings slip in.