### PR TITLE
Add optional parameter supporting alternate dataCodecs for sampleCodec

### DIFF
--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -76,7 +76,7 @@ class BinaryEncoder extends Encoder[IO, BitVector] {
       }
   }
 
-  def sampleCodec(model: DataType): Codec[Sample] = {
+  def sampleCodec(model: DataType, dCodec: Scalar => Codec[Data] = dataCodec): Codec[Sample] = {
     val (domainScalars: List[Scalar], rangeScalars: List[Scalar]) = model match {
       case s: Scalar =>
         (List[Scalar](), List[Scalar](s))
@@ -86,8 +86,8 @@ class BinaryEncoder extends Encoder[IO, BitVector] {
       case Function(d, r) =>
         (d.getScalars, r.getScalars)
     }
-    val domainList: List[Codec[Datum]] = domainScalars.map(s => dataCodec(s).downcast[Datum])
-    val rangeList: List[Codec[Data]] = rangeScalars.map(s => dataCodec(s))
+    val domainList: List[Codec[Datum]] = domainScalars.map(s => dCodec(s).downcast[Datum])
+    val rangeList: List[Codec[Data]] = rangeScalars.map(s => dCodec(s))
     codecOfList(domainList) ~ codecOfList(rangeList)
   }
 }

--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -9,13 +9,12 @@ import scodec.interop.cats._
 import scodec.stream.StreamEncoder
 import scodec.{Encoder => _, _}
 
-import latis.data.Data._
 import latis.data._
 import latis.dataset._
 import latis.model._
 import latis.ops.Uncurry
 
-class BinaryEncoder extends Encoder[IO, BitVector] {
+class BinaryEncoder(val dataCodec: Scalar => Codec[Data] = DataCodec.defaultDataCodec) extends Encoder[IO, BitVector] {
   //TODO: deal with NullData, require replaceMissing?
 
   /**
@@ -31,34 +30,6 @@ class BinaryEncoder extends Encoder[IO, BitVector] {
   /** Instance of scodec.stream.StreamEncoder for Sample. */
   def sampleStreamEncoder(model: DataType): StreamEncoder[Sample] =
     StreamEncoder.many(sampleCodec(model))
-
-  /** Instance of scodec.Codec for Data. */
-  def dataCodec(s: Scalar): Codec[Data] = s.valueType match {
-    case BooleanValueType => codecs.bool(8).xmap[BooleanValue](BooleanValue, _.value).upcast[Data]
-    case ByteValueType    => codecs.byte.xmap[ByteValue](ByteValue, _.value).upcast[Data]
-    case ShortValueType   => codecs.short16.xmap[ShortValue](ShortValue, _.value).upcast[Data]
-    case IntValueType     => codecs.int32.xmap[IntValue](IntValue, _.value).upcast[Data]
-    case LongValueType    => codecs.int64.xmap[LongValue](LongValue, _.value).upcast[Data]
-    case FloatValueType   => codecs.float.xmap[FloatValue](FloatValue, _.value).upcast[Data]
-    case DoubleValueType  => codecs.double.xmap[DoubleValue](DoubleValue, _.value).upcast[Data]
-    case StringValueType if s.metadata.getProperty("size").nonEmpty =>
-      val size = s.metadata.getProperty("size").get.toLong * 8
-      codecs.paddedFixedSizeBits(
-        size,
-        codecs.utf8,
-        codecs.literals.constantBitVectorCodec(BitVector(hex"00"))
-      ).xmap[StringValue](s => StringValue(s.replace("\u0000", "")), _.value).upcast[Data]
-    case StringValueType  => codecs.fail(Err("BinaryEncoder does not support String without a size defined."))
-    case BinaryValueType  =>
-      codecs.bytes.xmap[BinaryValue](
-        bytVec => BinaryValue(bytVec.toArray),
-        binVal => ByteVector(binVal.value)
-      ).upcast[Data]
-    //Note that there is no standard binary encoding for Char, BigInt, or BigDecimal
-    case CharValueType       => codecs.fail(Err("BinaryEncoder does not support Char."))
-    case BigIntValueType     => codecs.fail(Err("BinaryEncoder does not support BigInt."))
-    case BigDecimalValueType => codecs.fail(Err("BinaryEncoder does not support BigDecimal."))
-  }
 
   private def codecOfList[A](cs: List[Codec[A]]): Codec[List[A]] = new Codec[List[A]] {
 
@@ -76,7 +47,7 @@ class BinaryEncoder extends Encoder[IO, BitVector] {
       }
   }
 
-  def sampleCodec(model: DataType, dCodec: Scalar => Codec[Data] = dataCodec): Codec[Sample] = {
+  def sampleCodec(model: DataType): Codec[Sample] = {
     val (domainScalars: List[Scalar], rangeScalars: List[Scalar]) = model match {
       case s: Scalar =>
         (List[Scalar](), List[Scalar](s))
@@ -86,8 +57,8 @@ class BinaryEncoder extends Encoder[IO, BitVector] {
       case Function(d, r) =>
         (d.getScalars, r.getScalars)
     }
-    val domainList: List[Codec[Datum]] = domainScalars.map(s => dCodec(s).downcast[Datum])
-    val rangeList: List[Codec[Data]] = rangeScalars.map(s => dCodec(s))
+    val domainList: List[Codec[Datum]] = domainScalars.map(s => dataCodec(s).downcast[Datum])
+    val rangeList: List[Codec[Data]] = rangeScalars.map(s => dataCodec(s))
     codecOfList(domainList) ~ codecOfList(rangeList)
   }
 }

--- a/core/src/main/scala/latis/output/DataCodec.scala
+++ b/core/src/main/scala/latis/output/DataCodec.scala
@@ -1,0 +1,40 @@
+package latis.output
+
+import scodec._
+import scodec.bits._
+
+import latis.data.Data
+import latis.data.Data._
+import latis.model._
+
+object DataCodec {
+
+  /** Instance of scodec.Codec for Data. */
+  def defaultDataCodec(s: Scalar): Codec[Data] = s.valueType match {
+    case BooleanValueType => codecs.bool(8).xmap[BooleanValue](BooleanValue, _.value).upcast[Data]
+    case ByteValueType    => codecs.byte.xmap[ByteValue](ByteValue, _.value).upcast[Data]
+    case ShortValueType   => codecs.short16.xmap[ShortValue](ShortValue, _.value).upcast[Data]
+    case IntValueType     => codecs.int32.xmap[IntValue](IntValue, _.value).upcast[Data]
+    case LongValueType    => codecs.int64.xmap[LongValue](LongValue, _.value).upcast[Data]
+    case FloatValueType   => codecs.float.xmap[FloatValue](FloatValue, _.value).upcast[Data]
+    case DoubleValueType  => codecs.double.xmap[DoubleValue](DoubleValue, _.value).upcast[Data]
+    case StringValueType if s.metadata.getProperty("size").nonEmpty =>
+      val size = s.metadata.getProperty("size").get.toLong * 8
+      codecs.paddedFixedSizeBits(
+        size,
+        codecs.utf8,
+        codecs.literals.constantBitVectorCodec(BitVector(hex"00"))
+      ).xmap[StringValue](s => StringValue(s.replace("\u0000", "")), _.value).upcast[Data]
+    case StringValueType  => codecs.fail(Err("BinaryEncoder does not support String without a size defined."))
+    case BinaryValueType  =>
+      codecs.bytes.xmap[BinaryValue](
+        bytVec => BinaryValue(bytVec.toArray),
+        binVal => ByteVector(binVal.value)
+      ).upcast[Data]
+    //Note that there is no standard binary encoding for Char, BigInt, or BigDecimal
+    case CharValueType       => codecs.fail(Err("BinaryEncoder does not support Char."))
+    case BigIntValueType     => codecs.fail(Err("BinaryEncoder does not support BigInt."))
+    case BigDecimalValueType => codecs.fail(Err("BinaryEncoder does not support BigDecimal."))
+  }
+
+}


### PR DESCRIPTION
This was a very minor change, just adds optional ability to substitute a different dataCodec, which will be needed to support the HAPI specification.