### PR TITLE
Add support for nested catalogs

### DIFF
--- a/core/src/main/scala/latis/catalog/Catalog.scala
+++ b/core/src/main/scala/latis/catalog/Catalog.scala
@@ -11,17 +11,94 @@ import latis.dataset.Dataset
 import latis.util.Identifier
 
 /**
- * A collection of datasets that is enumerable and can find datasets
- * by their identifier.
+ * A collection of datasets and other catalogs.
+ *
+ * A catalog can list the datasets it contains and find subcatalogs
+ * and datasets (in the root catalog and subcatalogs) by their
+ * identifiers.
+ *
+ * Subcatalogs introduce a new scope for dataset identifiers:
+ *
+ * {{{
+ * // All datasets in c1 are accessible using their usual IDs.
+ * val c1 = Catalog(...)
+ *
+ * // All datasets in c1 are accessible in c2, but their IDs must now
+ * // be qualified with 'a'.
+ * val c2 = Catalog(...).addCatalog(id"a", c1)
+ * }}}
  */
-trait Catalog {
+trait Catalog { self =>
 
   /** Returns all datasets in this catalog. */
   def datasets: Stream[IO, Dataset]
 
-  /** Returns a dataset in the catalog given its name. */
+  /** This catalog's subcatalogs. */
+  def catalogs: Map[Identifier, Catalog] = Map.empty
+
+  /** Adds a single subcatalog to this catalog. */
+  def addCatalog(id: Identifier, catalog: Catalog): Catalog = new Catalog {
+    override val datasets: Stream[IO, Dataset] = self.datasets
+
+    override val catalogs: Map[Identifier, Catalog] =
+      self.catalogs + (id -> catalog)
+  }
+
+  /** Returns a subcatalog given its name. */
+  def findCatalog(name: Identifier): Option[Catalog] =
+    splitId(name) match {
+      case (Nil, id)     => catalogs.get(id)
+      case (q :: qs, id) =>
+        catalogs.get(q).flatMap(_.findCatalog(concatId(qs, id)))
+    }
+
+  /**
+   * Returns a dataset in this catalog or a subcatalog given its name.
+   */
   def findDataset(name: Identifier): IO[Option[Dataset]] =
-    datasets.find(_.id.forall(_ == name)).compile.last
+    splitId(name) match {
+      case (Nil, id)     =>
+        datasets.find(_.id.forall(_ == id)).compile.last
+      case (q :: qs, id) =>
+        catalogs.get(q).flatTraverse(_.findDataset(concatId(qs, id)))
+    }
+
+  /** Sets this catalog's subcatalogs. */
+  def withCatalogs(scs: (Identifier, Catalog)*): Catalog = new Catalog {
+    override val datasets: Stream[IO,Dataset] = self.datasets
+
+    override val catalogs: Map[Identifier, Catalog] = scs.toMap
+  }
+
+  // Constructs a qualified ID.
+  private def concatId(qs: List[Identifier], id: Identifier): Identifier = {
+    val qual = qs.map(_.asString)
+    if (qual.nonEmpty) {
+      Identifier.fromString(s"""${qual.mkString(".")}.${id.asString}""").get
+    } else {
+      id
+    }
+  }
+
+  // Splits an unofficially qualified identifier into a qualification
+  // and an identifier.
+  private def splitId(qid: Identifier): (List[Identifier], Identifier) = {
+    val sections = qid.asString.split('.').toList
+    if (sections.length == 1) {
+      val qual = List.empty
+      val id = Identifier.fromString(sections.head).get
+      (qual, id)
+    } else if (sections.length > 1) {
+      val qual = sections.init.traverse(Identifier.fromString).get
+      val id = Identifier.fromString(sections.last).get
+      (qual, id)
+    } else {
+      // Should never happen. Identifiers cannot be empty strings, and
+      // splitting on a non-empty string will return the string itself
+      // if the delimiter is not in the string.
+      throw new RuntimeException("Bug in qualified identifier splitting")
+    }
+  }
 }
 
 object Catalog {


### PR DESCRIPTION
Catalogs can now contain datasets and other catalogs. Adding one catalog to another requires giving the catalog to be added a name, which may be used to find the catalog later and introduces a scope for other catalogs and datasets. A catalog can list its own datasets and find catalogs and datasets in itself and its subcatalogs.

Here's an example of how this might be used in the telemetry packet use case:

```scala
val items: Catalog = ???
val packets: Catalog = ???

val catalog = Catalog.empty.withCatalogs(
  id"items" -> items,
  id"packets" -> packets
)
```

A dataset `d` in the `items` catalog is accessible through `catalog` as `items.d`:

```scala
catalog.findDataset(id"items.d")
```

A service interface that wants to support nested catalogs will need to turn however the nesting and dataset identifier are represented in the request into a qualified identifier.

This implementation takes advantage of the fact that we support periods in identifiers, even if these aren't really qualified identifiers yet. The methods for working with these unofficial qualified identifiers are kept private to discourage their use elsewhere.