### PR TITLE
Latis 1005: Byte Stream

### DIFF
--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -14,17 +14,17 @@ import latis.dataset._
 import latis.model._
 import latis.ops.Uncurry
 
-class BinaryEncoder(val dataCodec: Scalar => Codec[Data] = DataCodec.defaultDataCodec) extends Encoder[IO, BitVector] {
+class BinaryEncoder(val dataCodec: Scalar => Codec[Data] = DataCodec.defaultDataCodec) extends Encoder[IO, Byte] {
   //TODO: deal with NullData, require replaceMissing?
 
   /**
    * Encodes the Stream of Samples from the given Dataset as a Stream
    * of BitVectors.
    */
-  override def encode(dataset: Dataset): Stream[IO, BitVector] = {
+  override def encode(dataset: Dataset): Stream[IO, Byte] = {
     val uncurriedDataset = dataset.withOperation(Uncurry())
-    // Encode each Sample as a BitVector in the Stream
-    sampleStreamEncoder(uncurriedDataset.model).encode(uncurriedDataset.samples)
+    // Encode the samples as a Stream of Bytes
+    uncurriedDataset.samples.through(sampleStreamEncoder(uncurriedDataset.model).toPipeByte)
   }
 
   /** Instance of scodec.stream.StreamEncoder for Sample. */

--- a/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
@@ -40,7 +40,7 @@ class BinaryEncoderSpec extends AnyFlatSpec {
       SEncoder.encode(2).require ++
         SEncoder.encode(2).require ++
         SEncoder.encode(2.0).require
-    val expected: List[Byte] = bitVec.toByteVector.toSeq.toList
+    val expected: List[Byte] = bitVec.toByteArray.toList
 
     encodedList should be(expected)
   }

--- a/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
@@ -30,17 +30,17 @@ class BinaryEncoderSpec extends AnyFlatSpec {
     val ds: Dataset = DatasetGenerator("x -> (a: int, b: double)")
     val encodedList = enc.encode(ds).compile.toList.unsafeRunSync()
 
-    val expected = List(
+    val bitVec =
       SEncoder.encode(0).require ++
         SEncoder.encode(0).require ++
-        SEncoder.encode(0.0).require,
+        SEncoder.encode(0.0).require ++
       SEncoder.encode(1).require ++
         SEncoder.encode(1).require ++
-        SEncoder.encode(1.0).require,
+        SEncoder.encode(1.0).require ++
       SEncoder.encode(2).require ++
         SEncoder.encode(2).require ++
         SEncoder.encode(2.0).require
-    )
+    val expected: List[Byte] = bitVec.toByteVector.toSeq.toList
 
     encodedList should be(expected)
   }

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -80,9 +80,7 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
     case ""      => encode("html", ds)
     case "asc"   => new TextEncoder().encode(ds).through(text.utf8Encode).asRight
       .map((_,`Content-Type`(MediaType.text.plain)))
-    case "bin"   => new BinaryEncoder().encode(ds).flatMap {
-      bits => Stream.emits(bits.toByteArray)
-    }.asRight.map((_, `Content-Type`(MediaType.application.`octet-stream`)))
+    case "bin"   => new BinaryEncoder().encode(ds).asRight.map((_, `Content-Type`(MediaType.application.`octet-stream`)))
     case "csv"   => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
       .map((_, `Content-Type`(MediaType.text.csv)))
     case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8Encode).asRight


### PR DESCRIPTION
Modifies BinaryEncoder to encode to a `Stream[IO, Byte]` rather than `Stream[IO, BitVector]`.

Also updates the relevant test, and fixes some syntax in Dap2Service that this change breaks.