### PR TITLE
Granule append dataset

### DIFF
--- a/core/src/main/scala/latis/dataset/GranuleAppendDataset.scala
+++ b/core/src/main/scala/latis/dataset/GranuleAppendDataset.scala
@@ -1,0 +1,212 @@
+package latis.dataset
+
+import cats.effect.IO
+import fs2.Stream
+
+import latis.data._
+import latis.metadata.Metadata
+import latis.model._
+import latis.ops._
+import latis.util.Identifier
+
+/**
+ * A GranuleAppendDataset combines individual (granule) Datasets
+ * as defined by a granuleList Dataset.
+ *
+ * The granule list Dataset is expected to define granules that are ordered
+ * with no overlap of coverage. Each granule is expected to have the same model.
+ * As such, the Samples from each granule can be appended while preserving
+ * order without duplication.
+ *
+ * The general use case expects that the granule list Dataset has a single
+ * domain variable (usually time) that is the same as the first dimension of
+ * the granule datasets. Selections on that common variable can often be pushed down
+ * to the granule list to limit the number of granules that need to be accessed.
+ * In such cases, the granule list selection is treated with contiguous bin
+ * semantics such that the value of the domain variable of the granule list
+ * represents the inclusive start of the bin which ends with the exclusive
+ * start of the next granule. This assumes that the domain value for the granule
+ * in the granule list is less than or equal to the domain value of the first
+ * sample in the granule. For example, daily files (i.e. granules) could be
+ * represented as a time series of URLs (i.e. granule list dataset): time -> url
+ * with time values for the start of the day. Each file might contain hourly samples
+ * for that day that we want to combine with samples from other files.
+ *
+ * The granule list may have a different domain than the granules as long as
+ * uniqueness and ordering is maintained when simply appending Samples from the
+ * granules. No push-down optimization will be applied to such a granule list.
+ *
+ * Each Sample of the granule list Dataset becomes a granule Dataset via the
+ * granuleToDataset function. These Datasets are combined as a CompositeDataset
+ * using the Append join operation. This assumes that the granules are aligned
+ * in the proper order with no overlap in coverage. The CompositeDataset may
+ * enable operation push-down to the granules.
+ *
+ * The opportunity to push down an operation is limited by the commutative
+ * properties of operations that precede it.
+ */
+class GranuleAppendDataset private (
+  dsIdentifier: Identifier,
+  granuleList: Dataset,
+  granuleModel: DataType,
+  granuleToDataset: Sample => Dataset,
+  listOps: List[UnaryOperation] = List.empty,
+  operations: List[UnaryOperation] = List.empty
+) extends Dataset {
+  //TODO: support nD tiles
+
+  /*
+  TODO: apply bin semantics
+    require cadence?
+
+  TODO: handle error in granuleToDataset
+    how much can be raised into stream's IO error channel?
+    what if granule sample is invalid?
+    should function return Either?
+    just deal with thrown exceptions?
+
+  TODO: migrate sorted join from packets
+  TODO: migrate type matcher from packets
+   */
+
+  def metadata: Metadata = Metadata(dsIdentifier) //TODO: add prov, see AbstractDataset
+
+  def model: DataType = operations.foldLeft(granuleModel)((mod, op) => op.applyToModel(mod).fold(throw _, identity))
+
+  /**
+   * Combines a List of granule Datasets into a single Dataset.
+   */
+  private def makeDataset(granules: List[Dataset]): Dataset = granules match {
+    case ds1 :: ds2 :: dss => CompositeDataset(dsIdentifier, Append(), ds1, ds2, dss)
+    case ds :: Nil         => ds //just one granule, TODO: rename it with dsIdentifier?
+    case Nil               => new TappedDataset(metadata, granuleModel, SeqFunction(Seq.empty)) //empty dataset
+  }
+
+  /**
+   * Constructs a Stream of Samples from the granule Datasets with operations applied.
+   */
+  def samples: Stream[IO, Sample] =
+    Stream.eval(
+      granuleList                          //start with granule list dataset
+        .withOperations(listOps)           //add operations to granule list
+        .samples                           //get samples, one for each granule
+        .map(granuleToDataset)             //convert each sample to a dataset
+        .compile.toList                    //get the list of datasets from stream (in IO)
+        .map(makeDataset)                  //combine the granules into a single dataset
+        .map(_.withOperations(operations)) //add operations to dataset
+    ).flatMap(_.samples)                   //eval back into stream then get samples
+
+  /** Returns the granule list domain Scalar if it is one-dimensional. */
+  private def granuleDomain: Option[Scalar] = granuleList.model match {
+    case Function(s: Scalar, _) => Some(s)
+    case _ => None
+  }
+
+  /**
+   * Indicates if the given operation can be applied to the granule list dataset.
+   */
+  private def canPushDown(op: UnaryOperation): Boolean = op match {
+    case Selection(id, _, _) =>
+      // Push down selections that target the granule list domain variable.
+      // Prevent application to the list if certain operations have already been added.
+      granuleDomain match {
+        case Some(s: Scalar) =>
+          (s.id == id) && //TODO: must rewrite to match last rename
+          operations.forall {
+            // Can we safely push down the selection to the granule list dataset
+            // if the given operation has already been added.
+            // Note that this does NOT reorder the operations.
+            case _: Filter     => true
+            case _: Projection => true
+            case _: Taking     => true
+            case _: Rename     => true
+            case _ => false
+          }
+        case _ => false //not a 1D Function
+      }
+    case Rename(rid, _) =>
+      // Push down Rename if it targets the granule list domain.
+      // Account for previous renames by using the latest.
+      // This allows us to safely push down selections that follow a rename.
+      // Note that this assumes only one domain variable.
+      // TODO: drop this condition if rename with a missing target is a no-op?
+      listOps.collect {
+        case Rename(_, id) => id
+      }.lastOption.fold(granuleDomain.map(_.id).contains(rid))(_ == rid)
+    case _ => false
+  }
+
+  /**
+   * Makes a copy of this Dataset with the given operation added to the list
+   * to be applied. Some operations may also be applied (pushed down) to the
+   * granule list Dataset for optimization purposes.
+   */
+  def withOperation(op: UnaryOperation): Dataset = {
+    if (canPushDown(op)) {
+      new GranuleAppendDataset(
+        dsIdentifier,
+        granuleList,
+        granuleModel,
+        granuleToDataset,
+        listOps = listOps :+ op,
+        operations = operations :+ op
+      )
+    } else {
+      new GranuleAppendDataset(
+        dsIdentifier,
+        granuleList,
+        granuleModel,
+        granuleToDataset,
+        listOps = listOps,
+        operations = operations :+ op
+      )
+    }
+  }
+
+  /*
+  TODO: nearest neighbor
+    Note: should not be handled as a Selection, not a filter
+    e.g. last second of minute cadence in daily files
+      the time nominally falls within the bounds of the file but the nearest is in the next file
+      use time >= n & take(2)?
+      consider also start/previous
+        would need to know cadence of files?
+        can we use a 3 element sliding window?
+        or just best effort?
+   */
+
+  def unsafeForce(): MemoizedDataset = ???
+}
+
+object GranuleAppendDataset {
+
+  def apply(
+    id: Identifier,
+    granuleList: Dataset,
+    model: DataType,
+    granuleToDataset: Sample => Dataset
+  ): GranuleAppendDataset = new GranuleAppendDataset(
+    id,
+    granuleList,
+    model,
+    granuleToDataset
+  )
+
+  /*
+  TODO: FDML support
+    Assign "class" in "dataset" element, default to AdaptedDataset, use GranuleAppendDataset here
+    source is granuleList dataset (preferably via ref)
+    adapter and model are for granule
+    construct GranuleAppendDataset
+      make adapter from AdapterConfig
+      granuleToDataset: extract uri from granuleList, invoke adapter
+        require "uri" variable or var of type URI (subclass of scalar)?
+   */
+//  def apply(
+//    id: Identifier,
+//    granuleList: Dataset,
+//    model: DataType,
+//    adapterConfig: AdapterConfig
+//  ): GranuleAppendDataset = ???
+
+}

--- a/core/src/main/scala/latis/dataset/GranuleAppendDataset.scala
+++ b/core/src/main/scala/latis/dataset/GranuleAppendDataset.scala
@@ -111,7 +111,11 @@ class GranuleAppendDataset private (
       // Prevent application to the list if certain operations have already been added.
       granuleDomain match {
         case Some(s: Scalar) =>
-          (s.id == id) && //TODO: must rewrite to match last rename
+          // Get the domain variable id, account for potential rename
+          val domainId = listOps.collect {
+            case Rename(_, id) => id
+          }.lastOption.getOrElse(s.id)
+          (domainId == id) &&  //Selection target must match domain id
           operations.forall {
             // Can we safely push down the selection to the granule list dataset
             // if the given operation has already been added.

--- a/core/src/main/scala/latis/ops/Append.scala
+++ b/core/src/main/scala/latis/ops/Append.scala
@@ -10,7 +10,7 @@ import latis.util.LatisException
 /**
  * Joins two Datasets by appending their Streams of Samples.
  */
-case class Append() extends BinaryOperation {
+case class Append() extends Join {
   //TODO: assert that models are the same
   //TODO: deal with non-Function Data: add index domain? error?
 

--- a/core/src/main/scala/latis/ops/Curry.scala
+++ b/core/src/main/scala/latis/ops/Curry.scala
@@ -31,7 +31,7 @@ case class Curry(arity: Int = 1) extends GroupOperation {
       val msg = "Curry can only reduce arity. Use Uncurry to increase arity."
       throw LatisException(msg)
     }
-    (sample: Sample) => Some(sample.domain.take(arity))
+    (sample: Sample) => Some(sample.domain.take(arity)) //TODO: only Cartesian dataset can guarantee unique, order
   }
 
   // takes the model for the dataset and returns the domain of the curried dataset

--- a/core/src/main/scala/latis/ops/Filter.scala
+++ b/core/src/main/scala/latis/ops/Filter.scala
@@ -14,6 +14,7 @@ import latis.util.LatisException
  * in a new Dataset that has all the "false" Samples removed.
  * This only impacts the number of Samples in the Dataset.
  * It does not affect the model.
+ * A Filter operation is idempotent.
  */
 trait Filter extends UnaryOperation with StreamOperation { self =>
   //TODO: update "length" metadata?

--- a/core/src/main/scala/latis/ops/Head.scala
+++ b/core/src/main/scala/latis/ops/Head.scala
@@ -7,7 +7,7 @@ import latis.data.Sample
 import latis.model.DataType
 import latis.util.LatisException
 
-case class Head() extends StreamOperation {
+case class Head() extends StreamOperation with Taking {
 
   def pipe(model: DataType): Pipe[IO, Sample, Sample] = in => in.head
 

--- a/core/src/main/scala/latis/ops/Join.scala
+++ b/core/src/main/scala/latis/ops/Join.scala
@@ -1,0 +1,40 @@
+package latis.ops
+
+import latis.data.StreamFunction
+import latis.dataset._
+
+
+/**
+ * A Join is a BinaryOperation that combines two or more Datasets.
+ *
+ * Unlike arbitrary binary operations, Joins provide lawful behavior
+ * for distributing operations to the operands before applying the join.
+ * This is often important for performance reasons.
+ *
+ * Properties of Joins:
+ * - Each dataset must have the same domain type.
+ * - Joins must not generate new variables.
+ * - Joins may add fill data (e.g. outer joins).
+ * - Joins may compute new values only to resolve duplication (e.g. average).
+ *
+ * The following classes of UnaryOperations can be distributed over the Join
+ * operation and applied to the operands:
+ *   Filter (e.g. Selection)
+ *   MapOperation (e.g. Projection)
+ *
+ * Some classes of UnaryOperations can be applied to the operands
+ * but also need to be reapplied after the join:
+ *   Taking (Head, Take, TakeRight, Last)
+ *
+ * Joins can be used by a CompositeDataset while enabling operation
+ * push-down to member Datasets.
+ */
+trait Join extends BinaryOperation {
+
+  final def combine(ds1: Dataset, ds2: Dataset): Dataset = {
+    val md = ds1.metadata //TODO: combine metadata
+    val model = applyToModel(ds1.model, ds2.model).fold(throw _, identity)
+    val data = applyToData(StreamFunction(ds1.samples), StreamFunction(ds2.samples)).fold(throw _, identity)
+    new TappedDataset(md, model, data)
+  }
+}

--- a/core/src/main/scala/latis/ops/Join.scala
+++ b/core/src/main/scala/latis/ops/Join.scala
@@ -12,19 +12,19 @@ import latis.dataset._
  * This is often important for performance reasons.
  *
  * Properties of Joins:
- * - Each dataset must have the same domain type.
- * - Joins must not generate new variables.
- * - Joins may add fill data (e.g. outer joins).
- * - Joins may compute new values only to resolve duplication (e.g. average).
+ *  - Each dataset must have the same domain type.
+ *  - Joins must not generate new variables.
+ *  - Joins may add fill data (e.g. outer joins).
+ *  - Joins may compute new values only to resolve duplication (e.g. average).
  *
  * The following classes of UnaryOperations can be distributed over the Join
  * operation and applied to the operands:
- *   Filter (e.g. Selection)
- *   MapOperation (e.g. Projection)
+ *  - Filter (e.g. Selection)
+ *  - MapOperation (e.g. Projection)
  *
  * Some classes of UnaryOperations can be applied to the operands
  * but also need to be reapplied after the join:
- *   Taking (Head, Take, TakeRight, Last)
+ *  - Taking (Head, Take, TakeRight, Last)
  *
  * Joins can be used by a CompositeDataset while enabling operation
  * push-down to member Datasets.

--- a/core/src/main/scala/latis/ops/Last.scala
+++ b/core/src/main/scala/latis/ops/Last.scala
@@ -9,7 +9,7 @@ import latis.data.Sample
 import latis.model.DataType
 import latis.util.LatisException
 
-case class Last() extends StreamOperation {
+case class Last() extends StreamOperation with Taking {
 
   def pipe(model: DataType): Pipe[IO, Sample, Sample] =
     in =>

--- a/core/src/main/scala/latis/ops/Stride.scala
+++ b/core/src/main/scala/latis/ops/Stride.scala
@@ -1,17 +1,24 @@
 package latis.ops
 
+import cats.effect.IO
+import fs2._
+
 import latis.data.Sample
 import latis.model.DataType
+import latis.util.LatisException
 
 /**
  * Defines a unary operation that keeps every nth Sample
  * where n is the stride. The stride can have more than one element,
  * one for each dimension of a Cartesian Dataset.
  */
-case class Stride(stride: Seq[Int]) extends Filter {
+case class Stride(stride: Seq[Int]) extends StreamOperation {
   //TODO: support nD stride for Cartesian Datasets
 
-  def predicate(model: DataType): Sample => Boolean = {
+  def pipe(model: DataType): Pipe[IO, Sample, Sample] =
+    (stream: Stream[IO, Sample]) => stream.filter(predicate)
+
+  private val predicate: Sample => Boolean = {
     var count = -1
     (_: Sample) => {
       count = count + 1
@@ -19,6 +26,9 @@ case class Stride(stride: Seq[Int]) extends Filter {
       else false
     }
   }
+
+  // A Stride does not affect the model.
+  def applyToModel(model: DataType): Either[LatisException, DataType] = Right(model)
 
 }
 

--- a/core/src/main/scala/latis/ops/Take.scala
+++ b/core/src/main/scala/latis/ops/Take.scala
@@ -8,7 +8,7 @@ import latis.data.Sample
 import latis.model.DataType
 import latis.util.LatisException
 
-class Take private (val n: Int) extends StreamOperation {
+class Take private (val n: Int) extends StreamOperation with Taking {
 
   def pipe(model: DataType): Pipe[IO, Sample, Sample] = in => in.take(n.toLong)
 

--- a/core/src/main/scala/latis/ops/TakeRight.scala
+++ b/core/src/main/scala/latis/ops/TakeRight.scala
@@ -8,7 +8,7 @@ import latis.data.Sample
 import latis.model.DataType
 import latis.util.LatisException
 
-case class TakeRight(n: Int) extends StreamOperation {
+case class TakeRight(n: Int) extends StreamOperation with Taking {
 
   def pipe(model: DataType): Pipe[IO, Sample, Sample] = in => in.takeRight(n)
 

--- a/core/src/main/scala/latis/ops/Taking.scala
+++ b/core/src/main/scala/latis/ops/Taking.scala
@@ -1,0 +1,18 @@
+package latis.ops
+
+/**
+ * A UnaryOperation implementing the Taking trait preserves
+ * a subset of Samples without needing to examine the data or
+ * otherwise altering the data. A Taking operation is idempotent
+ * (i.e. it can be applied more than once with no effect
+ * beyond the first application).
+ *
+ * This property enables distribution over joins with reapplication
+ * after the join.
+ *
+ * Examples: Head, Take, TakeRight, Last
+ * Counter-examples (not Taking):
+ *   Selection requires data examination
+ *   Tail is not idempotent
+ */
+trait Taking

--- a/core/src/main/scala/latis/ops/Taking.scala
+++ b/core/src/main/scala/latis/ops/Taking.scala
@@ -11,8 +11,9 @@ package latis.ops
  * after the join.
  *
  * Examples: Head, Take, TakeRight, Last
+ *
  * Counter-examples (not Taking):
- *   Selection requires data examination
- *   Tail is not idempotent
+ *  - Selection requires data examination
+ *  - Tail is not idempotent
  */
 trait Taking

--- a/core/src/test/scala/latis/dataset/CompositeDatasetSpec.scala
+++ b/core/src/test/scala/latis/dataset/CompositeDatasetSpec.scala
@@ -1,16 +1,16 @@
 package latis.dataset
 
-import cats.data.NonEmptyList
 import org.scalatest.Inside._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
+import latis.data._
 import latis.data.Data._
 import latis.data.Sample
-import latis.data._
 import latis.dsl._
 import latis.metadata.Metadata
 import latis.model._
+import latis.ops.Append
 import latis.ops.Rename
 import latis.ops.Selection
 import latis.util.Identifier.IdentifierStringContext
@@ -34,6 +34,7 @@ class CompositeDatasetSpec extends AnyFlatSpec {
 
     new MemoizedDataset(metadata, model, data)
   }
+
   private lazy val ds2 = {
     val metadata = Metadata(id"test2")
 
@@ -49,8 +50,8 @@ class CompositeDatasetSpec extends AnyFlatSpec {
 
     new MemoizedDataset(metadata, model, data)
   }
-  private lazy val compDs =
-    new CompositeDataset(ds1.metadata, NonEmptyList(ds1, List(ds2)))
+
+  private lazy val compDs = CompositeDataset(id"test", Append(), ds1, ds2)
 
   "A dataset" should "provide a composite model" in {
     inside(compDs.model) {

--- a/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
+++ b/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
@@ -251,7 +251,7 @@ class GranuleAppendDatasetSuite extends AnyFunSuite {
   }
 
   test("error in granuleToDataset") {
-    val f: Sample => Dataset = (s: Sample) => throw new RuntimeException("Boom")
+    val f: Sample => Dataset = (_: Sample) => throw new RuntimeException("Boom")
     val ds = GranuleAppendDataset(id"myDataset", granuleList, model, f)
     ds.samples.compile.toList.attempt.map {
       inside(_) {

--- a/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
+++ b/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
@@ -1,0 +1,189 @@
+package latis.dataset
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.EitherValues._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Inside.inside
+
+import latis.data._
+import latis.dsl._
+import latis.metadata.Metadata
+import latis.ops._
+import latis.util.Identifier.IdentifierStringContext
+
+class GranuleAppendDatasetSuite extends AnyFunSuite {
+
+  private lazy val granuleList: Dataset = DatasetGenerator("t: double -> uri: string")
+  /*
+    t -> uri
+    0.0 -> a
+    1.0 -> b
+    2.0 -> c
+   */
+
+  private lazy val model = ModelParser("t: double -> a: string").value
+
+  //TODO: concurrency issue?
+  private lazy val counter = scala.collection.mutable.Map[String, Int]()
+
+  /** Converts granuleList sample into 2-sample Dataset. */
+  private lazy val granuleToDataset: Sample => Dataset = {
+    case Sample(DomainData(Number(t)), RangeData(Text(u))) =>
+      // Count which granules are accessed
+      counter.get(u) match {
+        case Some(n) => counter += u -> (n + 1)
+        case None    => counter += u -> 1
+      }
+      val mf: MemoizedFunction = SeqFunction(List(
+        Sample(DomainData(t), RangeData(u + t)),
+        Sample(DomainData(t + 0.5), RangeData(u + (t + 0.5)))
+      ))
+      new MemoizedDataset(
+        Metadata("id" -> s"granule_$u"),
+        model,
+        mf
+      )
+    case _ => throw new RuntimeException("Invalid Sample")
+  }
+
+  private lazy val dataset = GranuleAppendDataset(
+    id"myDataset",
+    granuleList,
+    model,
+    granuleToDataset
+  )
+
+  test("join all") {
+    dataset.samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5, 1.0, 1.5, 2.0, 2.5))
+    }.unsafeRunSync()
+  }
+
+  test("push down selection") {
+    counter.clear()
+    val ops = List(
+      Selection.makeSelection("t <= 1").value
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5, 1.0))
+      assert(!counter.contains("c")) //never accesses granule c
+    }.unsafeRunSync()
+  }
+
+  test("push down selection after filter") {
+    counter.clear()
+    val ops = List(
+      Selection.makeSelection("a < b").value, //not pushed down
+      Selection.makeSelection("t <= 1").value
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5))
+      assert(!counter.contains("c")) //never accesses granule c
+    }.unsafeRunSync()
+  }
+
+  test("push down selection after take") {
+    counter.clear()
+    val ops = List(
+      Take(3),
+      Selection.makeSelection("t <= 1").value
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5, 1.0))
+      assert(!counter.contains("c")) //never accesses granule c
+    }.unsafeRunSync()
+  }
+
+  //TODO: avoid need to rewrite selection
+  ignore("push down selection after t rename") {
+    counter.clear()
+    val ops = List(
+      Rename(id"t", id"foo"),
+      Selection.makeSelection("foo <= 1").value
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5, 1.0))
+      assert(!counter.contains("c")) //never accesses granule c
+    }.unsafeRunSync()
+  }
+
+  test("push down selection after other rename") {
+    counter.clear()
+    val ops = List(
+      Rename(id"a", id"bar"),
+      Selection.makeSelection("t <= 1").value
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5, 1.0))
+      assert(!counter.contains("c")) //never accesses granule c
+    }.unsafeRunSync()
+  }
+
+  //TODO: add another range variable to unproject
+  //TODO: test handling of Index
+  ignore("push down selection after projection") {}
+
+  test("don't push down selection after stride") {
+    counter.clear()
+    val ops = List(
+      Stride(2),
+      Selection.makeSelection("t <= 1").value
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 1.0))
+      assert(counter.contains("c")) //does accesses granule c
+    }.unsafeRunSync()
+  }
+
+  //TODO: seems to access 3rd granule though not needed?
+  ignore("take short circuit") {
+    counter.clear()
+    val ops = List(
+      Take(3)
+    )
+    dataset.withOperations(ops).samples.map {
+      inside(_) {
+        case Sample(DomainData(Number(t)), _) => t
+      }
+    }.compile.toList.map { ts =>
+      assert(ts == List(0.0, 0.5, 1.0))
+      assert(!counter.contains("c")) //never accesses granule c
+    }.unsafeRunSync()
+  }
+
+  ignore("single granule") {}
+
+  ignore("empty dataset") {}
+
+  ignore("error in granuleToDataset") {}
+
+  ignore("push down selection with bin semantics") {}
+}

--- a/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
+++ b/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
@@ -110,8 +110,7 @@ class GranuleAppendDatasetSuite extends AnyFunSuite {
     }.unsafeRunSync()
   }
 
-  //TODO: avoid need to rewrite selection
-  ignore("push down selection after t rename") {
+  test("push down selection after t rename") {
     counter.clear()
     val ops = List(
       Rename(id"t", id"foo"),


### PR DESCRIPTION
Just a WIP with some significant features that still need improvement.

I've added a `Join` trait that defines a special class of binary operations. `Append` is the first. `SortedJoin` will migrate over soon. I started to lay out the properties of a `Join` in the scaladoc.

I revamped the `CompositeDataset` to use any join. (This will replace the `SortedCompositeDataset` soon.) I put a lot of thought into what operations can be pushed down to the granules. I fixed the fact that `Stride` is not a `Filter` (needs state beyond just a `Sample`). I added a `Taking` trait for the family of operations that idempotently take samples without regard to their content. 

Finally I added the `GranuleAppendDataset` that manages granules as defined by a granule list dataset and a function that converts each `Sample` into a `Dataset` then appends those granules via a `CompositeDataset`. It will push down selection operations with some safety restrictions. (I'm still battling `Rename` and have some more tests to write.) The `CompositeDataset` can further push down operations to granules.

There are a number of improvements to make but a few key features that are looming:
- Apply bin semantics to granule list selections. I plan to bake that in here instead of using the general "domain binning" approach from latis2. General bin semantics will wait for another day.
- FDML support. See the TODOs