### PR TITLE
Fix CORS deprecations

### DIFF
--- a/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
+++ b/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
@@ -5,12 +5,12 @@ import scala.concurrent.ExecutionContext
 import cats.effect.IO
 import cats.effect.Resource
 import org.http4s.HttpRoutes
+import org.http4s.Method
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.Server
 import org.http4s.blaze.server._
 import org.http4s.server.middleware.CORS
-import org.http4s.server.middleware.CORSConfig
 import org.typelevel.log4cats.StructuredLogger
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
@@ -51,10 +51,12 @@ object Latis3ServerBuilder {
       .withHttpApp {
         LatisErrorHandler(
           LatisServiceLogger(
-            Router(conf.mapping -> CORS(
-              constructRoutes(interfaces),
-              CORSConfig.default
-            )).orNotFound,
+            Router(conf.mapping ->
+              CORS.policy
+                .withAllowOriginAll
+                .withAllowMethodsIn(Set(Method.GET, Method.HEAD))
+                .apply(constructRoutes(interfaces))
+            ).orNotFound,
             logger
           ),
           logger


### PR DESCRIPTION
The default CORS settings in previous versions of http4s were found to be insecure: https://github.com/http4s/http4s/security/advisories/GHSA-52cf-226f-rhr6

We've already upgraded to a version of http4s that contains the fix. This PR implements the fix.