### PR TITLE
Fix fs2 UTF-8 pipe deprecations

### DIFF
--- a/core/src/main/scala/latis/dsl/package.scala
+++ b/core/src/main/scala/latis/dsl/package.scala
@@ -64,7 +64,7 @@ package object dsl {
      */
     def show(): Unit = new TextEncoder()
       .encode(dataset)
-      .through(text.utf8Encode)
+      .through(text.utf8.encode)
       .through(OutputStreamWriter.unsafeFromOutputStream[IO](System.out).write)
       .compile
       .drain
@@ -77,7 +77,7 @@ package object dsl {
       //TODO: factor out extension to encoder mapping, reuse in dap2 service
       case Some("csv") => CsvEncoder()
         .encode(dataset)
-        .through(text.utf8Encode)
+        .through(text.utf8.encode)
         .through(Files[IO].writeAll(Paths.get(file)))
         .compile
         .drain

--- a/core/src/main/scala/latis/input/TextAdapter.scala
+++ b/core/src/main/scala/latis/input/TextAdapter.scala
@@ -27,7 +27,7 @@ class TextAdapter(model: DataType, config: TextAdapter.Config = new TextAdapter.
   def recordStream(uri: URI): Stream[IO, String] =
     StreamSource
       .getStream(uri)
-      .through(text.utf8Decode)
+      .through(text.utf8.decode)
       .through(text.lines)
       .drop(config.linesToSkip.toLong)
       .through(seekToDataMarker(config.dataMarker))

--- a/core/src/main/scala/latis/util/NetUtils.scala
+++ b/core/src/main/scala/latis/util/NetUtils.scala
@@ -48,7 +48,7 @@ object NetUtils {
   def readUriIntoString(uri: URI): Either[LatisException, String] =
     StreamSource
       .getStream(uri)
-      .through(text.utf8Decode)
+      .through(text.utf8.decode)
       .compile
       .string
       .attempt

--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -78,14 +78,14 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
 
   private def encode(ext: String, ds: Dataset): Either[Dap2Error, (Stream[IO, Byte], `Content-Type`)] = ext match {
     case ""      => encode("html", ds)
-    case "asc"   => new TextEncoder().encode(ds).through(text.utf8Encode).asRight
+    case "asc"   => new TextEncoder().encode(ds).through(text.utf8.encode).asRight
       .map((_,`Content-Type`(MediaType.text.plain)))
     case "bin"   => new BinaryEncoder().encode(ds).asRight.map((_, `Content-Type`(MediaType.application.`octet-stream`)))
-    case "csv"   => CsvEncoder.withColumnName.encode(ds).through(text.utf8Encode).asRight
+    case "csv"   => CsvEncoder.withColumnName.encode(ds).through(text.utf8.encode).asRight
       .map((_, `Content-Type`(MediaType.text.csv)))
-    case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8Encode).asRight
+    case "jsonl" => new JsonEncoder().encode(ds).map(_.noSpaces).intersperse("\n").through(text.utf8.encode).asRight
       .map((_, `Content-Type`(MediaType.unsafeParse("application/jsonl"))))
-    case "meta"  => new MetadataEncoder().encode(ds).map(_.noSpaces).through(text.utf8Encode).asRight
+    case "meta"  => new MetadataEncoder().encode(ds).map(_.noSpaces).through(text.utf8.encode).asRight
       .map((_,`Content-Type`(MediaType.application.json)))
     case "nc"    =>
       (for {
@@ -93,7 +93,7 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
         file    <- new NetcdfEncoder(tmpFile.toFile()).encode(ds)
         bytes   <- Files[IO].readAll(file.toPath(), 4096)
       } yield bytes).asRight.map((_, `Content-Type`(MediaType.application.`x-netcdf`)))
-    case "txt"   => CsvEncoder().encode(ds).through(text.utf8Encode).asRight
+    case "txt"   => CsvEncoder().encode(ds).through(text.utf8.encode).asRight
       .map((_, `Content-Type`(MediaType.text.plain)))
     case _       => UnknownExtension(s"Unknown extension: $ext").asLeft
   }

--- a/test-utils/src/main/scala/latis/util/DatasetTester.scala
+++ b/test-utils/src/main/scala/latis/util/DatasetTester.scala
@@ -38,7 +38,7 @@ class DatasetTester(catalog: Catalog) {
   def testFile(path: Path): Stream[IO, Boolean] =
     Files[IO]
       .readAll(path, 4096)
-      .through(text.utf8Decode)
+      .through(text.utf8.decode)
       .through(text.lines)
       .filter(pattern.matches)
       .evalMap(testLine)


### PR DESCRIPTION
`text.utf8{En,De}code` have been replaced with `text.utf8.{en,de}code`