### PR TITLE
Migrate to Ember

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val core = project
       "org.scodec"             %% "scodec-core"         % "1.11.9",
       "org.scodec"             %% "scodec-stream"       % "3.0.2",
       "org.scodec"             %% "scodec-cats"         % "1.1.0",
-      "org.http4s"             %% "http4s-blaze-client" % http4sVersion,
+      "org.http4s"             %% "http4s-ember-client" % http4sVersion,
       "com.github.regis-leray" %% "fs2-ftp"             % "0.8.2"
     )
   )
@@ -158,7 +158,7 @@ lazy val server = project
   .settings(
     name := "latis3-server",
     libraryDependencies ++= Seq(
-      "org.http4s"            %% "http4s-blaze-server"    % http4sVersion,
+      "org.http4s"            %% "http4s-ember-server"    % http4sVersion,
       "org.http4s"            %% "http4s-core"            % http4sVersion,
       "org.http4s"            %% "http4s-dsl"             % http4sVersion,
       "com.github.pureconfig" %% "pureconfig"             % pureconfigVersion,

--- a/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
+++ b/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
@@ -1,15 +1,14 @@
 package latis.server
 
-import scala.concurrent.ExecutionContext
-
 import cats.effect.IO
 import cats.effect.Resource
+import com.comcast.ip4s._
 import org.http4s.HttpRoutes
 import org.http4s.Method
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.Server
-import org.http4s.blaze.server._
+import org.http4s.ember.server._
 import org.http4s.server.middleware.CORS
 import org.typelevel.log4cats.StructuredLogger
 import pureconfig.ConfigSource
@@ -32,7 +31,6 @@ object Latis3ServerBuilder {
     conf: ServerConf,
     interfaces: List[(String, ServiceInterface)],
     logger: StructuredLogger[IO],
-    executionContext: ExecutionContext = ExecutionContext.global
   )(
     implicit timer: Temporal[IO]
   ): Resource[IO, Server] = {
@@ -46,8 +44,9 @@ object Latis3ServerBuilder {
       Router(routes:_*)
     }
 
-    BlazeServerBuilder[IO](executionContext)
-      .bindHttp(conf.port, "0.0.0.0")
+    EmberServerBuilder.default[IO]
+      .withHost(host"0.0.0.0")
+      .withPort(conf.port)
       .withHttpApp {
         LatisErrorHandler(
           LatisServiceLogger(
@@ -62,7 +61,6 @@ object Latis3ServerBuilder {
           logger
         )
       }
-      .withoutBanner
-      .resource
+      .build
   }
 }

--- a/server/src/main/scala/latis/server/conf.scala
+++ b/server/src/main/scala/latis/server/conf.scala
@@ -3,6 +3,7 @@ package latis.server
 import java.net.URL
 import java.nio.file.Path
 
+import com.comcast.ip4s.Port
 import pureconfig.CamelCase
 import pureconfig.ConfigFieldMapping
 import pureconfig.KebabCase
@@ -16,7 +17,7 @@ final case class CatalogConf(
 )
 
 final case class ServerConf(
-  port: Int,
+  port: Port,
   mapping: String
 )
 

--- a/server/src/main/scala/latis/server/package.scala
+++ b/server/src/main/scala/latis/server/package.scala
@@ -1,0 +1,15 @@
+package latis
+
+import com.comcast.ip4s.Port
+import pureconfig.ConfigReader
+import pureconfig.error.CannotConvert
+
+package object server {
+
+  implicit val portReader: ConfigReader[Port] =
+    ConfigReader[Int].emap { int =>
+      Port.fromInt(int).toRight(
+        CannotConvert(int.toString, "Port", "Invalid port number")
+      )
+    }
+}


### PR DESCRIPTION
This PR switches us to the http4s Ember backend, which is their new "default" that will be getting the most attention going forward.