### PR TITLE
Handle Index variable in BinaryEncoder

### DIFF
--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -55,7 +55,7 @@ class BinaryEncoder(val dataCodec: Scalar => Codec[Data] = DataCodec.defaultData
         val tuples: List[Scalar] = t.flatElements.collect { case s: Scalar => s }
         (List[Scalar](), tuples)
       case Function(d, r) =>
-        (d.getScalars, r.getScalars)
+        (d.getScalars.filterNot(_.isInstanceOf[Index]), r.getScalars)
     }
     val domainList: List[Codec[Datum]] = domainScalars.map(s => dataCodec(s).downcast[Datum])
     val rangeList: List[Codec[Data]] = rangeScalars.map(s => dataCodec(s))

--- a/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/BinaryEncoderSpec.scala
@@ -19,6 +19,7 @@ import latis.dataset.Dataset
 import latis.dsl.DatasetGenerator
 import latis.metadata.Metadata
 import latis.model._
+import latis.ops.Projection
 import latis.util.Identifier.IdentifierStringContext
 
 class BinaryEncoderSpec extends AnyFlatSpec {
@@ -38,6 +39,23 @@ class BinaryEncoderSpec extends AnyFlatSpec {
         SEncoder.encode(1).require ++
         SEncoder.encode(1.0).require ++
       SEncoder.encode(2).require ++
+        SEncoder.encode(2).require ++
+        SEncoder.encode(2.0).require
+    val expected: List[Byte] = bitVec.toByteArray.toList
+
+    encodedList should be(expected)
+  }
+
+  it should "encode a dataset with an Index variable" in {
+    val ds: Dataset = DatasetGenerator("x -> (a: int, b: double)")
+      .withOperation(Projection.fromExpression("a, b").value)
+    val encodedList = enc.encode(ds).compile.toList.unsafeRunSync()
+
+    val bitVec =
+        SEncoder.encode(0).require ++
+        SEncoder.encode(0.0).require ++
+        SEncoder.encode(1).require ++
+        SEncoder.encode(1.0).require ++
         SEncoder.encode(2).require ++
         SEncoder.encode(2.0).require
     val expected: List[Byte] = bitVec.toByteArray.toList


### PR DESCRIPTION
For PODA (latis3-packets) we need to be able to serve just the binary packet data. We do this by projecting only the packet variable. So, `time -> packet` becomes `_itime -> packet` where the `_itime` variable is an `Index` (subclass of `Scalar`) which is just a placeholder and has no data in a `Sample`.

When I tried to encode that, I got "scodec.stream.CodecError: wrong length". I assumed it is because the BinaryEncoder is trying to encode data for an Index variable that has no data in the Sample.

Since Index variables can only occur in the domain of a Function, we should filter out the Index scalars from the domain variables in the model when determining how to interpret the contents of a Sample. We've traditionally used `filterNot(_.isInstanceOf[Index])`. We do have a note to make better alternatives to `getScalars` including an option to exclude Index scalars, but the filter will suffice for now.