### PR TITLE
Disable SBT build formatting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,3 +6,4 @@ includeCurlyBraceInSelectChains = false
 newlines.alwaysBeforeMultilineDef = false
 rewrite.rules = [AvoidInfix, RedundantBraces, RedundantParens, SortImports, SortModifiers]
 docstrings = JavaDoc
+project.excludeFilters = ["build.sbt", "project/plugins.sbt"]


### PR DESCRIPTION
This will hopefully prevent Scala Steward from applying our `scalafmt` config to our `*.sbt` files.