### PR TITLE
LATIS-1040 CSV Line-Endings

### DIFF
--- a/core/src/main/scala/latis/output/CsvEncoder.scala
+++ b/core/src/main/scala/latis/output/CsvEncoder.scala
@@ -21,8 +21,8 @@ class CsvEncoder(header: Dataset => Stream[IO, String]) extends Encoder[IO, Stri
   override def encode(dataset: Dataset): Stream[IO, String] = {
     val uncurriedDataset = dataset.withOperation(Uncurry())
     // Encode each Sample as a String in the Stream
-    header(dataset).map(_ + "\n") ++ uncurriedDataset.samples
-      .map(encodeSample(uncurriedDataset.model, _) + "\n")
+    header(dataset).map(_ + "\r\n") ++ uncurriedDataset.samples
+      .map(encodeSample(uncurriedDataset.model, _) + "\r\n")
   }
 
   /**

--- a/core/src/test/scala/latis/output/CsvEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/CsvEncoderSpec.scala
@@ -18,7 +18,7 @@ class CsvEncoderSpec extends AnyFlatSpec {
       "0,0,0.0,a",
       "1,1,1.0,b",
       "2,2,2.0,c"
-    ).map(_ + "\n")
+    ).map(_ + "\r\n")
     csvList should be(expectedCsv)
   }
 
@@ -26,14 +26,14 @@ class CsvEncoderSpec extends AnyFlatSpec {
     val enc            = CsvEncoder.withColumnName
     val csvList        = enc.encode(ds).compile.toList.unsafeRunSync()
     val expectedHeader = "x,a,b,c"
-    csvList.head should be(expectedHeader + "\n")
+    csvList.head should be(expectedHeader + "\r\n")
 
     val expectedCsv = List(
       expectedHeader,
       "0,0,0.0,a",
       "1,1,1.0,b",
       "2,2,2.0,c"
-    ).map(_ + "\n")
+    ).map(_ + "\r\n")
     csvList should be (expectedCsv)
   }
 }


### PR DESCRIPTION
Simple fix to update the CSV Encoder's line endings from `\n` to the standard expected CRLF (`\r\n')