### PR TITLE
Beef up boolean variable support

### DIFF
--- a/core/src/main/scala/latis/model/valueType.scala
+++ b/core/src/main/scala/latis/model/valueType.scala
@@ -55,7 +55,7 @@ object BooleanValueType extends ValueType {
 
   def parseValue(value: String): Either[LatisException, Datum] = Try {
     BooleanValue(value.toBoolean)
-  }.toEither.leftMap { _ => LatisException(s"Failed to parse IntValue: $value") }
+  }.toEither.leftMap { _ => LatisException(s"Failed to parse BooleanValue: $value") }
 
   override def toString: String = "boolean"
 }

--- a/core/src/main/scala/latis/util/DefaultDatumOrdering.scala
+++ b/core/src/main/scala/latis/util/DefaultDatumOrdering.scala
@@ -9,8 +9,8 @@ object DefaultDatumOrdering extends PartialOrdering[Datum] {
   TODO: should we match specific value types? avoid conversion to doubles
         but would require exact type match
     do we need to keep unorderable Datums out of domain?
-      only boolean and binary?
-      default ord currently based on match to Number or Text
+      only binary?
+      default ord currently based on match to Number or Text or BooleanValue
       null put at end but not good
         required for spark groupBy?
       require only non-nullable vars in domain?
@@ -23,7 +23,9 @@ object DefaultDatumOrdering extends PartialOrdering[Datum] {
       else Some(Ordering[Double].compare(d1, d2))
     case (Text(s1), Text(s2)) =>
       Some(String.compare(s1, s2))
-    case _                      => None
+    case (b1: Data.BooleanValue, b2: Data.BooleanValue) =>
+      Some(Boolean.compare(b1.value, b2.value))
+    case _ => None
   }
 
   def lteq(x: Datum, y: Datum): Boolean = (x, y) match {
@@ -31,6 +33,8 @@ object DefaultDatumOrdering extends PartialOrdering[Datum] {
       d1 <= d2 //Note, always false for NaNs
     case (Text(s1), Text(s2)) =>
       String.compare(s1, s2) <= 0
+    case (b1: Data.BooleanValue, b2: Data.BooleanValue) =>
+      Boolean.compare(b1.value, b2.value) <= 0
     case _ => false
   }
 }

--- a/core/src/test/scala/latis/model/ValueTypeSuite.scala
+++ b/core/src/test/scala/latis/model/ValueTypeSuite.scala
@@ -2,6 +2,9 @@ package latis.model
 
 import org.scalatest.EitherValues._
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Inside.inside
+
+import latis.data.Data._
 
 class ValueTypeSuite extends AnyFunSuite {
 
@@ -9,5 +12,39 @@ class ValueTypeSuite extends AnyFunSuite {
     val svt = ValueType.fromName("string").value
     assert(svt == StringValueType)
     assert(svt != IntValueType)
+  }
+
+  //-- BooleanValueType --//
+
+  test("'true' is true") {
+    inside (BooleanValueType.parseValue("true")) {
+      case Right(bv: BooleanValue) => assert(bv.value)
+    }
+  }
+
+  test("mixed case 'tRuE' is true") {
+    inside (BooleanValueType.parseValue("tRuE")) {
+      case Right(bv: BooleanValue) => assert(bv.value)
+    }
+  }
+
+  test("'t' is not a valid boolean value") {
+    assert(BooleanValueType.parseValue("t").isLeft)
+  }
+
+  test("'false' is false") {
+    inside (BooleanValueType.parseValue("false")) {
+      case Right(bv: BooleanValue) => assert(! bv.value)
+    }
+  }
+
+  test("mixed case 'fAlSe' is false") {
+    inside (BooleanValueType.parseValue("fAlSe")) {
+      case Right(bv: BooleanValue) => assert(! bv.value)
+    }
+  }
+
+  test("'f' is not a valid boolean value") {
+    assert(BooleanValueType.parseValue("f").isLeft)
   }
 }

--- a/core/src/test/scala/latis/ops/SelectionSuite.scala
+++ b/core/src/test/scala/latis/ops/SelectionSuite.scala
@@ -5,9 +5,11 @@ import org.scalatest.EitherValues._
 
 import latis.data.Data
 import latis.metadata.Metadata
+import latis.model.BooleanValueType
 import latis.model.Scalar
 import latis.time.Time
 import latis.util.dap2.parser.ast
+import latis.util.Identifier.IdentifierStringContext
 
 class SelectionSuite extends AnyFunSuite {
   //TODO: test regular selections...
@@ -154,5 +156,35 @@ class SelectionSuite extends AnyFunSuite {
     val datum = Data.StringValue("Jan 01, 1970")
     val value = Data.StringValue("Jan 02, 1970")
     assert(Selection.datumPredicateWithBinning(binnedNonIsoFormattedTime, ast.Eq, value)(datum))
+  }
+
+  //-- Boolean selection --//
+
+  private val boolean = Scalar(id"b", BooleanValueType)
+  private val trueDatum  = Data.BooleanValue(true)
+  private val falseDatum = Data.BooleanValue(false)
+
+  test("true equals") {
+    assert(Selection.datumPredicate(boolean, ast.Eq, trueDatum)(trueDatum))
+  }
+
+  test("false equals") {
+    assert(Selection.datumPredicate(boolean, ast.Eq, falseDatum)(falseDatum))
+  }
+
+  test("false less than true") {
+    assert(Selection.datumPredicate(boolean, ast.Lt, trueDatum)(falseDatum))
+  }
+
+  test("true greater than false") {
+    assert(Selection.datumPredicate(boolean, ast.Gt, falseDatum)(trueDatum))
+  }
+
+  test("false not equal true") {
+    assert(! Selection.datumPredicate(boolean, ast.Eq, trueDatum)(falseDatum))
+  }
+
+  test("true not equal false") {
+    assert(! Selection.datumPredicate(boolean, ast.Eq, falseDatum)(trueDatum))
   }
 }


### PR DESCRIPTION
This adds `PartialOrdering` for `BooleanValue` `Data`. (Note that Scala does define an ordering such that `false` < `true`.) This allows us to do `Selection`s on `Scalar`s of type boolean. (`Selection` uses `PartialOrdering.equiv` for equality.) This also means that boolean variables can be valid domain variables.

This also adds some tests to indicate valid string values for a boolean variable, e.g. valid values for a selection expression. The value must be "true" or "false" ignoring case.