### PR TITLE
Buildinfo

### DIFF
--- a/server/src/main/scala/latis/dataset/BuildInfoDataset.scala
+++ b/server/src/main/scala/latis/dataset/BuildInfoDataset.scala
@@ -1,0 +1,48 @@
+package latis.dataset
+
+import latis.data._
+import latis.metadata.Metadata
+import latis.model._
+import latis.util.BuildInfo
+import latis.util.Identifier
+import latis.util.Identifier.IdentifierStringContext
+
+/**
+ * Defines a Dataset that provides build information.
+ *
+ * This uses the BuildInfo that is derived by the sbt-buildinfo plugin.
+ * This project provides a stub to support compilation. If the service
+ * project does not use the sbt-buildinfo plugin, this dataset will use
+ * default properties from the stub.
+ */
+object BuildInfoDataset {
+  //TODO: deal with 0 or 1 property in the BuildInfo Map
+
+  def apply(): Dataset = {
+    val metadata = Metadata(id"build_info")
+
+    val properties: List[(String, String)] = BuildInfo.toMap.toList.map {
+      case (k: String, v) => (k, v.toString)
+    }
+
+    val scalars: List[Scalar] = properties.map { case (id, _) =>
+      Scalar(Identifier.fromString(id).get, StringValueType)
+    }
+
+    val model = Tuple.fromSeq(scalars).fold(throw _, identity)
+
+    val values: List[Data] = properties.map { case (_, value) =>
+      Data.StringValue(value)
+    }
+
+    // Single zero-arity Sample
+    val sample = Sample(
+      DomainData(),
+      RangeData(values)
+    )
+
+    val mf = SeqFunction(sample)
+
+    new MemoizedDataset(metadata, model, mf)
+  }
+}

--- a/server/src/main/scala/latis/util/BuildInfo.scala
+++ b/server/src/main/scala/latis/util/BuildInfo.scala
@@ -1,0 +1,9 @@
+package latis.util
+
+/** Defines a stub that service projects will replace via sbt-buildinfo. */
+object BuildInfo {
+  val toMap: Map[String, scala.Any] = Map[String, scala.Any](
+    "service" -> "LaTiS",
+    "version" -> "3"
+  )
+}


### PR DESCRIPTION
This adds a `BuildInfo` stub so we can write code that uses it. The `sbt-buildinfo` plugin used in service projects should effectively overwrite this (assuming that it's jar appears in the classpath before the latis3-server jar).

I also added a `BuildInfoDataset` that can be added to a catalog and accessed as `build_info`. Since we can't have a Dataset with no variables, I added two default properties to the stub which will be used if the service project is not using sbt-buildinfo.

I put this in the `latis3-server` project since it is presumably needed only by service projects.