### PR TITLE
Change "mapping" to "prefix"

### DIFF
--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -2,10 +2,10 @@ latis {
   port = 8080
   port = ${?LATIS_PORT}
 
-  mapping = "/"
-  mapping = ${?LATIS_MAPPING}
+  prefix = "/"
+  prefix = ${?LATIS_PREFIX}
 
   services = [
-    {type: "class", mapping: "/dap2", class: "latis.service.dap2.Dap2Service"}
+    {type: "class", prefix: "/dap2", class: "latis.service.dap2.Dap2Service"}
   ]
 }

--- a/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
+++ b/server/src/main/scala/latis/server/Latis3ServerBuilder.scala
@@ -40,7 +40,7 @@ object Latis3ServerBuilder {
       interfaces: List[(String, ServiceInterface)]
     ): HttpRoutes[IO] = {
       val routes = interfaces.map {
-        case (mapping, service) => (mapping, service.routes)
+        case (prefix, service) => (prefix, service.routes)
       }
       Router(routes:_*)
     }
@@ -51,7 +51,7 @@ object Latis3ServerBuilder {
       .withHttpApp {
         LatisErrorHandler(
           LatisServiceLogger(
-            Router(conf.mapping ->
+            Router(conf.prefix ->
               CORS.policy
                 .withAllowOriginAll
                 .withAllowMethodsIn(Set(Method.GET, Method.HEAD))

--- a/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
+++ b/server/src/main/scala/latis/server/ServiceInterfaceLoader.scala
@@ -27,7 +27,7 @@ final class ServiceInterfaceLoader {
       for {
         loader  <- getClassLoader(spec)
         service <- loadService(loader, spec, catalog)
-      } yield (spec.mapping, service)
+      } yield (spec.prefix, service)
     }
 
   private def loadService(

--- a/server/src/main/scala/latis/server/conf.scala
+++ b/server/src/main/scala/latis/server/conf.scala
@@ -18,7 +18,7 @@ final case class CatalogConf(
 
 final case class ServerConf(
   port: Port,
-  mapping: String
+  prefix: String
 )
 
 final case class ServiceConf(
@@ -26,18 +26,18 @@ final case class ServiceConf(
 )
 
 sealed trait ServiceSpec {
-  val mapping: String
+  val prefix: String
   val clss: String
 }
 
 final case class JarServiceSpec(
   path: URL,
-  mapping: String,
+  prefix: String,
   clss: String
 ) extends ServiceSpec
 
 final case class ClassPathServiceSpec(
-  mapping: String,
+  prefix: String,
   clss: String
 ) extends ServiceSpec
 


### PR DESCRIPTION
I'm looking into alternatives for LATIS_MAPPING which is confusing to me. I see that it is ultimately used to make a http4s `Router` which takes `mappings: (String, HttpRoutes[F])*`, so I assume that is what inspired the name. However, our mapping config property is just used for the first half of that mapping. The `Router` code goes on to turn this into a `prefixPath`. Ansible uses `PathPrefix`.  `LATIS_PREFIX` is sounding like a popular alternative. I've changed the use of "mapping" to "prefix" here.