### PR TITLE
Add CountBy and CountAggregation operations

### DIFF
--- a/core/src/main/scala/latis/dsl/package.scala
+++ b/core/src/main/scala/latis/dsl/package.scala
@@ -1,5 +1,6 @@
 package latis
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import fs2.io.file.Files
@@ -31,7 +32,7 @@ package object dsl {
     def stride(s: Int, ss: Int*): Dataset          = dataset.withOperation(Stride((s +: ss).toIndexedSeq))
     def uncurry(): Dataset                         = dataset.withOperation(Uncurry())
     def curry(n: Int): Dataset                     = dataset.withOperation(Curry(n))
-    def groupByVariable(ids: Identifier*): Dataset = dataset.withOperation(GroupByVariable(ids: _*))
+    def groupByVariable(ids: Identifier*): Dataset = dataset.withOperation(new GroupByVariable(ids: _*))
     def groupByBin(set: DomainSet, agg: Aggregation = DefaultAggregation()): Dataset =
       dataset.withOperation(GroupByBin(set, agg))
     def substitute(df: Dataset): Dataset           = dataset.withOperation(Substitution(df))
@@ -52,6 +53,9 @@ package object dsl {
     def take(n: Int): Dataset                      = dataset.withOperation(Take(n))
     def takeRight(n: Int): Dataset                 = dataset.withOperation(TakeRight(n))
     def transpose(): Dataset                       = dataset.withOperation(Transpose())
+    def count(): Dataset                           = dataset.withOperation(CountAggregation())
+    def countBy(id: Identifier, ids: Identifier*): Dataset =
+      dataset.withOperation(new CountBy(NonEmptyList.of(id, ids: _*)))
 
     def filter(predicate: Sample => Boolean): Dataset = dataset.withOperation(Filter(predicate))
     //TODO: map, flataMap, mapRange, but need to know how model changes

--- a/core/src/main/scala/latis/model/ScalarAlgebra.scala
+++ b/core/src/main/scala/latis/model/ScalarAlgebra.scala
@@ -5,6 +5,7 @@ import cats.syntax.all._
 import latis.data._
 import latis.util.DefaultDatumOrdering
 import latis.util.LatisException
+import latis.util.StringUtils
 
 trait ScalarAlgebra { scalar: Scalar =>
 
@@ -62,9 +63,10 @@ trait ScalarAlgebra { scalar: Scalar =>
    * Converts a string value into the appropriate type and units
    * for this Scalar.
    */
-  def convertValue(value: String): Either[Exception, Datum] =
-    parseValue(value)
-  //TODO: support units, e.g. "1.2 meters"
+  def convertValue(value: String): Either[LatisException, Datum] = valueType match {
+    case StringValueType => parseValue(StringUtils.removeDoubleQuotes(value))
+    case _               => parseValue(value)
+  }
 
   /**
    * Defines a PartialOrdering for Datums of the type described by this Scalar.

--- a/core/src/main/scala/latis/ops/Contains.scala
+++ b/core/src/main/scala/latis/ops/Contains.scala
@@ -1,5 +1,7 @@
 package latis.ops
 
+import cats.syntax.all._
+
 import latis.data._
 import latis.model._
 import latis.util.Identifier
@@ -16,27 +18,47 @@ case class Contains(id: Identifier, values: String*) extends Filter {
     // Determine the path to the selected variable
     val path: SamplePosition = model.findPath(id) match {
       case Some(p) => p.head //assume no nested functions for now
-      case None => ???    //TODO: invalid path or vname
+      case None => throw LatisException(s"Variable not found: ${id.asString}")
     }
 
+    // Get the target Scalar variable
+    val scalar: Scalar = model.findVariable(id) match {
+      case Some(s: Scalar) => s
+      case _ => throw LatisException(s"Scalar variable not found: ${id.asString}")
+    }
+
+    val ordering = scalar.ordering
+
     // Convert values to appropriate type for comparison
-    val cvals: Seq[Datum] = model.findVariable(id) match {
-      case Some(s: Scalar) => values.map { v =>
-        s.convertValue(v).getOrElse {
-          val msg = s"Invalid comparison value: $v"
-          throw LatisException(msg)
-        }
+    val cvals: Seq[Datum] = values.map { v =>
+      scalar.convertValue(v).getOrElse {
+        val msg = s"Invalid comparison value: $v"
+        throw LatisException(msg)
       }
-      case _  => ??? //bug, invalid path
     }
 
     // Define predicate function
     (sample: Sample) =>
-      sample.getValue(path).map { d =>
-        cvals.contains(d)  // Uses "==" or "equals", should work for Datum value classes
+      sample.getValue(path).map {
+        case d: Datum => cvals.exists(c => ordering.equiv(c, d))
+        case NullData => false
+        case d        => throw LatisException(s"Sample value is not a Datum: $d")
       }.getOrElse {
-        ??? //bug, we should have a valid path at this point
+        throw LatisException("Invalid Sample")
       }
   }
 
+}
+
+object Contains {
+
+  def fromArgs(args: List[String]): Either[LatisException, Contains] = args match {
+    //TODO: support quoted string literals
+    case id :: value :: values =>
+      Either.fromOption(
+        Identifier.fromString(id),
+        LatisException(s"Invalid identifier: $id")
+      ).map(Contains(_, (value :: values): _*))
+    case _ => LatisException("Contains expects a variable identifier and at least one value.").asLeft
+  }
 }

--- a/core/src/main/scala/latis/ops/CountAggregation.scala
+++ b/core/src/main/scala/latis/ops/CountAggregation.scala
@@ -1,0 +1,27 @@
+package latis.ops
+
+import cats.syntax.all._
+
+import latis.data._
+import latis.model._
+import latis.util.Identifier.IdentifierStringContext
+import latis.util.LatisException
+
+/**
+ * Defines an Aggregation that reduces the Samples of a Dataset
+ * to a variable capturing the number of Samples.
+ */
+class CountAggregation() extends Aggregation {
+
+  def aggregateFunction(model: DataType): Iterable[Sample] => Data =
+    samples => Data.LongValue(samples.size.toLong)
+
+  def applyToModel(model:DataType): Either[LatisException, DataType] =
+    Scalar(id"count", LongValueType).asRight
+
+}
+
+object CountAggregation {
+
+  def apply(): CountAggregation = new CountAggregation()
+}

--- a/core/src/main/scala/latis/ops/CountBy.scala
+++ b/core/src/main/scala/latis/ops/CountBy.scala
@@ -1,0 +1,31 @@
+package latis.ops
+
+import cats.data.NonEmptyList
+import cats.syntax.all._
+
+import latis.util.Identifier
+import latis.util.LatisException
+
+/**
+ * Defines an operation that groups a dataset by the given variables
+ * to generate a new domain with the range being a `count` variable
+ * representing the number of samples with that domain value.
+ */
+class CountBy(ids: NonEmptyList[Identifier]) extends GroupByVariable(ids.toList: _*) {
+
+  override def aggregation: Aggregation = CountAggregation()
+}
+
+object CountBy {
+
+  def fromArgs(args: List[String]): Either[LatisException, CountBy] = args match {
+    case id :: ids =>
+      NonEmptyList(id, ids).traverse { id =>
+        Either.fromOption(
+          Identifier.fromString(id),
+          LatisException(s"Invalid identifier: $id")
+        )
+      }.map(new CountBy(_))
+    case Nil => LatisException("CountBy requires at least one variable identifier").asLeft
+  }
+}

--- a/core/src/main/scala/latis/ops/Filter.scala
+++ b/core/src/main/scala/latis/ops/Filter.scala
@@ -1,6 +1,7 @@
 package latis.ops
 
 import cats.effect.IO
+import cats.syntax.all._
 import fs2.Pipe
 import fs2.Stream
 
@@ -29,27 +30,30 @@ trait Filter extends UnaryOperation with StreamOperation { self =>
    * Defines a function that specifies whether a Sample
    * should be kept.
    */
-  def predicate(model: DataType): Sample => Boolean
+  def predicate(model: DataType): Either[LatisException, Sample => Boolean]
 
   /**
    * Implements a Pipe in terms of the predicate.
    */
   def pipe(model: DataType): Pipe[IO, Sample, Sample] =
-    (stream: Stream[IO, Sample]) => stream.filter(predicate(model))
+    (stream: Stream[IO, Sample]) => predicate(model) match {
+      case Right(p) => stream.filter(p)
+      case Left(le) => Stream.raiseError[IO](le)
+    }
 
   /**
    * Composes this operation with the given MappingOperation.
    * Note that the given operation will be applied first.
    */
   def compose(mapOp: MapOperation): Filter = (model: DataType) =>
-    mapOp.mapFunction(model).andThen {
-      self.predicate(mapOp.applyToModel(model).fold(throw _, identity))
-    }
+    mapOp.applyToModel(model)                // model after mapOp application
+      .flatMap(predicate)                    // predicate with that model
+      .map(mapOp.mapFunction(model).andThen) // compose predicate with map function
 
 }
 
 object Filter {
   def apply(f: Sample => Boolean): Filter = new Filter {
-    def predicate(model: DataType): Sample => Boolean = f
+    def predicate(model: DataType): Either[LatisException, Sample => Boolean] = f.asRight
   }
 }

--- a/core/src/main/scala/latis/ops/GroupByVariable.scala
+++ b/core/src/main/scala/latis/ops/GroupByVariable.scala
@@ -14,7 +14,7 @@ import latis.util.LatisException
  * Assumes there are no nested function, for now.
  * Does not preserve nested Tuples, for now.
  */
-case class GroupByVariable(ids: Identifier*) extends GroupOperation {
+class GroupByVariable(ids: Identifier*) extends GroupOperation {
 
   /**
    * Defines a DefaultAggregation composed with a MapOperation that un-projects

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -30,6 +30,8 @@ object UnaryOperation {
     args: List[String]
   ): Either[LatisException, UnaryOperation] = name match {
     case "convertTime" => ConvertTime.fromArgs(args)
+    case "count" => CountAggregation().asRight
+    case "countBy" => CountBy.fromArgs(args)
     case "curry" => Curry.fromArgs(args)
     case "drop" => Drop.fromArgs(args)
     case "dropLast" => DropLast().asRight

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -29,6 +29,7 @@ object UnaryOperation {
     name: String,
     args: List[String]
   ): Either[LatisException, UnaryOperation] = name match {
+    case "contains" => Contains.fromArgs(args)
     case "convertTime" => ConvertTime.fromArgs(args)
     case "count" => CountAggregation().asRight
     case "countBy" => CountBy.fromArgs(args)

--- a/core/src/main/scala/latis/time/Time.scala
+++ b/core/src/main/scala/latis/time/Time.scala
@@ -65,7 +65,7 @@ class Time protected (
    * This method is intended for lightweight use such as parsing time selections.
    * Construct a reusable TimeFormat or UnitConverter for bigger conversion tasks.
    */
-  override def convertValue(value: String): Either[Exception, Datum] = {
+  override def convertValue(value: String): Either[LatisException, Datum] = {
     TimeFormat.parseIso(value).flatMap { ms =>
       // Interpreted as ISO
       valueType match {

--- a/core/src/main/scala/latis/util/StringUtils.scala
+++ b/core/src/main/scala/latis/util/StringUtils.scala
@@ -38,6 +38,15 @@ object StringUtils {
    */
   def ensureSingleQuoted(string: String): String = ensureQuoted(string, singleQuote)
 
+  /**
+   * Removes double quotes from a string that is quoted.
+   */
+  def removeDoubleQuotes(string: String): String = {
+    if (string.head == doubleQuote && string.last == doubleQuote)
+      string.substring(1, string.length - 1)
+    else string
+  }
+
   /** Implicit class to enable color console output. */
   implicit class ColoredString(s: String) {
     import Console._

--- a/core/src/test/scala/latis/ops/ContainsSuite.scala
+++ b/core/src/test/scala/latis/ops/ContainsSuite.scala
@@ -27,6 +27,13 @@ class ContainsSuite extends AnyFunSuite {
     }.unsafeRunSync()
   }
 
+  test("contains no values") {
+    val c = Contains.fromArgs(List("x", "9", "10")).value
+    ds.withOperation(c).samples.compile.toList.map { list =>
+      assertResult(0)(list.length)
+    }.unsafeRunSync()
+  }
+
   test("contains text value") {
     val c = Contains.fromArgs(List("a", "b")).value
     ds.withOperation(c).samples.compile.toList.map { list =>
@@ -34,10 +41,29 @@ class ContainsSuite extends AnyFunSuite {
     }.unsafeRunSync()
   }
 
-  ignore("contains quoted text value") {
+  test("contains quoted text value") {
     val c = Contains.fromArgs(List("a", """"b"""")).value
     ds.withOperation(c).samples.compile.toList.map { list =>
       assertResult(1)(list.length)
     }.unsafeRunSync()
+  }
+
+  test("application fails with invalid value types") {
+    val c = Contains.fromArgs(List("x", "foo")).value
+    ds.withOperation(c).samples.attempt.compile.toList.map { list =>
+      assert(list.head.isLeft)
+    }.unsafeRunSync()
+  }
+
+  test("application fails with missing id") {
+    val c = Contains.fromArgs(List("z", "foo")).value
+    ds.withOperation(c).samples.attempt.compile.toList.map { list =>
+      assert(list.head.isLeft)
+    }.unsafeRunSync()
+  }
+
+  test("construction fails with invalid id") {
+    val c = Contains.fromArgs(List("!x", "foo"))
+    assert(c.isLeft)
   }
 }

--- a/core/src/test/scala/latis/ops/ContainsSuite.scala
+++ b/core/src/test/scala/latis/ops/ContainsSuite.scala
@@ -1,0 +1,43 @@
+package latis.ops
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.EitherValues._
+
+import latis.dsl._
+
+class ContainsSuite extends AnyFunSuite {
+
+  /**
+   * Defines a Dataset with three samples: (0,a), (1,b), (2,c).
+   */
+  private lazy val ds = DatasetGenerator("x -> a: string")
+
+  test("contains single value") {
+    val c = Contains.fromArgs(List("x", "1")).value
+    ds.withOperation(c).samples.compile.toList.map { list =>
+      assertResult(1)(list.length)
+    }.unsafeRunSync()
+  }
+
+  test("contains two values") {
+    val c = Contains.fromArgs(List("x", "1", "2")).value
+    ds.withOperation(c).samples.compile.toList.map { list =>
+      assertResult(2)(list.length)
+    }.unsafeRunSync()
+  }
+
+  test("contains text value") {
+    val c = Contains.fromArgs(List("a", "b")).value
+    ds.withOperation(c).samples.compile.toList.map { list =>
+      assertResult(1)(list.length)
+    }.unsafeRunSync()
+  }
+
+  ignore("contains quoted text value") {
+    val c = Contains.fromArgs(List("a", """"b"""")).value
+    ds.withOperation(c).samples.compile.toList.map { list =>
+      assertResult(1)(list.length)
+    }.unsafeRunSync()
+  }
+}

--- a/core/src/test/scala/latis/ops/CountAggregationSuite.scala
+++ b/core/src/test/scala/latis/ops/CountAggregationSuite.scala
@@ -1,0 +1,44 @@
+package latis.ops
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Inside._
+
+import latis.data._
+import latis.dataset._
+import latis.dsl.DatasetGenerator
+import latis.metadata.Metadata
+import latis.model._
+import latis.util.Identifier.IdentifierStringContext
+
+class CountAggregationSuite extends AnyFunSuite {
+
+  test("count function") {
+    DatasetGenerator("x -> a") //makes a dataset with 3 samples
+      .withOperation(CountAggregation())
+      .samples.compile.toList.map {
+        inside(_) {
+          // Single zero-arity Sample with count data
+          case Sample(DomainData(), RangeData(lv: Data.LongValue)) :: Nil =>
+            assertResult(3)(lv.value)
+        }
+      }.unsafeRunSync()
+  }
+
+  test("count scalar") {
+    val ds = {
+      val model = Scalar(id"x", IntValueType)
+      val data = Data.IntValue(0)
+      new TappedDataset(Metadata(id"test"), model, data)
+    }
+    ds.withOperation(CountAggregation())
+      .samples.compile.toList.map {
+        inside(_) {
+          // Single zero-arity Sample with count data
+          case Sample(DomainData(), RangeData(lv: Data.LongValue)) :: Nil =>
+            assertResult(1)(lv.value)
+        }
+      }.unsafeRunSync()
+  }
+
+}

--- a/core/src/test/scala/latis/ops/CountBySuite.scala
+++ b/core/src/test/scala/latis/ops/CountBySuite.scala
@@ -1,0 +1,62 @@
+package latis.ops
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.EitherValues._
+
+import latis.data._
+import latis.dataset._
+import latis.dsl._
+import latis.metadata._
+import latis.util.Identifier.IdentifierStringContext
+
+class CountBySuite extends AnyFunSuite {
+
+  // (x, y) -> a
+  private lazy val model = ModelParser.unsafeParse("(x, y) -> a")
+
+  private lazy val data = SeqFunction(Seq(
+    Sample(DomainData(0, 10), RangeData(1)),
+    Sample(DomainData(1, 11), RangeData(2)),
+    Sample(DomainData(1, 12), RangeData(3)),
+    Sample(DomainData(2, 10), RangeData(4)),
+    Sample(DomainData(2, 11), RangeData(5)),
+    Sample(DomainData(2, 12), RangeData(6)),
+  ))
+
+  private lazy val ds = new MemoizedDataset(Metadata(id"test"), model, data)
+
+  test("count by first domain variable") {
+    val cb = CountBy.fromArgs(List("x")).value
+    val counts = ds.withOperation(cb)
+      .samples.compile.toList.map {
+        _.collect {
+          case Sample(_, RangeData(Integer(count))) => count
+        }
+      }.unsafeRunSync()
+    assertResult(List(1,2,3))(counts)
+  }
+
+  test("count by second domain variable") {
+    val cb = CountBy.fromArgs(List("y")).value
+    val counts = ds.withOperation(cb)
+      .samples.compile.toList.map {
+        _.collect {
+          case Sample(_, RangeData(Integer(count))) => count
+        }
+      }.unsafeRunSync()
+    assertResult(List(2,2,2))(counts)
+  }
+
+  test("count by range variable") {
+    val cb = CountBy.fromArgs(List("a")).value
+    val counts = ds.withOperation(cb)
+      .samples.compile.toList.map {
+        _.collect {
+          case Sample(_, RangeData(Integer(count))) => count
+        }
+      }.unsafeRunSync()
+    assertResult(List(1,1,1,1,1,1))(counts)
+  }
+
+}

--- a/core/src/test/scala/latis/ops/GroupByVariableSpec.scala
+++ b/core/src/test/scala/latis/ops/GroupByVariableSpec.scala
@@ -22,7 +22,7 @@ class GroupByVariableSpec extends AnyFlatSpec {
   ))
 
   private lazy val ds = new MemoizedDataset(Metadata(id"test"), model, data)
-      .withOperation(GroupByVariable(id"y"))
+      .withOperation(new GroupByVariable(id"y"))
       .unsafeForce()
 
   "GroupByVariable" should "unProject the grouped variables" in {

--- a/core/src/test/scala/latis/ops/SelectionSpec.scala
+++ b/core/src/test/scala/latis/ops/SelectionSpec.scala
@@ -32,7 +32,7 @@ class SelectionSpec extends AnyFlatSpec {
       RangeData(1)
     )
 
-    Selection.makeSelection("time > 1999").fold(throw _, identity).predicate(model)(sample) should be (true)
-    Selection.makeSelection("time > 2001").fold(throw _, identity).predicate(model)(sample) should be (false)
+    Selection.makeSelection("time > 1999").value.predicate(model).value(sample) should be (true)
+    Selection.makeSelection("time > 2001").value.predicate(model).value(sample) should be (false)
   }
 }

--- a/core/src/test/scala/latis/util/StringUtilSuite.scala
+++ b/core/src/test/scala/latis/util/StringUtilSuite.scala
@@ -45,4 +45,14 @@ class StringUtilsSuite extends AnyFunSuite {
     val qs = ensureQuoted("", 'q')
     assert(qs == "qq")
   }
+
+  test("remove double quotes") {
+    val s = """"foo""""
+    assert(removeDoubleQuotes(s) == "foo")
+  }
+
+  test("remove double quotes no-op") {
+    val s = "foo"
+    assert(removeDoubleQuotes(s) == "foo")
+  }
 }


### PR DESCRIPTION
The `CountBy` operation regroups the data by the given variables which become the domain of a new dataset. The range is the number of samples with that domain value. This builds on the `GroupByVariable` operation by using an aggregation operation that simply counts the number of samples being aggregated. As a bonus, the `CountAggregation` can be used to return the number of samples in a dataset so I exposed that as a `count` operation.