### PR TITLE
Nested catalog and JSON response

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,7 @@ lazy val `dap2-service` = project
     libraryDependencies ++= Seq(
       "org.http4s"     %% "http4s-core"      % http4sVersion % Provided,
       "org.http4s"     %% "http4s-dsl"       % http4sVersion % Provided,
+      "org.http4s"     %% "http4s-circe"     % http4sVersion,
       "org.http4s"     %% "http4s-scalatags" % http4sVersion
     )
   )

--- a/core/src/main/scala/latis/output/TextEncoder.scala
+++ b/core/src/main/scala/latis/output/TextEncoder.scala
@@ -35,8 +35,10 @@ class TextEncoder extends Encoder[IO, String] {
     indexGenerator = new IndexGenerator()
 
     // Create a Stream with the header
-    val header: Stream[IO, String] =
-      Stream.emit(dataset.model.toString + lineSeparator)
+    val header: Stream[IO, String] = {
+      val id = dataset.id.map(_.asString + ": ").getOrElse("")
+      Stream.emit(id + dataset.model.toString + lineSeparator)
+    }
 
     // Encode each Sample as a String in the Stream
     val samples: Stream[IO, String] =

--- a/core/src/test/scala/latis/output/TextEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/TextEncoderSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers._
 
 import latis.dataset.Dataset
 import latis.dsl._
+import latis.util.Identifier.IdentifierStringContext
 
 class TextEncoderSpec extends AnyFlatSpec {
 
@@ -15,9 +16,9 @@ class TextEncoderSpec extends AnyFlatSpec {
   val enc = new TextEncoder
 
   "A Text encoder" should "encode a dataset to Text" in {
-    val ds: Dataset = DatasetGenerator("x -> (a: int, b: double, c: string)")
+    val ds: Dataset = DatasetGenerator("x -> (a: int, b: double, c: string)", id"foo")
     val expectedOutput: Seq[String] = List(
-      "x -> (a, b, c)",
+      "foo: x -> (a, b, c)",
       "0 -> (0, 0.0, a)",
       "1 -> (1, 1.0, b)",
       "2 -> (2, 2.0, c)"

--- a/dap2-service/src/main/scala/latis/service/dap2/HtmlCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/HtmlCatalogEncoder.scala
@@ -1,0 +1,42 @@
+package latis.service.dap2
+
+import cats.effect._
+import scalatags.Text
+import scalatags.Text.all._
+
+import latis.catalog.Catalog
+
+object HtmlCatalogEncoder {
+
+  /** Provides an HTML representation of a Catalog. */
+  def encode(catalog: Catalog): IO[Text.TypedTag[String]] =
+    catalogTable(catalog).map { table =>
+      html(
+        body(
+          h1("LaTiS 3 DAP2 Server"),
+          hr(),
+          table
+        )
+      )
+    }
+
+  /** Provides an HTML table representation of a Catalog. */
+  private[dap2] def catalogTable(catalog: Catalog): IO[Text.TypedTag[String]] =
+    catalog.datasets.map { ds =>
+      val id = ds.id.fold("")(_.asString)
+      val title = ds.metadata.getProperty("title").getOrElse(id)
+      tr(
+        td(id),
+        td(a(href := id+".meta")(title))
+      )
+    }.compile.toList.map { catalogEntries =>
+      table(
+        caption(b(i(u("Catalog")))),
+        tr(
+          th("id"),
+          th("title"),
+        ),
+        catalogEntries
+      )
+    }
+}

--- a/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
@@ -1,0 +1,38 @@
+package latis.service.dap2
+
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.syntax.all._
+import io.circe.Json
+import io.circe.syntax._
+
+import latis.catalog.Catalog
+import latis.dataset.Dataset
+import latis.util.Identifier
+
+object JsonCatalogEncoder {
+
+  /** Provides a JSON representation of a Catalog for a dap2 response. */
+  def encode(catalog: Catalog, id: Option[Identifier] = None): IO[Json] =
+    for {
+      cats <- catalog.catalogs.toList.traverse { case (id, cat) => encode(cat, Some(id)) }
+      dss  <- catalog.datasets.compile.toList.map(dss => dss.map(datasetToJson))
+    } yield {
+      val fields = List(
+        id.map(id => "identifier" -> id.asString.asJson),
+        NonEmptyList.fromList(cats).map(cats => "catalog" -> cats.asJson),
+        NonEmptyList.fromList(dss).map(dss => "dataset" -> dss.asJson)
+      ).unite //keep only fields that are defined
+      Json.obj(fields: _*)
+    }
+
+  /** Provides a JSON representation of a Dataset in a catalog. */
+  private def datasetToJson(dataset: Dataset): Json = {
+    val id = dataset.id.map(_.asString).getOrElse("unknown")
+    Json.obj(
+      "identifier" -> id.asJson,
+      "title"      -> dataset.metadata.getProperty("title", id).asJson
+    )
+  }
+
+}

--- a/dap2-service/src/test/scala/latis/service/dap2/Dap2ServiceSpec.scala
+++ b/dap2-service/src/test/scala/latis/service/dap2/Dap2ServiceSpec.scala
@@ -16,7 +16,8 @@ class Dap2ServiceSpec extends AnyFlatSpec {
 
   private lazy val dataset1 = new MemoizedDataset(Metadata("id"->"id1", "title"->"title1"), null, null)
   private lazy val dataset2 = new MemoizedDataset(Metadata("id"->"id2", "title"->"title2"), null, null)
-  private lazy val dap2Service = new Dap2Service(Catalog(dataset1, dataset2))
+  private lazy val catalog = Catalog(dataset1, dataset2)
+  private lazy val dap2Service = new Dap2Service(catalog)
 
   "The Dap2 Landing Page" should "create a non-zero length '200 OK' response" in {
     val req = Request[IO](Method.GET, uri"/", headers=Headers(Header.Raw(ci"Host", "testhost:0000")))
@@ -30,7 +31,7 @@ class Dap2ServiceSpec extends AnyFlatSpec {
 
   it should "correctly generate the catalog table" in {
     (for {
-      catalog <- dap2Service.catalogTable
+      catalog <- HtmlCatalogEncoder.catalogTable(catalog)
     } yield {
       val expected =
         """<table>

--- a/dap2-service/src/test/scala/latis/service/dap2/Dap2ServiceSuite.scala
+++ b/dap2-service/src/test/scala/latis/service/dap2/Dap2ServiceSuite.scala
@@ -1,0 +1,167 @@
+package latis.service.dap2
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.http4s._
+import org.http4s.implicits.http4sLiteralsSyntax
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.Inside.inside
+import org.typelevel.ci.CIStringSyntax
+
+import latis.catalog.Catalog
+import latis.dsl.DatasetGenerator
+import latis.util.Identifier.IdentifierStringContext
+
+class Dap2ServiceSuite extends AnyFunSuite {
+  //TODO: test other error handling
+  //  bad query
+  //  error after streaming
+
+  private lazy val ds0 = DatasetGenerator("x -> a", id"ds0")
+  private lazy val ds1 = DatasetGenerator("y -> b", id"ds1")
+
+  private lazy val catalog: Catalog =
+    Catalog(ds0).addCatalog(id"cat1", Catalog(ds1))
+
+  private lazy val dap2Service = new Dap2Service(catalog)
+
+  def showResponse(uri: Uri): Unit = {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri)).flatMap { response =>
+      IO.println(response.status) >>
+        response.bodyText.evalMap(IO.println).compile.drain
+    }.unsafeRunSync()
+  }
+
+  test("top level catalog") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/")).map { response =>
+      assert(response.status == Status.Ok)
+    }.unsafeRunSync()
+  }
+
+  test("resource not found") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/foo")).map { response =>
+      assert(response.status == Status.NotFound)
+    }.unsafeRunSync()
+  }
+
+  test("invalid id") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/foo.bar/baz")).map { response =>
+      assert(response.status == Status.NotFound)
+    }.unsafeRunSync()
+  }
+
+  test("nested catalog independent of trailing slash") {
+    (for {
+      resp1 <- dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1"))
+      resp2 <- dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/"))
+      body1 <- resp1.bodyText.compile.toList.map(_.mkString)
+      body2 <- resp2.bodyText.compile.toList.map(_.mkString)
+    } yield {
+      assert(resp1.status == Status.Ok)
+      assert(body1 == body2)
+    }).unsafeRunSync()
+  }
+
+  test("dataset with extension") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/ds0.meta")).map { response =>
+      assert(response.status == Status.Ok)
+      inside(response.headers.get(ci"Content-Type")) {
+        case Some(NonEmptyList(header, _)) => assertResult("application/json")(header.value)
+      }
+    }.unsafeRunSync()
+  }
+
+  test("dataset without extension") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/ds0")).map { response =>
+      assert(response.status == Status.Ok)
+      inside(response.headers.get(ci"Content-Type")) {
+        case Some(NonEmptyList(header, _)) => assertResult("application/json")(header.value)
+      }
+    }.unsafeRunSync()
+  }
+
+  test("nested dataset with extension") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/ds1.meta")).map { response =>
+      assert(response.status == Status.Ok)
+      inside(response.headers.get(ci"Content-Type")) {
+        case Some(NonEmptyList(header, _)) => assertResult("application/json")(header.value)
+      }
+    }.unsafeRunSync()
+  }
+
+  test("nested dataset without extension") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/ds1")).map { response =>
+      assert(response.status == Status.Ok)
+      inside(response.headers.get(ci"Content-Type")) {
+        case Some(NonEmptyList(header, _)) => assertResult("application/json")(header.value)
+      }
+    }.unsafeRunSync()
+  }
+
+  test("dataset not found with trailing slash") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/ds1/")).map { response =>
+      assert(response.status == Status.NotFound)
+    }.unsafeRunSync()
+  }
+
+  test("dataset not found with extension and trailing slash") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/ds1.meta/")).map { response =>
+      assert(response.status == Status.NotFound)
+    }.unsafeRunSync()
+  }
+
+  test("dataset not found with trailing dot") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/ds1.")).map { response =>
+      assert(response.status == Status.NotFound)
+    }.unsafeRunSync()
+  }
+
+  test("dataset not found with extension and trailing dot") {
+    dap2Service.routes.orNotFound(Request[IO](Method.GET, uri"/cat1/ds1.meta.")).map { response =>
+      assert(response.status == Status.NotFound)
+    }.unsafeRunSync()
+  }
+
+  //---- Test catalog content negotiation ----//
+
+  test("negotiate json response") {
+    val headers = Headers(Header.Raw(ci"Accept", "application/json,text/html"))
+    val req = Request[IO](Method.GET, uri"/", headers=headers)
+    dap2Service.routes.orNotFound(req).map { resp =>
+      assertResult("application/json")(resp.headers.get(ci"Content-Type").get.head.value)
+    }.unsafeRunSync()
+  }
+
+  test("negotiate json response by default") {
+    val headers = Headers()
+    val req = Request[IO](Method.GET, uri"/", headers=headers)
+    dap2Service.routes.orNotFound(req).map { resp =>
+      assertResult("application/json")(resp.headers.get(ci"Content-Type").get.head.value)
+    }.unsafeRunSync()
+  }
+
+  test("negotiate json response over all") {
+    val headers = Headers(Header.Raw(ci"Accept", "*/*"))
+    val req = Request[IO](Method.GET, uri"/", headers=headers)
+    dap2Service.routes.orNotFound(req).map { resp =>
+      assertResult("application/json")(resp.headers.get(ci"Content-Type").get.head.value)
+    }.unsafeRunSync()
+  }
+
+  test("negotiate json response over image") {
+    val headers = Headers(Header.Raw(ci"Accept", "image/*,application/json"))
+    val req = Request[IO](Method.GET, uri"/", headers=headers)
+    dap2Service.routes.orNotFound(req).map { resp =>
+      assertResult("application/json")(resp.headers.get(ci"Content-Type").get.head.value)
+    }.unsafeRunSync()
+  }
+
+  test("negotiate html response") {
+    val headers = Headers(Header.Raw(ci"Accept", "text/*,application/json"))
+    val req = Request[IO](Method.GET, uri"/", headers=headers)
+    dap2Service.routes.orNotFound(req).map { resp =>
+      assert(resp.headers.get(ci"Content-Type").get.head.value.startsWith("text/html"))
+    }.unsafeRunSync()
+  }
+}

--- a/dap2-service/src/test/scala/latis/service/dap2/JsonCatalogEncoderSuite.scala
+++ b/dap2-service/src/test/scala/latis/service/dap2/JsonCatalogEncoderSuite.scala
@@ -1,0 +1,58 @@
+package latis.service.dap2
+
+import cats.effect.unsafe.implicits.global
+import org.scalatest.funsuite.AnyFunSuite
+
+import latis.catalog.Catalog
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+import latis.util.Identifier.IdentifierStringContext
+
+class JsonCatalogEncoderSuite extends AnyFunSuite {
+
+  private lazy val ds0 = new MemoizedDataset(Metadata("id"->"ds0", "title"->"Dataset 0"), null, null)
+  private lazy val ds1 = new MemoizedDataset(Metadata("id"->"ds1", "title"->"Dataset 1"), null, null)
+  private lazy val ds2 = new MemoizedDataset(Metadata("id"->"ds2", "title"->"Dataset 2"), null, null)
+
+  private lazy val catalog: Catalog = {
+    Catalog(ds0)
+      .addCatalog(id"cat1", Catalog(ds1))
+      .addCatalog(id"cat2", Catalog(ds2))
+  }
+
+  test("json catalog") {
+    val expected =
+      """{
+        |  "catalog" : [
+        |    {
+        |      "identifier" : "cat1",
+        |      "dataset" : [
+        |        {
+        |          "identifier" : "ds1",
+        |          "title" : "Dataset 1"
+        |        }
+        |      ]
+        |    },
+        |    {
+        |      "identifier" : "cat2",
+        |      "dataset" : [
+        |        {
+        |          "identifier" : "ds2",
+        |          "title" : "Dataset 2"
+        |        }
+        |      ]
+        |    }
+        |  ],
+        |  "dataset" : [
+        |    {
+        |      "identifier" : "ds0",
+        |      "title" : "Dataset 0"
+        |    }
+        |  ]
+        |}""".stripMargin
+    JsonCatalogEncoder.encode(catalog).map { json =>
+      assertResult(expected)(json.toString)
+    }.unsafeRunSync()
+  }
+
+}


### PR DESCRIPTION
I refactored the `Dap2Service` to generically handle a GET path instead of specifically matching a dataset id and extension. Any "/" will be treated as a delimiter between catalog ids with the last id being a catalog or a dataset. If the path leads to a catalog, a separate catalog response will be invoked.

The catalog response uses server-driven (proactive) content negotiation using the Accept header to determine if it should respond with JSON (default) or HTML (pre-existing landing page).

The JSON response uses the DCAT vocabulary though it is currently limited to `identifier` and `title`. Nested catalogs will be a "catalog" array and datasets will be a "dataset" array. We'll worry about context and other json-ld content another time.

Since a Catalog does not contain an id (nor title or other metadata), the top level catalog has no identifier. We may want to change this some day.
