### PR TITLE
Change metadata encoder to use "variable"

### DIFF
--- a/core/src/main/scala/latis/output/MetadataEncoder.scala
+++ b/core/src/main/scala/latis/output/MetadataEncoder.scala
@@ -45,7 +45,7 @@ object MetadataEncoder {
         Json.fromJsonObject(
           datasetMetadata
             .add("model", md.ds.model.toString().asJson)
-            .add("variables", variableMetadata)
+            .add("variable", variableMetadata)
         )
       }
     }

--- a/core/src/test/scala/latis/output/MetadataEncoderSpec.scala
+++ b/core/src/test/scala/latis/output/MetadataEncoderSpec.scala
@@ -40,7 +40,7 @@ final class MetadataEncoderSpec extends AnyFlatSpec {
       fail("Missing model")
     } should equal ("function: a -> b")
 
-    val variables = cursor.downField("variables")
+    val variables = cursor.downField("variable")
     variables.downN(0).get[String]("id").getOrElse {
       fail("Missing variable ID")
     } should equal ("a")


### PR DESCRIPTION
The singular is more consistent with predicates like "dataset" in DCAT.