### PR TITLE
Add binary conversion operation

### DIFF
--- a/core/src/main/scala/latis/ops/ConvertBinary.scala
+++ b/core/src/main/scala/latis/ops/ConvertBinary.scala
@@ -1,0 +1,78 @@
+package latis.ops
+
+import cats.syntax.all._
+import scodec.bits.ByteVector
+
+import latis.data._
+import latis.model._
+import latis.ops.ConvertBinary._
+import latis.util.Identifier
+import latis.util.LatisException
+
+/**
+ * The ConvertBinary operation converts the target binary variable to a
+ * string variable representing the given base.
+ *
+ * The new variable will have the same identifier but the type will be changed
+ * to "string" and the encoding will be appended to the mediaType, if defined.
+ *
+ * This currently supports bases 2, 16, and 64.
+ */
+case class ConvertBinary(id: Identifier, base: Base) extends MapOperation {
+  //TODO: ensure that id maps to a binary variable
+  //TODO: support variable in nested function
+  //TODO: modify other metadata?
+
+  /** Converts the binary data to a string for the given base. */
+  private val convert: Array[Byte] => Datum = base match {
+    case Base2  => bytes => Data.StringValue(ByteVector(bytes).toBin)
+    case Base16 => bytes => Data.StringValue(ByteVector(bytes).toHex)
+    case Base64 => bytes => Data.StringValue(ByteVector(bytes).toBase64)
+  }
+
+  /** Replaces the binary value with the converted string. */
+  def mapFunction(model: DataType): Sample => Sample = {
+    val pos = model.findPath(id) match {
+      case Some(head :: Nil) => head
+      case Some(_) => throw LatisException("Target variable must not be in nested function")
+      case None    => throw LatisException("Variable not found")
+    }
+    (sample: Sample) => sample.getValue(pos) match {
+      case Some(b: Data.BinaryValue) => sample.updatedValue(pos, convert(b.value))
+      case _ => throw LatisException("Target variable must be Binary")
+    }
+  }
+
+  /** Changes the Binary variable to a String variable. */
+  def applyToModel(model: DataType): Either[LatisException, DataType] =
+    model.map {
+      case s: Scalar if (s.id == id) =>
+        var md = s.metadata + ("type", StringValueType.toString)
+        s.metadata.getProperty("mediaType").foreach { mt =>
+          md = md + ("mediaType", s"$mt;$base") //append encoding to mediaType
+        }
+        Scalar.fromMetadata(md).fold(throw _, identity) //should be safe
+      case dt => dt
+    }.asRight
+}
+
+object ConvertBinary {
+
+  def fromArgs(args: List[String]): Either[LatisException, ConvertBinary] = args match {
+    case id :: base :: Nil => for {
+      id   <- Either.fromOption(Identifier.fromString(id), LatisException("Invalid Identifier"))
+      base <- base match {
+        case "2"  => Base2.asRight
+        case "16" => Base16.asRight
+        case "64" => Base64.asRight
+        case _    => LatisException("ConvertBinary base must be 2, 16, or 64").asLeft
+      }
+    } yield ConvertBinary(id, base)
+    case _ => LatisException("ConvertBinary requires two argument: id, base").asLeft
+  }
+
+  sealed trait Base
+  object Base2  extends Base { override def toString: String = "base2" }
+  object Base16 extends Base { override def toString: String = "base16" }
+  object Base64 extends Base { override def toString: String = "base64" }
+}

--- a/core/src/main/scala/latis/ops/ConvertBinary.scala
+++ b/core/src/main/scala/latis/ops/ConvertBinary.scala
@@ -68,7 +68,7 @@ object ConvertBinary {
         case _    => LatisException("ConvertBinary base must be 2, 16, or 64").asLeft
       }
     } yield ConvertBinary(id, base)
-    case _ => LatisException("ConvertBinary requires two argument: id, base").asLeft
+    case _ => LatisException("ConvertBinary requires two arguments: id, base").asLeft
   }
 
   sealed trait Base

--- a/core/src/main/scala/latis/ops/UnaryOperation.scala
+++ b/core/src/main/scala/latis/ops/UnaryOperation.scala
@@ -4,6 +4,8 @@ import cats.syntax.all._
 
 import latis.data.Data
 import latis.model.DataType
+import latis.ops.ConvertBinary._
+import latis.util.Identifier
 import latis.util.LatisException
 
 /**
@@ -49,6 +51,14 @@ object UnaryOperation {
     case "tail" => Tail().asRight
     case "take" => Take.fromArgs(args)
     case "takeRight" => TakeRight.fromArgs(args)
+    case "toBase64" => Either.fromOption(
+      args.headOption.flatMap(Identifier.fromString),
+      LatisException("Invalid Identifier")
+    ).map(ConvertBinary(_, Base64))
+    case "toHex" => Either.fromOption(
+      args.headOption.flatMap(Identifier.fromString),
+      LatisException("Invalid Identifier")
+    ).map(ConvertBinary(_, Base16))
     case "transpose" => Transpose().asRight
     case "timeTupleToTime" => TimeTupleToTime.fromArgs(args)
     case n => Left(LatisException(s"Unknown operation: $n"))

--- a/core/src/test/scala/latis/ops/ConvertBinarySuite.scala
+++ b/core/src/test/scala/latis/ops/ConvertBinarySuite.scala
@@ -1,0 +1,65 @@
+package latis.ops
+
+import munit.CatsEffectSuite
+import scodec.bits._
+
+import latis.data._
+import latis.dataset.TappedDataset
+import latis.metadata.Metadata
+import latis.model._
+import latis.ops.ConvertBinary._
+import latis.util.Identifier.IdentifierStringContext
+
+class ConvertBinarySuite extends CatsEffectSuite {
+
+  private lazy val dataset = new TappedDataset(
+    Metadata(id"test"),
+    Scalar.fromMetadata(Metadata(
+      "id"        -> "bytes",
+      "type"      -> "binary",
+      "mediaType" -> "example"
+    )).getOrElse(fail("Invalid scalar")),
+    Data.BinaryValue(hex"cafebabe".toArray)
+  )
+
+  test("toBase64") {
+    val ds = dataset.withOperation(ConvertBinary(id"bytes", Base64))
+    ds.samples.compile.toList.map { list =>
+      list.head match {
+        case Sample(_, RangeData(Text(s))) => assertEquals(s, "yv66vg==")
+        case _ => fail("Bad sample")
+      }
+    }
+  }
+
+  test("toHex") {
+    val ds = dataset.withOperation(ConvertBinary(id"bytes", Base16))
+    ds.samples.compile.toList.map { list =>
+      list.head match {
+        case Sample(_, RangeData(Text(s))) => assertEquals(s, "cafebabe")
+        case _ => fail("Bad sample")
+      }
+    }
+  }
+
+  test("toBin") {
+    val ds = dataset.withOperation(ConvertBinary(id"bytes", Base2))
+    ds.samples.compile.toList.map { list =>
+      list.head match {
+        case Sample(_, RangeData(Text(s))) => assertEquals(s, "11001010111111101011101010111110")
+        case _ => fail("Bad sample")
+      }
+    }
+  }
+
+  test("mediaType") {
+    val ds = dataset.withOperation(ConvertBinary(id"bytes", Base64))
+    ds.model.findVariable(id"bytes") match {
+      case Some(s: Scalar) => s.metadata.getProperty("mediaType") match {
+        case Some(mt) => assertEquals(mt, "example;base64")
+        case _ => fail("No mediaType")
+      }
+      case _ => fail("Variable not found")
+    }
+  }
+}


### PR DESCRIPTION
This was inspired by the smallsat ops team wanting packets as Hex but it also handles base64 which we need for image encoding. Unfortunately, scodec does not directly support octal. I threw in base2 because I could, but didn't expose it to the service API. We could easily add bases 32 and 58 but those just don't seem useful.

I chose to make this a targeted operation requiring a variable id. I considered having it act on all binary variables (like we do in latis-swp), but that seemed less flexible. That's still open for debate. `ConvertTime` is similar but it applies to all time variables. That distinction bugs me a bit.

For the service API, I chose to expose `toHex` and `toBase64` as opposed to `convertBinary`. I didn't add it to the DSL, yet.