### PR TITLE
Optimize NetcdfAdapter to handle selections with cadence

### DIFF
--- a/core/src/main/scala/latis/dsl/datasetGenerator.scala
+++ b/core/src/main/scala/latis/dsl/datasetGenerator.scala
@@ -57,7 +57,7 @@ object DatasetGenerator {
   private def modelFromString(s: String): DataType =
     ModelParser.parse(s).fold(throw _, identity)
 
-  private def generateData(m: DataType): MemoizedFunction = m.arity match {
+  def generateData(m: DataType): MemoizedFunction = m.arity match {
     case 1 => generateData1D(m)
     case 2 => generateData2D(m)
     case 3 => generateData3D(m)

--- a/core/src/main/scala/latis/model/ScalarAlgebra.scala
+++ b/core/src/main/scala/latis/model/ScalarAlgebra.scala
@@ -77,6 +77,24 @@ trait ScalarAlgebra { scalar: Scalar =>
     if (scalar.ascending) DefaultDatumOrdering
     else DefaultDatumOrdering.reverse
 
+  /** Returns the numerical cadence as optionally defined in the metadata. */
+  def getCadence: Option[Double] =
+    metadata.getProperty("cadence").flatMap(_.toDoubleOption)
+
+  /** Returns the numeric coverage as optionally defined in the metadata. */
+  def getCoverage: Option[(Double,Double)] = {
+    metadata.getProperty("coverage").flatMap { c =>
+      c.split("/").toList match {
+        case s :: e :: Nil if s.nonEmpty && e.nonEmpty =>
+          for {
+            s <- s.toDoubleOption
+            e <- e.toDoubleOption
+          } yield (s, e)
+        case _ => None
+      }
+    }
+  }
+
   /** Defines the string representation as the Scalar id. */
   override def toString: String = id.asString
 }

--- a/core/src/main/scala/latis/time/Time.scala
+++ b/core/src/main/scala/latis/time/Time.scala
@@ -1,8 +1,7 @@
 package latis.time
 
 import java.time.Duration
-
-import scala.util.Try
+import java.time.format.DateTimeParseException
 
 import cats.syntax.all._
 
@@ -109,12 +108,12 @@ class Time protected (
   override def getCadence: Option[Double] = {
     //TODO: support cadence in millis for text times?
     if (valueType == StringValueType) metadata.getProperty("cadence").flatMap { c =>
-      Try(Duration.parse(c).getSeconds * 1000d).toOption
+      Either.catchOnly[DateTimeParseException](Duration.parse(c).getSeconds * 1000d).toOption
     } else super.getCadence
   }
 
   /** Adds support for text time and undefined end as now. */
-  override def getCoverage: Option[(Double,Double)] =
+  override def getCoverage: Option[(Double, Double)] =
     //TODO: apply latency offset when end time is open
     if (valueType == StringValueType) metadata.getProperty("coverage").flatMap { c =>
       c.split("/").toList match {

--- a/core/src/main/scala/latis/util/Section.scala
+++ b/core/src/main/scala/latis/util/Section.scala
@@ -128,6 +128,8 @@ class Section private (ranges: List[Range.Inclusive]) {
 
   /** Returns a new Section with a subset applied to the given dimension. */
   def subsetDimension(dim: Int, from: Int, to: Int, step: Int = 1): Either[LatisException, Section] =
+    //TODO: prevent from > to
+    //TODO: handle subset outside section with empty Section
     for {
       range <- getDimensionRange(dim)
       newStart = Math.max(range.start, from)

--- a/core/src/test/scala/latis/util/SectionSuite.scala
+++ b/core/src/test/scala/latis/util/SectionSuite.scala
@@ -120,6 +120,18 @@ class SectionSuite extends AnyFunSuite {
     }
   }
 
+  ignore("subset outside section") {
+    println(sectionWithOffset.subsetDimension(0, 10, 20))
+    // 1:9:1 => 10:9:1, section should be empty
+    // presumably NcSection construction would fail
+  }
+
+  ignore("prevent from > to") {
+    println(sectionWithOffset.subsetDimension(0, 10, -1))
+    // => 10:*:1
+    // Can fool it into unlimited dimension (with -1) outside of original section!
+  }
+
   //---- Chunk ----//
 
   test("chunk") {


### PR DESCRIPTION
If a domain variable has a cadence (absolutely regular) and start value (via "coverage"), the NetcdfAdapter will now handle selections with the following operators: ">", ">=", "<", "<=". I excluded "=" and "==" because we need support for empty Sections to handle the cases when there is no match. Even this is fragile since selections outside of bounds will yield invalid Sections that will likely throw netcdf-java exceptions, failing on the Stream's error channel instead of politely returning an empty dataset. (Another vote for Adapters to return IO[Stream].)

I'll make a new issue to improve Section then add "=", "==", and possibly "~".