### PR TITLE
Use new IndexRange for Sections

### DIFF
--- a/core/src/main/scala/latis/util/IndexRange.scala
+++ b/core/src/main/scala/latis/util/IndexRange.scala
@@ -1,0 +1,222 @@
+package latis.util
+
+import cats.syntax.all._
+import fs2.Pure
+import fs2.Stream
+
+/**
+ * An IndexRange represents the indices defining one dimension of a Section.
+ *
+ * A FiniteRange is expressed in terms of start, end, and step positive integers.
+ * The end value is inclusive and is required to be greater than or equal to the start.
+ * The length is limited to Int.MaxValue (2147483647).
+ *
+ * An UnlimitedRange is expressed in terms of start and step positive integers
+ * but has no end. The length is undefined.
+ *
+ * An EmptyRange represents an IndexRange of length zero.
+ */
+sealed trait IndexRange {
+
+  /** Returns the number of elements in this IndexRange if it is not unlimited. */
+  def length: Option[Int] = this match {
+    case FiniteRange(start, end, step) => Some((end - start) / step  + 1)
+    case _: UnlimitedRange             => None
+    case EmptyRange                    => Some(0)
+  }
+
+  /** Returns whether this IndexRange has a specified length. */
+  def isUnlimited: Boolean = length.isEmpty
+
+  /** Returns whether this IndexRange is empty. */
+  def isEmpty: Boolean = length.contains(0)
+
+  /** Computes the new step size given the original step and a new stride. */
+  private def computeNewStep(origStep: Int, stride: Int): Either[LatisException, Int] = {
+    if (stride > Int.MaxValue / origStep) LatisException("New step exceeds max Int").asLeft
+    else if (stride <= 0) LatisException("stride must be greater than zero").asLeft
+    else (origStep * stride).asRight
+  }
+
+  /**
+   * Applies a stride to this IndexRange.
+   *
+   * Note that this takes the current stride into account, unlike scala's Range.by.
+   * The current end value may be truncated to match a whole number of steps.
+   */
+  def stride(stride: Int): Either[LatisException, IndexRange] =
+    if (stride == 1) this.asRight //no-op
+    else this match {
+      case FiniteRange(start, end, step) =>
+        computeNewStep(step, stride).flatMap(IndexRange.finite(start, end, _))
+      case UnlimitedRange(start, step) =>
+        computeNewStep(step, stride).map(UnlimitedRange(start, _))
+      case EmptyRange => EmptyRange.asRight
+    }
+
+  /**
+   * Creates a subset of this IndexRange.
+   *
+   * The start and end values are inclusive but they may be truncated
+   * to align with the current start and step and to preserve whole steps.
+   */
+  def subset(from: Int, to: Int, stride: Int = 1): Either[LatisException, IndexRange] = {
+    if (from < 0) LatisException("Subset start must be non-negative").asLeft
+    else if (to < from) LatisException("Subset end must not be less that start").asLeft
+    else if (stride <= 0) LatisException("Subset stride must greater than zero").asLeft
+    else this match {
+      case FiniteRange(start, end, step) =>
+        computeNewStep(step, stride).flatMap { newStep =>
+          val newStart =
+            if (start >= from) start
+            // Get first value in range >= "from" accounting for step
+            else Math.ceil((from - start).toDouble / step).toInt * step + start
+          val newEnd = Math.min(end, to)
+          if (newStart > newEnd) EmptyRange.asRight
+          else IndexRange.finite(newStart, newEnd, newStep)
+        }
+      case UnlimitedRange(start, step) =>
+        computeNewStep(step, stride).flatMap { newStep =>
+          val newStart =
+            if (start >= from) start
+            // Get first value in range >= "from" accounting for step
+            else Math.ceil((from - start).toDouble / step).toInt * step + start
+          if (newStart > to) EmptyRange.asRight
+          else IndexRange.finite(newStart, to, newStep)
+        }
+      case EmptyRange => EmptyRange.asRight
+    }
+  }
+
+  /**
+   * Presents this IndexRange using range notation.
+   *
+   *   FiniteRange: "start:end:step"
+   *   UnlimitedRange: "start:*:step"
+   *   EmptyRange: "0" (i.e. a length of zero)
+   *
+   * These values can in turn be used by IndexRange.fromExpression.
+   */
+  override def toString: String = this match {
+    case FiniteRange(start, end, step) => s"$start:$end:$step"
+    case UnlimitedRange(start, step)   => s"$start:*:$step"
+    case EmptyRange                    => "0" //represents length = 0
+  }
+}
+
+sealed trait NonEmptyRange extends IndexRange {
+  //TODO: consider putting other methods here, e.g. stride
+  //  Section has only NonEmptyRanges, this preserves the type so we can use the constructor safely
+  //  But no reason to exclude these from EmptyRange?
+
+  /** Breaks this IndexRange into a Stream of FiniteRanges with the given length. */
+  def chunk(size: Int): Stream[Pure, NonEmptyRange] = {
+    //Note: treating size < 1 as no-op: one single chunk //TODO: consider error, refined type
+    if (size < 1) Stream(this) //single chunk
+    else this match {
+      case FiniteRange(start, end, step) =>
+        Stream.emits(start to end by size * step).map { s =>
+          FiniteRange(s, Math.min(s + (size - 1) * step, end), step)
+        }
+      case UnlimitedRange(start, step) =>
+        Stream.iterate(start)(_ + size * step).map { s =>
+          FiniteRange(s, s + (size - 1) * step, step)
+        }
+    }
+  }
+}
+
+/** Represents an IndexRange with a specified end. */
+final case class FiniteRange private[util] (start: Int, end: Int, step: Int) extends NonEmptyRange
+
+/** Represents an IndexRange without a specified end. */
+final case class UnlimitedRange private (start: Int, step: Int) extends NonEmptyRange
+
+/** Represents an empty IndexRange. */
+object EmptyRange extends IndexRange
+
+
+object IndexRange {
+
+  /**
+   * Constructs a FiniteRange.
+   *
+   * The inclusive end value may be truncated to match a whole number of steps.
+   * This ensures that `end` is indeed the last value.
+   */
+  def finite(from: Int, to: Int, stride: Int = 1): Either[LatisException, FiniteRange] = {
+    if (from < 0)        LatisException("IndexRange start must be non-negative").asLeft
+    else if (from > to)  LatisException("IndexRange end must be greater than start").asLeft
+    else if (stride < 1) LatisException("IndexRange step must be greater than zero").asLeft
+    else {
+      // Note: integer division will do floor
+      val end = (to - from) / stride * stride + from
+      FiniteRange(from, end, stride).asRight
+    }
+  }
+
+  /** Constructs an UnlimitedRange. */
+  def unlimited(from: Int, stride: Int): Either[LatisException, UnlimitedRange] = {
+    if (from < 0)        LatisException("IndexRange start must be non-negative").asLeft
+    else if (stride < 1) LatisException("IndexRange step must be greater than zero").asLeft
+    else UnlimitedRange(from, stride).asRight
+  }
+
+  /**
+   * Constructs an IndexRange from a range expression.
+   *
+   * An IndexRange expression is a string representation of an index range of the forms:
+   *   "start:end:step"
+   *   "start:end" - Equivalent to "start:end:1"
+   *   "length" - Equivalent to "0:length-1:1", must be >= 0
+   *
+   * All values must be non-negative integers.
+   * The end value is inclusive or may be "*" to indicate an unlimited range.
+   *
+   * The output of toString adheres to this expression syntax.
+   */
+  def fromExpression(expr: String): Either[LatisException, IndexRange] =
+    expr.split(":").toList match {
+      case length :: Nil => parseInt(length).flatMap { l =>
+        if (l < 0) LatisException("Length must be greater than zero.").asLeft
+        else if (l == 0) EmptyRange.asRight
+        else FiniteRange(0, l - 1, 1).asRight
+      }
+      case start :: end :: Nil => for {
+        s <- parseInt(start)
+        e <- parseEnd(end)
+        r <- makeRange(s, e)
+      } yield r
+      case start :: end :: step :: Nil => for {
+        s <- parseInt(start)
+        e <- parseEnd(end)
+        d <- parseInt(step)
+        r <- makeRange(s, e, d)
+      } yield r
+      case _ => LatisException(s"Invalid range expression: $expr").asLeft
+    }
+
+  /** Adds special handling for end = -1 for unlimited range. */
+  private def makeRange(start: Int, end: Int, step: Int = 1): Either[LatisException, IndexRange] = {
+    // Delegates to primary constructors for error handling.
+    if (end == -1) IndexRange.unlimited(start, step)
+    else IndexRange.finite(start, end, step)
+  }
+
+  /** Parses a string as an Int. */
+  private def parseInt(s: String): Either[LatisException, Int] =
+    Either.catchOnly[NumberFormatException](s.toInt).leftMap(LatisException(_))
+
+  /**
+   * Parses a string representing the upper value of a IndexRange.
+   *
+   * A "*" will yield "-1", representing an unlimited range.
+   */
+  private def parseEnd(end: String): Either[LatisException, Int] = end match {
+    case "*" => (-1).asRight
+    case end => parseInt(end)
+  }
+
+  /** Returns an empty IndexRange. */
+  def empty: IndexRange = EmptyRange
+}

--- a/core/src/main/scala/latis/util/IndexRange.scala
+++ b/core/src/main/scala/latis/util/IndexRange.scala
@@ -127,10 +127,20 @@ sealed trait NonEmptyRange extends IndexRange {
 }
 
 /** Represents an IndexRange with a specified end. */
-final case class FiniteRange private[util] (start: Int, end: Int, step: Int) extends NonEmptyRange
+sealed abstract case class FiniteRange private[util] (start: Int, end: Int, step: Int) extends NonEmptyRange
+
+object FiniteRange {
+  private[util] def apply(start: Int, end: Int, step: Int): FiniteRange =
+    new FiniteRange(start, end, step) {}
+}
 
 /** Represents an IndexRange without a specified end. */
-final case class UnlimitedRange private (start: Int, step: Int) extends NonEmptyRange
+sealed abstract case class UnlimitedRange private (start: Int, step: Int) extends NonEmptyRange
+
+object UnlimitedRange {
+  private[util] def apply(start: Int, step: Int): UnlimitedRange =
+    new UnlimitedRange(start, step) {}
+}
 
 /** Represents an empty IndexRange. */
 object EmptyRange extends IndexRange

--- a/core/src/test/scala/latis/util/IndexRangeSuite.scala
+++ b/core/src/test/scala/latis/util/IndexRangeSuite.scala
@@ -1,0 +1,234 @@
+package latis.util
+
+import munit.FunSuite
+
+class IndexRangeSuite extends FunSuite {
+
+  //--- FiniteRange ---//
+
+  test("construct finite range") {
+    val r = IndexRange.finite(1, 3, 2).fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:3:2")
+  }
+
+  test("construct finite range with default step") {
+    val r = IndexRange.finite(1, 3).fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:3:1")
+  }
+
+  test("construct finite range with truncation") {
+    val r = IndexRange.finite(1, 4, 2).fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:3:2")
+  }
+
+  test("construct finite range with start = end") {
+    val r = IndexRange.finite(1, 1, 2).fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:1:2")
+  }
+
+  test("fail to construct finite range with start after end") {
+    assert(IndexRange.finite(1, 0, 2).isLeft)
+  }
+
+  test("fail to construct finite range with negative start") {
+    assert(IndexRange.finite(-1, 3, 2).isLeft)
+  }
+
+  test("fail to construct finite range with negative step") {
+    assert(IndexRange.finite(1, 3, -2).isLeft)
+  }
+
+  test("fail to construct finite range with step = 0") {
+    assert(IndexRange.finite(1, 3, 0).isLeft)
+  }
+
+  test("finite range length") {
+    val r = IndexRange.finite(1, 3, 2).fold(e => fail(e.getMessage), identity)
+    assertEquals(r.length, Some(2))
+  }
+
+  test("finite range is not unlimited") {
+    val r = IndexRange.finite(1, 1, 2).fold(e => fail(e.getMessage), identity)
+    assert(!r.isUnlimited)
+  }
+
+  test("finite range is not emmpty") {
+    val r = IndexRange.finite(1, 1, 2).fold(e => fail(e.getMessage), identity)
+    assert(!r.isEmpty)
+  }
+
+  test("finite stride") {
+    val r = IndexRange.finite(1, 5, 2)
+      .flatMap(_.stride(2))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:5:4")
+  }
+
+  test("non-positive finite stride fails") {
+    assert(IndexRange.finite(1, 5, 2).flatMap(_.stride(0)).isLeft)
+  }
+
+  test("finite stride with truncation") {
+    val r = IndexRange.finite(1, 7, 2)
+      .flatMap(_.stride(2))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:5:4")
+  }
+
+  test("stride too large") {
+    assert(IndexRange.finite(1, Int.MaxValue, Int.MaxValue / 10)
+      .flatMap(_.stride(Int.MaxValue)).isLeft)
+  }
+
+  test("finite subset") {
+    val r = IndexRange.finite(1, 7, 2)
+      .flatMap(_.subset(3, 5))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "3:5:2")
+  }
+
+  test("finite subset with truncation") {
+    val r = IndexRange.finite(1, 7, 2)
+      .flatMap(_.subset(2, 6))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "3:5:2")
+  }
+
+  test("finite subset with stride") {
+    val r = IndexRange.finite(1, 13, 2)
+      .flatMap(_.subset(2, 12, 2))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "3:11:4")
+  }
+
+  test("finite subset including start") {
+    val r = IndexRange.finite(3, 7, 2)
+      .flatMap(_.subset(3, 5))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "3:5:2")
+  }
+
+  test("finite subset including end") {
+    val r = IndexRange.finite(3, 7, 2)
+      .flatMap(_.subset(5, 7))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "5:7:2")
+  }
+
+  test("finite subset starting before start") {
+    val r = IndexRange.finite(3, 7, 2)
+      .flatMap(_.subset(1, 5))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "3:5:2")
+  }
+
+  test("finite subset ending after end") {
+    val r = IndexRange.finite(3, 7, 2)
+      .flatMap(_.subset(5, 9))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "5:7:2")
+  }
+
+  test("finite subset outside start should be empty") {
+    val r = IndexRange.finite(3, 7, 2)
+      .flatMap(_.subset(1, 1))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "0")
+  }
+
+  test("finite subset outside end should be empty") {
+    val r = IndexRange.finite(3, 7, 2)
+      .flatMap(_.subset(9, 9))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "0")
+  }
+
+  test("finite chunk") { //first chunk test is 100 time longer?
+    val r = IndexRange.finite(1, 7, 2).fold(e => fail(e.getMessage), identity)
+    val chunks = r.chunk(2).compile.toList
+    assertEquals(chunks.length, 2)
+    assertEquals(chunks.last.length.get, 2)
+  }
+
+  test("finite chunk with partial chunk") {
+    val r = IndexRange.finite(1, 9, 2).fold(e => fail(e.getMessage), identity)
+    val chunks = r.chunk(2).compile.toList
+    assertEquals(chunks.length, 3)
+    assertEquals(chunks.last.length.get, 1)
+  }
+
+  test("finite chunk with single big chunk") {
+    val r = IndexRange.finite(1, 7, 2).fold(e => fail(e.getMessage), identity)
+    val chunks = r.chunk(100).compile.toList
+    assertEquals(chunks.length, 1)
+    assertEquals(chunks.last.length.get, 4)
+  }
+
+  //--- UnlimitedRange ---//
+
+  test("unlimited range has no length") {
+    val r = IndexRange.unlimited(1, 2).fold(e => fail(e.getMessage), identity)
+    assertEquals(r.length, None)
+  }
+
+  test("unlimited range is not empty") {
+    val r = IndexRange.unlimited(1, 2).fold(e => fail(e.getMessage), identity)
+    assert(!r.isEmpty)
+  }
+
+  test("unlimited range is unlimited") {
+    val r = IndexRange.unlimited(1, 2).fold(e => fail(e.getMessage), identity)
+    assert(r.isUnlimited)
+  }
+
+  test("unlimited range stride") {
+    val r = IndexRange.unlimited(1, 2)
+      .flatMap(_.stride(3))
+      .fold(e => fail(e.getMessage), identity)
+    assertEquals(r.toString, "1:*:6")
+  }
+
+  test("unlimited range subset") {
+    val r = IndexRange.unlimited(1, 2)
+      .flatMap(_.subset(2, 10, 2))
+      .fold(e => fail(e.getMessage), identity)
+    assert(!r.isUnlimited) //no longer unlimited
+    assertEquals(r.toString, "3:7:4")
+  }
+
+  test("unlimited range chunk") {
+    val r = IndexRange.unlimited(1, 2)
+      .map(_.chunk(10))
+      .fold(e => fail(e.getMessage), identity)
+      .head.compile.toList.head
+    assertEquals(r.toString, "1:19:2")
+  }
+
+  //--- EmptyRange ---//
+
+  test("empty range has length 0") {
+    assertEquals(EmptyRange.length, Some(0))
+  }
+
+  test("empty range is empty") {
+    assert(EmptyRange.isEmpty)
+  }
+
+  test("empty range is not unlimited") {
+    assert(!EmptyRange.isUnlimited)
+  }
+
+  test("empty range stride is empty") {
+    val r = EmptyRange.stride(2).fold(e => fail(e.getMessage), identity)
+    assert(r.isEmpty)
+  }
+
+  test("empty range subset is empty") {
+    val r = EmptyRange.subset(0, 10, 2).fold(e => fail(e.getMessage), identity)
+    assert(r.isEmpty)
+  }
+
+  test("empty range toString") {
+    assertEquals(EmptyRange.toString, "0")
+  }
+}

--- a/netcdf/src/test/scala/latis/input/NetcdfWrapperSuite.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfWrapperSuite.scala
@@ -79,49 +79,49 @@ class NetcdfWrapperSuite extends CatsEffectSuite {
 
   test("default section") {
     ncWapper.makeSection(List()).map { s =>
-      assert(s.toString == "0:1:1,0:2:1")
+      assertEquals(s.toString, "0:1:1,0:2:1")
     }
   }
 
   test("head section") {
     val ops = List(Head())
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:0:1,0:0:1")
+      assertEquals(s.toString, "0:0:1,0:0:1")
     }
   }
 
   test("stride section") {
     val ops = List(Stride(List(2,2)))
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:1:2,0:2:2")
+      assertEquals(s.toString, "0:0:2,0:2:2")
     }
   }
 
   test("selection with >") {
     val ops = List(Selection.makeSelection("y > 1").getOrElse(fail("Bad selection")))
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:1:1,2:2:1")
+      assertEquals(s.toString, "0:1:1,2:2:1")
     }
   }
 
   test("selection with >=") {
     val ops = List(Selection.makeSelection("y >= 1").getOrElse(fail("Bad selection")))
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:1:1,1:2:1")
+      assertEquals(s.toString, "0:1:1,1:2:1")
     }
   }
 
   test("selection with <") {
     val ops = List(Selection.makeSelection("y < 1").getOrElse(fail("Bad selection")))
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:1:1,0:0:1")
+      assertEquals(s.toString, "0:1:1,0:0:1")
     }
   }
 
   test("selection with <=") {
     val ops = List(Selection.makeSelection("y <= 1").getOrElse(fail("Bad selection")))
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:1:1,0:1:1")
+      assertEquals(s.toString, "0:1:1,0:1:1")
     }
   }
 
@@ -131,15 +131,24 @@ class NetcdfWrapperSuite extends CatsEffectSuite {
       Selection.makeSelection("y < 2").getOrElse(fail("Bad selection"))
     )
     ncWapper.makeSection(ops).map { s =>
-      assert(s.toString == "0:1:1,1:1:1")
+      assertEquals(s.toString, "0:1:1,1:1:1")
     }
   }
 
-  //TODO: support empty Section
-  test("selection outside bounds".ignore) {
+  test("selection outside bounds") {
     val ops = List(Selection.makeSelection("y > 9").getOrElse(fail("Bad selection")))
     ncWapper.makeSection(ops).map { s =>
-      println(s) //0:1:1,10:2:1
+      assert(s.isEmpty)
+    }
+  }
+
+  test("stride then selection with truncation") {
+    val ops = List(
+      Stride(List(1, 2)),
+      Selection.makeSelection("y >= 1").getOrElse(fail("Bad selection"))
+    )
+    ncWapper.makeSection(ops).map { s =>
+      assertEquals(s.toString, "0:1:1,2:2:2")
     }
   }
 
@@ -148,7 +157,7 @@ class NetcdfWrapperSuite extends CatsEffectSuite {
       sec <- Stream.eval(ncWapper.makeSection(List()))
       ss  <- ncWapper.chunkSection(sec)
     } yield ss).compile.toList.map { list =>
-      assert(list.length == 2)
+      assertEquals(list.length, 2)
     }
   }
 
@@ -158,10 +167,10 @@ class NetcdfWrapperSuite extends CatsEffectSuite {
       s   <- ncWapper.streamSamples(sec).compile.toList.map(_.head)
     } yield s).map {
       case Sample(DomainData(Integer(x), Integer(y)), RangeData(Integer(a), Integer(b))) =>
-        assert(x == 0)
-        assert(y == 0)
-        assert(a == 0)
-        assert(b == 1)
+        assertEquals(x, 0L)
+        assertEquals(y, 0L)
+        assertEquals(a, 0L)
+        assertEquals(b, 1L)
       case _ => fail("Invalid Sample")
     }
   }


### PR DESCRIPTION
This replaces the use of scala's `Range` with a new `IndexRange` which has safer behavior requiring `start <= end`, non-negative integers, and supporting unlimited and empty ranges.

`Section` was updated to use the new `IndexRange` and to better support the notion of an empty `Section`.

The `NetcdfWrapper` was updated to use the new `Section`, fixing some bugs and making it a bit more robust.