### PR TITLE
Granule list generator

### DIFF
--- a/core/src/main/scala/latis/input/GranuleListGenerator.scala
+++ b/core/src/main/scala/latis/input/GranuleListGenerator.scala
@@ -1,0 +1,158 @@
+package latis.input
+
+import java.net.URI
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+import cats.syntax.all._
+import fs2.Stream
+
+import latis.data.Data
+import latis.data.Datum
+import latis.data.Sample
+import latis.data.StreamFunction
+import latis.model.DataType
+import latis.model.Function
+import latis.model.Scalar
+import latis.ops.Operation
+import latis.time.Time
+import latis.time.TimeFormat
+import latis.util.ConfigLike
+import latis.util.Duration
+import latis.util.Identifier._
+import latis.util.LatisException
+
+/**
+ * An adapter for creating datasets of granule URIs generated for a
+ * given time range and step.
+ *
+ * This adapter produces datasets of the form `time → uri` where the
+ * values of `uri` are derived from the corresponding values of `time`
+ * using a format string and are then resolved against the base URI.
+ *
+ * The scalar `time` must be a [[latis.time.Time Time]]. It must have
+ * type `string` and its units must be consistent with an ISO 8601
+ * time string.
+ *
+ * The scalar `uri` must have `uri` as its identifier and it must have
+ * type `string`.
+ *
+ * The base URI is given by the `source` element in FDML or by the
+ * [[java.net.URI URI]] given when calling [[getData]].
+ *
+ * The `pattern` configuration key defines the format string. The
+ * format string is expected to follow the Java [[java.util.Formatter
+ * Formatter]] format. The date and time conversions will be the most
+ * useful. Because there is only one time per URI, each conversion
+ * character must be prefixed with `1$` to work properly.
+ *
+ * The `start` and `end` configuration keys define the coverage
+ * (inclusive on the end) of the generated dataset. These are expected
+ * to be ISO 8601 strings in UTC. The `end` is optional and defaults
+ * to "now".
+ *
+ * The `step` configuration key defines the time step between
+ * generated samples. It is expected to be an ISO 8601 duration string
+ * using only integers.
+ */
+class GranuleListGenerator private[input] (
+  model: DataType,
+  config: GranuleListGenerator.Config
+) extends Adapter {
+
+  // The baseUri is the URI to which the pattern will be appended
+  override def getData(baseUri: URI, ops: Seq[Operation]): Data =
+    validateModel(model) match {
+      case Left(ex) => throw ex
+      case Right((time, uri)) =>
+        StreamFunction(enumerateTimes.map(makeSample(time, uri, baseUri, _)))
+    }
+
+  private def enumerateTimes: Stream[fs2.Pure, LocalDateTime] =
+    Stream.iterate(config.start)(_.plus(config.step))
+      .takeWhile(t => t.isBefore(config.end) || t.isEqual(config.end))
+
+  private def makeSample(
+    time: Time,
+    uri: Scalar,
+    baseUri: URI,
+    t: LocalDateTime
+  ): Sample = (for {
+    d <- makeTime(time, t)
+    r <- makeUri(uri, baseUri, t)
+  } yield Sample(List(d), List(r))).fold(throw _, identity)
+
+  private def makeTime(
+    time: Time,
+    t: LocalDateTime
+  ): Either[LatisException, Datum] =
+    time.parseValue(TimeFormat.Iso.format(t.toEpochSecond(ZoneOffset.UTC)*1000))
+
+  private def makeUri(
+    uri: Scalar,
+    baseUri: URI,
+    t: LocalDateTime
+  ): Either[LatisException, Data] =
+    uri.parseValue(baseUri.resolve(config.pattern.format(t)).toString)
+
+  // Checks that the model given is a function from time to a scalar
+  // called "uri", otherwise returns a LatisException which will
+  // eventually be thrown.
+  private def validateModel(
+    model: DataType
+  ): Either[LatisException, (Time, Scalar)] = model match {
+    case Function(t: Time, u: Scalar) if u.id == id"uri" => (t, u).asRight
+    case _ => LatisException(s"Unsupported model: $model").asLeft
+  }
+}
+
+object GranuleListGenerator extends AdapterFactory {
+
+  override def apply(
+    model: DataType,
+    config: AdapterConfig
+  ): GranuleListGenerator =
+    Config.fromConfigLike(config).fold(
+      throw _,
+      new GranuleListGenerator(model, _)
+    )
+
+  private[input] final case class Config(
+    start: LocalDateTime,
+    end: LocalDateTime,
+    step: Duration,
+    pattern: String
+  )
+
+  private[input] object Config {
+    def fromConfigLike(
+      now: LocalDateTime,
+      cl: ConfigLike
+    ): Either[LatisException, Config] = for {
+      start   <- cl.get("start").toRight(
+        LatisException("Adapter requires a start time")
+      ).flatMap(parseTime)
+      end     <- cl.get("end").traverse(parseTime).map(_.getOrElse(now))
+      _       <- if (end.isAfter(start)) {
+        ().asRight
+      } else LatisException("End must come before start").asLeft
+      step    <- cl.get("step").toRight(
+        LatisException("Adapter requires a step.")
+      ).flatMap(Duration.fromIsoString)
+      pattern <- cl.get("pattern").toRight(
+        LatisException("Adapter requires a pattern.")
+      )
+    } yield Config(start, end, step, pattern)
+
+    def fromConfigLike(cl: ConfigLike): Either[LatisException, Config] = {
+      val now = LocalDateTime.now(ZoneId.of("Z"))
+      fromConfigLike(now, cl)
+    }
+
+    private def parseTime(str: String): Either[LatisException, LocalDateTime] =
+      TimeFormat.parseIso(str).map { ms =>
+        LocalDateTime.ofEpochSecond(ms/1000, 0, ZoneOffset.UTC)
+      }
+  }
+}

--- a/core/src/main/scala/latis/util/Duration.scala
+++ b/core/src/main/scala/latis/util/Duration.scala
@@ -1,0 +1,125 @@
+package latis.util
+
+import java.time.temporal.ChronoUnit
+import java.time.temporal.Temporal
+import java.time.temporal.TemporalAmount
+import java.time.temporal.TemporalUnit
+import java.time.temporal.UnsupportedTemporalTypeException
+import java.util.Objects
+
+import scala.jdk.CollectionConverters._
+import scala.util.matching.Regex
+
+/**
+ * An implementation of a temporal duration compatible with ISO 8601
+ * durations that plays nicely with the Java time API.
+ */
+final class Duration private (
+  years: Long,
+  months: Long,
+  days: Long,
+  hours: Long,
+  minutes: Long,
+  seconds: Long
+) extends TemporalAmount {
+
+  // The set of units supported by this TemporalAmount.
+  //
+  // Units must be listed in order from longest to shortest.
+  private val units: List[TemporalUnit] = List(
+    ChronoUnit.YEARS,
+    ChronoUnit.MONTHS,
+    ChronoUnit.DAYS,
+    ChronoUnit.HOURS,
+    ChronoUnit.MINUTES,
+    ChronoUnit.SECONDS
+  )
+
+  override def addTo(temporal: Temporal): Temporal =
+    temporal
+      .plus(years, ChronoUnit.YEARS)
+      .plus(months, ChronoUnit.MONTHS)
+      .plus(days, ChronoUnit.DAYS)
+      .plus(hours, ChronoUnit.HOURS)
+      .plus(minutes, ChronoUnit.MINUTES)
+      .plus(seconds, ChronoUnit.SECONDS)
+
+  /**
+   * Compares Durations for equality.
+   *
+   * The comparison is not done by the length of the duration but by
+   * the number of each time unit the duration was constructed with.
+   * This is because we don't know the actual length of the duration
+   * without knowing when the duration is being applied. For instance,
+   * whether `P31D` and `P1M` are equal depends on which month we're
+   * talking about.
+   */
+  override def equals(x: Any): Boolean = x match {
+    case d: Duration => units.forall(u => get(u) == d.get(u))
+    case _ => false
+  }
+
+  override def get(unit: TemporalUnit): Long = unit match {
+    case ChronoUnit.YEARS => years
+    case ChronoUnit.MONTHS => months
+    case ChronoUnit.DAYS => days
+    case ChronoUnit.HOURS => hours
+    case ChronoUnit.MINUTES => minutes
+    case ChronoUnit.SECONDS => seconds
+    case _ => throw new UnsupportedTemporalTypeException(unit.toString())
+  }
+
+  override def getUnits(): java.util.List[TemporalUnit] = units.asJava
+
+  override def hashCode(): Int =
+    Objects.hash(years, months, days, hours, minutes, seconds)
+
+  override def subtractFrom(temporal: Temporal): Temporal =
+    temporal
+      .minus(years, ChronoUnit.YEARS)
+      .minus(months, ChronoUnit.MONTHS)
+      .minus(days, ChronoUnit.DAYS)
+      .minus(hours, ChronoUnit.HOURS)
+      .minus(minutes, ChronoUnit.MINUTES)
+      .minus(seconds, ChronoUnit.SECONDS)
+}
+
+object Duration {
+
+  // Inspired by https://rgxdb.com/r/MD2234J
+  //
+  // fromIsoString assumes only valid longs will be matched in the
+  // capture groups
+  private val regex: Regex =
+    """^P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$""".r
+
+  def fromIsoString(str: String): Either[LatisException, Duration] = {
+    // This assumes the regex will only match valid longs in the
+    // capture groups.
+    def longOrZero(m: Regex.Match, i: Int): Long =
+      Option(m.group(i)).map(_.toLong).getOrElse(0L)
+
+    regex.findFirstMatchIn(str).map { m =>
+      Duration.of(
+        longOrZero(m, 1),
+        longOrZero(m, 2),
+        longOrZero(m, 3),
+        longOrZero(m, 4),
+        longOrZero(m, 5),
+        longOrZero(m, 6)
+      )
+    }.toRight(LatisException(s"Failed to parse duration: $str"))
+  }
+
+  // This is private because changing methods with default arguments
+  // will lead to binary compatibility issues. I could see maybe
+  // adding milliseconds in the future.
+  private[util] def of(
+    years: Long = 0,
+    months: Long = 0,
+    days: Long = 0,
+    hours: Long = 0,
+    minutes: Long = 0,
+    seconds: Long = 0
+  ): Duration = new Duration(years, months, days, hours, minutes, seconds)
+}

--- a/core/src/test/scala/latis/input/GranuleListGeneratorSuite.scala
+++ b/core/src/test/scala/latis/input/GranuleListGeneratorSuite.scala
@@ -1,0 +1,164 @@
+package latis.input
+
+import java.net.URI
+import java.time.LocalDateTime
+
+import cats.syntax.all._
+
+import latis.data.DomainData
+import latis.data.RangeData
+import latis.data.Sample
+import latis.input.GranuleListGenerator.Config
+import latis.metadata.Metadata
+import latis.model.DataType
+import latis.model.Function
+import latis.model.Scalar
+import latis.model.StringValueType
+import latis.time.Time
+import latis.util.Duration
+import latis.util.Identifier._
+
+class GranuleListGeneratorSuite extends munit.CatsEffectSuite {
+
+  test("generate a list of granules") {
+    val adapter = {
+      val config = Config(
+        LocalDateTime.of(2022, 1, 1, 0, 0, 0),
+        LocalDateTime.of(2022, 1, 4, 0, 0, 0),
+        Duration.fromIsoString("P1D").getOrElse(
+          fail("Failed to construct Duration")
+        ),
+        "/%1$tY/%1$tm/%1$td/file-%1$tY-%1$tm-%1$td.ext"
+      )
+
+      val model: DataType = (
+        Time.fromMetadata(
+          Metadata(
+            "id" -> "time",
+            "type" -> "string",
+            "units" -> "yyyy-MM-dd"
+          )
+        ),
+        Scalar(id"uri", StringValueType).asRight
+      ).flatMapN(Function.from).fold(
+        err => fail("Failed to construct Function", clues(err)),
+        identity
+      )
+
+      new GranuleListGenerator(model, config)
+    }
+
+    val expected = List(
+      Sample(DomainData("2022-01-01T00:00:00.000Z"), RangeData("https://host/2022/01/01/file-2022-01-01.ext")),
+      Sample(DomainData("2022-01-02T00:00:00.000Z"), RangeData("https://host/2022/01/02/file-2022-01-02.ext")),
+      Sample(DomainData("2022-01-03T00:00:00.000Z"), RangeData("https://host/2022/01/03/file-2022-01-03.ext")),
+      Sample(DomainData("2022-01-04T00:00:00.000Z"), RangeData("https://host/2022/01/04/file-2022-01-04.ext"))
+    )
+
+    adapter
+      .getData(new URI("https://host"))
+      .samples
+      .compile
+      .toList
+      .assertEquals(expected)
+  }
+
+  test("config: build config from ConfigLike") {
+    val conf = Config.fromConfigLike(
+      AdapterConfig(
+        "class" -> "",
+        "start" -> "2022-01-02T03:04:05",
+        "end" -> "2023-05-04T03:02:01",
+        "step" -> "P1D",
+        "pattern" -> "%1$tY-%1$tm-%1$td"
+      )
+    )
+
+    val expected = Config(
+      LocalDateTime.of(2022, 1, 2, 3, 4, 5),
+      LocalDateTime.of(2023, 5, 4, 3, 2, 1),
+      Duration.fromIsoString("P1D").getOrElse(
+        fail("Failed to construct Duration")
+      ),
+      "%1$tY-%1$tm-%1$td"
+    )
+
+    assertEquals(conf, expected.asRight)
+  }
+
+  test("config: end time is optional") {
+    val now = LocalDateTime.of(2022, 1, 3, 0, 0, 0)
+
+    val conf = Config.fromConfigLike(
+      now,
+      AdapterConfig(
+        "class" -> "",
+        "start" -> "2022-01-02T03:04:05",
+        "step" -> "P1D",
+        "pattern" -> "%1$tY-%1$tm-%1$td"
+      )
+    )
+
+    val expected = Config(
+      LocalDateTime.of(2022, 1, 2, 3, 4, 5),
+      now,
+      Duration.fromIsoString("P1D").getOrElse(
+        fail("Failed to construct Duration")
+      ),
+      "%1$tY-%1$tm-%1$td"
+    )
+
+    assertEquals(conf, expected.asRight)
+  }
+
+  test("config: start time is required") {
+    val conf = Config.fromConfigLike(
+      AdapterConfig(
+        "class" -> "",
+        "step" -> "P1D",
+        "pattern" -> "%1$tY-%1$tm-%1$td"
+      )
+    )
+
+    assert(conf.isLeft)
+  }
+
+  test("config: step is required") {
+    val conf = Config.fromConfigLike(
+      AdapterConfig(
+        "class" -> "",
+        "start" -> "2022-01-02T03:04:05",
+        "pattern" -> "%1$tY-%1$tm-%1$td"
+      )
+    )
+
+    assert(conf.isLeft)
+  }
+
+  test("config: pattern is required") {
+    val conf = Config.fromConfigLike(
+      AdapterConfig(
+        "class" -> "",
+        "start" -> "2022-01-02T03:04:05",
+        "step" -> "P1D"
+      )
+    )
+
+    assert(conf.isLeft)
+  }
+
+  test("config: require end > start") {
+    val conf = Config.fromConfigLike(
+      AdapterConfig(
+        "class" -> "",
+        "start" -> "2022-01-02",
+        "end" -> "2022-01-01",
+        "step" -> "P1D",
+        "pattern" -> "%1$tY-%1$tm-%1$td"
+      )
+    )
+
+    assert(conf.isLeft)
+  }
+}
+

--- a/core/src/test/scala/latis/util/DurationSuite.scala
+++ b/core/src/test/scala/latis/util/DurationSuite.scala
@@ -1,0 +1,137 @@
+package latis.util
+
+import java.time.LocalDateTime
+
+import cats.syntax.all._
+
+class DurationSuite extends munit.FunSuite {
+
+  test("add a year") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).plus(Duration.of(years = 1)),
+      LocalDateTime.of(2023, 1, 1, 0, 0, 0)
+    )
+  }
+
+  test("add a month") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).plus(Duration.of(months = 1)),
+      LocalDateTime.of(2022, 2, 1, 0, 0, 0)
+    )
+  }
+
+  test("add a day") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).plus(Duration.of(days = 1)),
+      LocalDateTime.of(2022, 1, 2, 0, 0, 0)
+    )
+  }
+
+  test("add an hour") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).plus(Duration.of(hours = 1)),
+      LocalDateTime.of(2022, 1, 1, 1, 0, 0)
+    )
+  }
+
+  test("add a minute") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).plus(Duration.of(minutes = 1)),
+      LocalDateTime.of(2022, 1, 1, 0, 1, 0)
+    )
+  }
+
+  test("add a second") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).plus(Duration.of(seconds = 1)),
+      LocalDateTime.of(2022, 1, 1, 0, 0, 1)
+    )
+  }
+
+  test("subtract a year") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).minus(Duration.of(years = 1)),
+      LocalDateTime.of(2021, 1, 1, 0, 0, 0)
+    )
+  }
+
+  test("subtract a month") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).minus(Duration.of(months = 1)),
+      LocalDateTime.of(2021, 12, 1, 0, 0, 0)
+    )
+  }
+
+  test("subtract a day") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).minus(Duration.of(days = 1)),
+      LocalDateTime.of(2021, 12, 31, 0, 0, 0)
+    )
+  }
+
+  test("subtract an hour") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).minus(Duration.of(hours = 1)),
+      LocalDateTime.of(2021, 12, 31, 23, 0, 0)
+    )
+  }
+
+  test("subtract a minute") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).minus(Duration.of(minutes = 1)),
+      LocalDateTime.of(2021, 12, 31, 23, 59, 0)
+    )
+  }
+
+  test("subtract a second") {
+    assertEquals(
+      LocalDateTime.of(2022, 1, 1, 0, 0, 0).minus(Duration.of(seconds = 1)),
+      LocalDateTime.of(2021, 12, 31, 23, 59, 59)
+    )
+  }
+
+  test("construct from an ISO duration") {
+    assertEquals(
+      Duration.fromIsoString("P1Y2M3DT4H5M6S"),
+      Duration.of(1, 2, 3, 4, 5, 6).asRight
+    )
+    assertEquals(
+      Duration.fromIsoString("P1DT5S"),
+      Duration.of(days = 1, seconds = 5).asRight
+    )
+  }
+
+  test("construct from an ISO duration without T segment") {
+    assertEquals(
+      Duration.fromIsoString("P3Y2M1D"),
+      Duration.of(3, 2, 1, 0, 0, 0).asRight
+    )
+    assertEquals(
+      Duration.fromIsoString("P1D"),
+      Duration.of(days = 1).asRight
+    )
+  }
+
+  test("construct from an ISO duration with only T segment") {
+    assertEquals(
+      Duration.fromIsoString("PT1H2M3S"),
+      Duration.of(0, 0, 0, 1, 2, 3).asRight
+    )
+    assertEquals(
+      Duration.fromIsoString("PT30M"),
+      Duration.of(minutes = 30).asRight
+    )
+  }
+
+  test("reject invalid ISO durations") {
+    // Some duration is required
+    assert(Duration.fromIsoString("").isLeft)
+    assert(Duration.fromIsoString("P").isLeft)
+    assert(Duration.fromIsoString("PT").isLeft)
+
+    // Must be in descending order
+    assert(Duration.fromIsoString("P1D2M").isLeft)
+    assert(Duration.fromIsoString("PT1S2M").isLeft)
+  }
+}
+


### PR DESCRIPTION
This PR adds:

- `latis.util.Duration`, which implements ISO 8601 durations as a subclass of [`java.time.TemporalAmount`](https://docs.oracle.com/javase/8/docs/api/java/time/temporal/TemporalAmount.html) so we can use it with [`LocalDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html) to generate our times.
  - `java.time` already defines [`Period`](https://docs.oracle.com/javase/8/docs/api/java/time/Period.html) and [`Duration`](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html), but each captures only a subset of what's supported by ISO 8601 durations. (I wonder if there is a good reason for this.) Rather than try to use both, it was more straightforward to implement our own.
  - The `fromIsoString` constructor will parse an ISO 8601 duration string using a regular expression. The most significant caveats that I'm aware of are that we don't support negative or fractional durations.
- ~`latis.util.IsoDurationParser`, which parses an ISO 8601 duration string into a `latis.util.Duration`.~
  - ~I only had the Wikipedia description of the spec to go on. The most significant caveats that I'm aware of are that we don't support negative or fractional durations.~
- `latis.input.GranuleListGenerator`, which will generate datasets of the form `time -> uri` given a `start`, `end` (optional, defaults to now), a `step`, and a `pattern`. It supports durations that aren't constant length, like `P1M`.
  - A caveat: I add the duration to each time to get the next one. That means that if you were to use a duration like `P1M` and start at the end of a month, you will eventually switch days when you hit a month that has fewer days than the one you started on. For instance, if you start on `2022-01-31`, the next times will be `2022-02-28` and `2022-03-28`. This is a limitation of the `java.time` API, but I could imagine adding our own methods to `Duration` for multiplying the duration and then creating a stream like `t0 + d, t0 + 2d, t0 + 3d...` rather than `t0 + d, t0 + d + d, t0 + d + d + d` (which, while normally the same, is different in this case).