### PR TITLE
Log after response has been streamed

### DIFF
--- a/server/src/main/scala/latis/server/LatisServiceLogger.scala
+++ b/server/src/main/scala/latis/server/LatisServiceLogger.scala
@@ -15,9 +15,9 @@ import org.http4s.server.middleware.{Logger => Http4sLogger}
 import org.typelevel.log4cats.StructuredLogger
 
 /**
- * Middleware that logs requests and responses (without bodies) and
- * the time elapsed between receiving the request and finishing the
- * response.
+ * Middleware that logs requests and responses (without bodies), time
+ * elapsed between receiving the request and finishing the response,
+ * and exceptions thrown during the response.
  */
 object LatisServiceLogger {
 
@@ -39,7 +39,11 @@ object LatisServiceLogger {
           ctxLogger.info(s"Elapsed (ms): ${elapsed.toMillis}")
         }
       }
-      res2      = res.copy(body = timedBody)
+      errBody   = timedBody.handleErrorWith { err =>
+        Stream.exec(ctxLogger.error(err)("Exception thrown during response")) ++
+        Stream.raiseError(err)
+      }
+      res2      = res.copy(body = errBody)
       _        <- Http4sLogger.logMessage[F, Response[F]](res2)(
         logHeaders = true, logBody = false
       )(ctxLogger.info(_))


### PR DESCRIPTION
- Elapsed time logged for a request will include the time it took to send the entire response, not just the headers.
- Exceptions thrown while sending the response will be logged.