### PR TITLE
Use def to get predicate

### DIFF
--- a/core/src/main/scala/latis/ops/Stride.scala
+++ b/core/src/main/scala/latis/ops/Stride.scala
@@ -19,7 +19,7 @@ case class Stride(stride: Seq[Int]) extends StreamOperation {
   def pipe(model: DataType): Pipe[IO, Sample, Sample] =
     (stream: Stream[IO, Sample]) => stream.filter(predicate)
 
-  private val predicate: Sample => Boolean = {
+  private def predicate: Sample => Boolean = {
     var count = -1
     (_: Sample) => {
       count = count + 1


### PR DESCRIPTION
In the case of a GranuleAppendDataset with a stride processing instruction, I am seeing two concurrent applications of the same operation yielding no results. This change ensures that each invocation has its own counter. This is a quick fix until we identify the rogue application.