### PR TITLE
Apply data operations with the initial granule model

### DIFF
--- a/core/src/main/scala/latis/dataset/CompositeDataset.scala
+++ b/core/src/main/scala/latis/dataset/CompositeDataset.scala
@@ -92,7 +92,7 @@ class CompositeDataset private (
       (dat, ds) => joinOperation.applyToData(dat, StreamFunction(ds.samples))
     }
     // Apply other operations
-    newData <- afterOps.foldM((model, data)) {
+    newData <- afterOps.foldM((dss.head.model, data)) {
       case ((mod, dat), op) =>
         (op.applyToModel(mod), op.applyToData(dat, mod)).mapN((_, _))
     }.map(_._2) //drop model, keep data


### PR DESCRIPTION
The data operation application was starting with the final transformed model. Thus when applying a time conversion to string values, it already though that the time was of the converted type.

This assumes that all granules have the same model (also that of the final result) so we can start with the first granule's model.

One of these days I want to redesign operations.