### PR TITLE
Remove dependency on scalacheck-shapeless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,8 +129,7 @@ lazy val `dap2-parser` = project
   .settings(
     name := "dap2-parser",
     libraryDependencies ++= Seq(
-      "org.tpolecat"   %% "atto-core"  % attoVersion,
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0" % Test
+      "org.tpolecat"   %% "atto-core"  % attoVersion
     )
   )
 

--- a/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
+++ b/dap2-parser/src/test/scala/latis/util/dap2/parser/ConstraintParserProps.scala
@@ -1,7 +1,6 @@
 package latis.util.dap2.parser
 
 import org.scalacheck._
-import org.scalacheck.ScalacheckShapeless._
 
 import latis.util.Identifier
 
@@ -30,7 +29,7 @@ object ConstraintParserProps extends Properties("DAP 2 Constraint Parser") {
   } yield init.asString + rest
 
   val operator: Gen[SelectionOp] =
-    implicitly[Arbitrary[SelectionOp]].arbitrary
+    Gen.oneOf(Gt, Lt, Eq, GtEq, LtEq, EqEq, NeEq, Tilde, EqTilde, NeEqTilde)
 
   val sign: Gen[String] = Gen.oneOf("+", "-", "")
 


### PR DESCRIPTION
This dependency keeps us from cross-building for Scala 3 and doesn't add much anyway.