### PR TITLE
Replace hand-written macro with literally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,9 +200,9 @@ lazy val macros = project
   .settings(
     name := "latis3-macros",
     libraryDependencies ++= Seq(
+      "org.typelevel" %% "literally" % "1.1.0",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
-    ),
-    scalacOptions += "-language:experimental.macros"
+    )
   )
 
 lazy val netcdf = project

--- a/macros/src/main/scala/latis/util/identifier.scala
+++ b/macros/src/main/scala/latis/util/identifier.scala
@@ -1,6 +1,6 @@
 package latis.util
 
-import scala.reflect.macros.blackbox.Context
+import org.typelevel.literally.Literally
 
 /**
  * Defines a LaTiS identifier, a name that may contain only:
@@ -13,24 +13,29 @@ import scala.reflect.macros.blackbox.Context
 sealed abstract case class Identifier(asString: String)
 object Identifier {
   def fromString(id: String): Option[Identifier] =
-    if (checkValidIdentifier(id)) Some(new Identifier(id) {}) else None
+    if (isValidIdentifier(id)) Some(new Identifier(id) {}) else None
 
   implicit class IdentifierStringContext(val sc: StringContext) extends AnyVal {
-    def id(): Identifier = macro literalMacro
+    def id(args: Any*): Identifier = macro IdentifierLiteral.make
   }
 
-  /** Returns whether the String is a regex "word" that doesn't start with a digit (may also contain dots). */
-  private def checkValidIdentifier(str: String): Boolean = str.matches("^(?!\\d)(\\w|\\.)+") //TODO: revert to "^(?!\\d)\\w+"
+  /**
+   * Returns whether the String is a regex "word" that doesn't start
+   * with a digit (may also contain dots).
+   */
+  private[util] def isValidIdentifier(str: String): Boolean =
+    str.matches("^(?!\\d)(\\w|\\.)+") //TODO: revert to "^(?!\\d)\\w+"
+}
 
-  def literalMacro(c: Context)(): c.Expr[Identifier] = {
+object IdentifierLiteral extends Literally[Identifier] {
+  override def validate(c: Context)(s: String): Either[String, c.Expr[Identifier]] = {
     import c.universe._
-
-    val idExpr: Expr[String] = c.prefix.tree match {
-      case Apply(_, Apply(_, List(id @ Literal(Constant(s: String)))) :: Nil)
-          if checkValidIdentifier(s) => c.Expr(id)
-      case _ => c.abort(c.enclosingPosition, "not a valid LaTiS identifier")
-    }
-
-    reify(Identifier.fromString(idExpr.splice).get)
+    Either.cond(
+      Identifier.isValidIdentifier(s),
+      c.Expr(q"_root_.latis.util.Identifier.fromString($s).get"),
+      "not a valid LaTiS identifier"
+    )
   }
+
+  def make(c: Context)(args: c.Expr[Any]*): c.Expr[Identifier] = apply(c)(args: _*)
 }


### PR DESCRIPTION
This replaces our hand-written macro for `Identifier` literals with one made using [`literally`](https://github.com/typelevel/literally).

We will still need to write another version for Scala 3, but `literally` will handle some of that complexity for us.