### PR TITLE
Construct composite dataset with metadata

### DIFF
--- a/core/src/main/scala/latis/dataset/CompositeDataset.scala
+++ b/core/src/main/scala/latis/dataset/CompositeDataset.scala
@@ -9,7 +9,6 @@ import latis.data._
 import latis.metadata.Metadata
 import latis.model.DataType
 import latis.ops._
-import latis.util.Identifier
 import latis.util.LatisException
 
 /**
@@ -19,7 +18,7 @@ import latis.util.LatisException
  * This assumes that each dataset has the same model, for now.
  */
 class CompositeDataset private (
-  dsIdentifier: Identifier,
+  md: Metadata,
   datasets: NonEmptyList[Dataset],
   joinOperation: Join,
   granuleOps: List[UnaryOperation] = List.empty, //ops to be applied to granules before the join
@@ -28,7 +27,7 @@ class CompositeDataset private (
   //TODO: support "horizontal" joins: datasets with different models (i.e. diff set of variables, combine "columns")
 
   //TODO: make richer metadata, prov
-  override def metadata: Metadata = Metadata(dsIdentifier)
+  override def metadata: Metadata = md
 
   /**
    * Returns a new Dataset with the given Operation *logically*
@@ -49,19 +48,19 @@ class CompositeDataset private (
   }
 
   private def copyWithOperationForGranule(op: UnaryOperation): CompositeDataset =
-    new CompositeDataset(dsIdentifier, datasets, joinOperation,
+    new CompositeDataset(md, datasets, joinOperation,
       granuleOps :+ op,
       afterOps
     )
 
   private def copyWithOperationAfterJoin(op: UnaryOperation): CompositeDataset =
-    new CompositeDataset(dsIdentifier, datasets, joinOperation,
+    new CompositeDataset(md, datasets, joinOperation,
       granuleOps,
       afterOps :+ op
     )
 
   private def copyWithOperationForBoth(op: UnaryOperation): CompositeDataset =
-    new CompositeDataset(dsIdentifier, datasets, joinOperation,
+    new CompositeDataset(md, datasets, joinOperation,
       granuleOps :+ op,
       afterOps :+ op
     )
@@ -124,12 +123,12 @@ object CompositeDataset {
    * to be applied to at least two datasets.
    */
   def apply(
-    id: Identifier,
+    md: Metadata,
     joinOperation: Join,
     ds1: Dataset,
     ds2: Dataset,
     rest: List[Dataset] = List.empty
   ): CompositeDataset =
-    new CompositeDataset(id, NonEmptyList.of(ds1, (ds2 :: rest): _*), joinOperation)
+    new CompositeDataset(md, NonEmptyList.of(ds1, (ds2 :: rest): _*), joinOperation)
 
 }

--- a/core/src/main/scala/latis/dataset/GranuleAppendDataset.scala
+++ b/core/src/main/scala/latis/dataset/GranuleAppendDataset.scala
@@ -11,7 +11,6 @@ import latis.input.Adapter
 import latis.metadata.Metadata
 import latis.model._
 import latis.ops._
-import latis.util.Identifier
 import latis.util.Identifier._
 import latis.util.dap2.parser.ast
 import latis.util.LatisException
@@ -48,7 +47,7 @@ import latis.util.LatisException
  * properties of operations that precede it.
  */
 class GranuleAppendDataset private (
-  dsIdentifier: Identifier,
+  md: Metadata,
   granuleList: Dataset,
   granuleModel: DataType,
   granuleToDataset: Sample => Dataset,
@@ -56,7 +55,7 @@ class GranuleAppendDataset private (
   operations: List[UnaryOperation] = List.empty
 ) extends Dataset {
 
-  def metadata: Metadata = Metadata(dsIdentifier) //TODO: add prov, see AbstractDataset
+  def metadata: Metadata = md //TODO: add prov, see AbstractDataset
 
   def model: DataType = operations.foldLeft(granuleModel)((mod, op) => op.applyToModel(mod).fold(throw _, identity))
 
@@ -64,7 +63,7 @@ class GranuleAppendDataset private (
    * Combines a List of granule Datasets into a single Dataset.
    */
   private def makeDataset(granules: List[Dataset]): Dataset = granules match {
-    case ds1 :: ds2 :: dss => CompositeDataset(dsIdentifier, Append(), ds1, ds2, dss)
+    case ds1 :: ds2 :: dss => CompositeDataset(md, Append(), ds1, ds2, dss)
     case ds :: Nil         => ds //just one granule, TODO: rename it with dsIdentifier?
     case Nil               => new TappedDataset(metadata, granuleModel, SeqFunction(Seq.empty)) //empty dataset
   }
@@ -154,7 +153,7 @@ class GranuleAppendDataset private (
         case _ => op
       }
       new GranuleAppendDataset(
-        dsIdentifier,
+        md,
         granuleList,
         granuleModel,
         granuleToDataset,
@@ -163,7 +162,7 @@ class GranuleAppendDataset private (
       )
     } else {
       new GranuleAppendDataset(
-        dsIdentifier,
+        md,
         granuleList,
         granuleModel,
         granuleToDataset,
@@ -179,12 +178,12 @@ class GranuleAppendDataset private (
 object GranuleAppendDataset {
 
   def apply(
-    id: Identifier,
+    md: Metadata,
     granuleList: Dataset,
     model: DataType,
     granuleToDataset: Sample => Dataset
   ): GranuleAppendDataset = new GranuleAppendDataset(
-    id,
+    md,
     granuleList,
     model,
     granuleToDataset
@@ -200,7 +199,7 @@ object GranuleAppendDataset {
    * Dataset and invoke the Adapter to generate Data for that granule.
    */
   def withAdapter(
-    id: Identifier,
+    md: Metadata,
     granuleList: Dataset,
     model: DataType,
     adapter: Adapter,
@@ -217,12 +216,12 @@ object GranuleAppendDataset {
       val granuleToDataset: Sample => Dataset = (sample: Sample) =>
         sample.getValue(pos) match {
           case Some(Text(u)) =>
-            val md = Metadata(id) //TODO: generate unique granule id?
+            //TODO: generate unique granule id?
             val uri = new URI(u) //may throw URISyntaxException
             new AdaptedDataset(md, model, adapter, uri)
           case _ => throw LatisException("Invalid Sample") //TODO: log warning
         }
-      GranuleAppendDataset(id, granuleList, model, granuleToDataset).withOperations(ops)
+      GranuleAppendDataset(md, granuleList, model, granuleToDataset).withOperations(ops)
     }
 
 }

--- a/core/src/main/scala/latis/input/fdml/FdmlReader.scala
+++ b/core/src/main/scala/latis/input/fdml/FdmlReader.scala
@@ -48,20 +48,12 @@ object FdmlReader {
   private def readGranuleAppendFdml(
     fdml: GranuleAppendFdml
   ): Either[LatisException, Dataset] = for {
-    sid        <- Either.fromOption(
-      fdml.metadata.getProperty("id"),
-      LatisException("Missing identifier")
-    )
-    id         <- Either.fromOption(
-      Identifier.fromString(sid),
-      LatisException(s"Invalid identifier: $sid")
-    )
     granules   <- readDatasetFdml(fdml.source.fdml)
     model      <- makeFunction(fdml.model)
     adapter    <- makeAdapter(fdml.adapter, model)
     operations <- fdml.operations.traverse(makeOperation)
     dataset    <- GranuleAppendDataset.withAdapter(
-                    id,
+                    fdml.metadata,
                     granules,
                     model,
                     adapter,

--- a/core/src/test/scala/latis/dataset/CompositeDatasetSuite.scala
+++ b/core/src/test/scala/latis/dataset/CompositeDatasetSuite.scala
@@ -2,8 +2,6 @@ package latis.dataset
 
 import munit.CatsEffectSuite
 
-import latis.data.Data._
-import latis.data.Sample
 import latis.data._
 import latis.dsl._
 import latis.metadata.Metadata
@@ -48,7 +46,7 @@ class CompositeDatasetSuite extends CatsEffectSuite {
     new MemoizedDataset(metadata, model, data)
   }
 
-  private lazy val compDs = CompositeDataset(id"test", Append(), ds1, ds2)
+  private lazy val compDs = CompositeDataset(Metadata(id"test"), Append(), ds1, ds2)
 
   test("provide a composite model") {
     compDs.model match {

--- a/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
+++ b/core/src/test/scala/latis/dataset/GranuleAppendDatasetSuite.scala
@@ -65,7 +65,7 @@ class GranuleAppendDatasetSuite extends AnyFunSuite {
   }
 
   private lazy val dataset = GranuleAppendDataset(
-    id"myDataset",
+    Metadata(id"myDataset"),
     granuleList,
     model,
     granuleToDataset
@@ -261,7 +261,7 @@ class GranuleAppendDatasetSuite extends AnyFunSuite {
         if (cnt == 1) throw new RuntimeException("Boom")
         else granuleToDataset(sample)
     }
-    val ds = GranuleAppendDataset(id"myDataset", granuleList, model, f)
+    val ds = GranuleAppendDataset(Metadata(id"myDataset"), granuleList, model, f)
     ds.samples.compile.toList.map { ss =>
       assert(4 == ss.length)
     }.unsafeRunSync()
@@ -281,7 +281,7 @@ class GranuleAppendDatasetSuite extends AnyFunSuite {
         ))
       }
     }
-    val ds = GranuleAppendDataset.withAdapter(id"myDataset", granuleList, model, adapter).value
+    val ds = GranuleAppendDataset.withAdapter(Metadata(id"myDataset"), granuleList, model, adapter).value
     ds.samples.compile.toList.map { ss =>
       assert(6 == ss.length)
     }.unsafeRunSync()


### PR DESCRIPTION
This was preventing us from using the `temporalCoverage` in the fdml for `GranuleAppendDataset`s.
And it just makes sense to empower the dataset creator with metadata beyond the identifier.