### PR TITLE
Use fs2 Path for NetcdfEncoder

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -6,7 +6,6 @@ import cats.effect._
 import cats.syntax.all._
 import fs2.Stream
 import fs2.io.file.Files
-import fs2.io.file.{Path => FPath}
 import fs2.text
 import org.http4s.Header.Raw
 import org.http4s.Headers
@@ -166,8 +165,8 @@ class Dap2Service(catalog: Catalog) extends ServiceInterface(catalog) with Http4
     case "nc"    =>
       (for {
         tmpFile <- Stream.resource(Files[IO].tempFile)
-        file    <- new NetcdfEncoder(tmpFile.toNioPath.toFile()).encode(ds)
-        bytes   <- Files[IO].readAll(FPath.fromNioPath(file.toPath()))
+        file    <- new NetcdfEncoder(tmpFile).encode(ds)
+        bytes   <- Files[IO].readAll(file)
       } yield bytes).asRight.map((_, Headers(Raw(ci"Content-Type", "application/x-netcdf"))))
     case "txt"   => CsvEncoder().encode(ds).through(text.utf8.encode).asRight
       .map((_, Headers(Raw(ci"Content-Type", "text/plain"))))

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -1,11 +1,10 @@
 package latis.output
 
-import java.io.File
-
 import cats.effect.IO
 import cats.effect.Resource
 import cats.syntax.all._
 import fs2.Stream
+import fs2.io.file.Path
 import ucar.ma2.{Array => NcArray}
 import ucar.ma2.{DataType => NcDataType}
 import ucar.nc2.Attribute
@@ -39,10 +38,10 @@ import latis.util.LatisException
  *
  * @param file location to write to.
  */
-class NetcdfEncoder(file: File) extends Encoder[IO, File] {
+class NetcdfEncoder(file: Path) extends Encoder[IO, Path] {
   //TODO: deal with NullData, require replaceMissing?
   import NetcdfEncoder._
-  private val path = file.getAbsolutePath
+  private val path = file.absolute.toString
   private val ncFileWriter: Resource[IO, NetcdfFileWriter] =
     Resource.fromAutoCloseable(IO(NetcdfFileWriter.createNew(netcdf4, path)))
 
@@ -50,7 +49,7 @@ class NetcdfEncoder(file: File) extends Encoder[IO, File] {
    * Encodes a [[latis.dataset.Dataset]] to netCDF4
    * @param dataset dataset to encode
    */
-  override def encode(dataset: Dataset): Stream[IO, File] = {
+  override def encode(dataset: Dataset): Stream[IO, Path] = {
     val uncurriedDataset = dataset.withOperation(Uncurry())
     Stream
       .resource(ncFileWriter)
@@ -119,7 +118,7 @@ class NetcdfEncoder(file: File) extends Encoder[IO, File] {
 }
 
 object NetcdfEncoder {
-  def apply(file: File): NetcdfEncoder =
+  def apply(file: Path): NetcdfEncoder =
     new NetcdfEncoder(file)
 
   private type Accumulator = List[Any]

--- a/netcdf/src/test/scala/latis/input/NetcdfWrapperSuite.scala
+++ b/netcdf/src/test/scala/latis/input/NetcdfWrapperSuite.scala
@@ -63,9 +63,9 @@ class NetcdfWrapperSuite extends CatsEffectSuite {
   override def beforeAll(): Unit = {
     (for {
       path <- Files[IO].tempFile(None, "netcdf_test", ".nc", None)
-      enc   = NetcdfEncoder(path.toNioPath.toFile)
+      enc   = NetcdfEncoder(path)
       file <- Resource.eval(enc.encode(dataset).compile.toList.map(_.head))
-      nc   <- NetcdfWrapper.open(file.toURI, dataset.model, config)
+      nc   <- NetcdfWrapper.open(file.toNioPath.toUri(), dataset.model, config)
     } yield nc).allocated.map { case (nc, io) =>
       ncWapper = nc
       finalizer = io


### PR DESCRIPTION
My original goal was to remove NIO stuff from `Dap2Service`, but that meant making `NetcdfEncoder` using `fs2` `Path`s.