### PR TITLE
Add support for customizing generated SQL based on database vendor

### DIFF
--- a/jdbc/src/main/scala/latis/util/SqlBuilder.scala
+++ b/jdbc/src/main/scala/latis/util/SqlBuilder.scala
@@ -105,12 +105,15 @@ case class SqlBuilder(
       case list => list.mkString(" WHERE ", " AND ", "")
     }
 
-    //TODO: support other databases
-    //  This works for oracle and h2
-    //  PostgreSQL and others use "limit n"
-    val lim = limit.map(n => s" FETCH FIRST $n ROWS ONLY").getOrElse("")
+    // TODO: More complete support for different databases.
+    val lim = vendor match {
+      case Some("SQLite") =>
+        limit.map(n => s" LIMIT $n")
+      case _ =>
+        limit.map(n => s" FETCH FIRST $n ROWS ONLY")
+    }
 
-    select + from + where + order + lim
+    select + from + where + order + lim.getOrElse("")
   }
 }
 

--- a/jdbc/src/main/scala/latis/util/SqlBuilder.scala
+++ b/jdbc/src/main/scala/latis/util/SqlBuilder.scala
@@ -13,7 +13,8 @@ case class SqlBuilder(
   otherPredicate: Option[String],
   limit: Option[Int],
   model: DataType,
-  order: String
+  order: String,
+  vendor: Option[String]
 ) {
 
   def addOp(op: UnaryOperation): SqlBuilder = op match {
@@ -119,7 +120,8 @@ object SqlBuilder {
     table: String, //TODO: use model ID?
     model: DataType,
     ops: List[UnaryOperation] = List.empty,
-    otherPredicate: Option[String] = None
+    otherPredicate: Option[String] = None,
+    vendor: Option[String] = None
   ): String = {
     // Order by domain variables even if not projected.
     // We must do it here before they are projected away.
@@ -140,7 +142,8 @@ object SqlBuilder {
       otherPredicate = otherPredicate,
       limit = None,
       model = model,
-      order = order
+      order = order,
+      vendor = vendor
     )
 
     ops.foldLeft(init)((b, op) => b.addOp(op)).result

--- a/jdbc/src/test/scala/latis/util/SqlBuilderSuite.scala
+++ b/jdbc/src/test/scala/latis/util/SqlBuilderSuite.scala
@@ -127,7 +127,7 @@ class SqlBuilderSuite extends FunSuite {
   test("no limit") {
     val ops = List()
     val sql = SqlBuilder.buildQuery(table, model, ops)
-    assert(!sql.contains("FETCH"))
+    assert(!sql.contains("FETCH") && !sql.contains("LIMIT"))
   }
 
   test("limit with take") {
@@ -158,5 +158,11 @@ class SqlBuilderSuite extends FunSuite {
     val ops = List(Take(0), Head())
     val sql = SqlBuilder.buildQuery(table, model, ops)
     assert(sql.contains("0 ROWS")) //yes, oracle does allow this
+  }
+
+  test("limit with LIMIT") {
+    val ops = List(Head())
+    val sql = SqlBuilder.buildQuery(table, model, ops, vendor = Option("SQLite"))
+    assert(sql.contains("LIMIT 1"))
   }
 }


### PR DESCRIPTION
This PR adds initial support for customizing SQL based on database vendor. It uses JDBC's mechanism to get the database product name/vendor and provides it to the SQL builder. I used this to generate a `LIMIT` clause instead of a `FETCH FIRST` clause for SQLite.

This is just a first attempt to support caching with SQLite. I think it would be a good idea to think about the databases we want to confidently support, make sure we understand the differences we need to account for, and encode that more formally in the SQL builder.