### PR TITLE
Properly encode CSV output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,8 @@ lazy val core = project
       "org.scodec"             %% "scodec-core"         % "1.11.10",
       "org.scodec"             %% "scodec-stream"       % "3.0.2",
       "org.scodec"             %% "scodec-cats"         % "1.2.0",
-      "org.http4s"             %% "http4s-ember-client" % http4sVersion
+      "org.http4s"             %% "http4s-ember-client" % http4sVersion,
+      "org.gnieh"              %% "fs2-data-csv"        % "1.7.0"
     )
   )
 

--- a/core/src/main/scala/latis/output/CsvEncoder.scala
+++ b/core/src/main/scala/latis/output/CsvEncoder.scala
@@ -50,8 +50,8 @@ class CsvEncoder(header: Dataset => Stream[IO, String]) extends Encoder[IO, Stri
   private def sampleEncoder(scalars: NonEmptyList[Scalar]): RowEncoder[Sample] =
     new RowEncoder[Sample] {
       override def apply(sample: Sample): Row = {
-        // NOTE: Assuming there are the same number of samples as
-        // scalars and that there is more than one scalar.
+        // NOTE: Assuming there are the same number of sample elements
+        // as scalars and that there is more than one scalar.
         val values = scalars.toList.zip(sample.domain ++ sample.range).map {
           case (s, d) => s.formatValue(d)
         }


### PR DESCRIPTION
Properly encodes commas, double quotes, and CRLFs in CSV output by switching to `fs2-data-csv` for encoding.