### PR TITLE
Make ConvertBinary accept NullData

### DIFF
--- a/core/src/main/scala/latis/ops/ConvertBinary.scala
+++ b/core/src/main/scala/latis/ops/ConvertBinary.scala
@@ -39,6 +39,7 @@ case class ConvertBinary(id: Identifier, base: Base) extends MapOperation {
     }
     (sample: Sample) => sample.getValue(pos) match {
       case Some(b: Data.BinaryValue) => sample.updatedValue(pos, convert(b.value))
+      case Some(NullData) => sample
       case _ => throw LatisException("Target variable must be Binary")
     }
   }


### PR DESCRIPTION
This makes `ConvertBinary` accept `NullData` by passing the sample through unchanged.

We could instead replace the `NullData` with an empty string so it doesn't print anything. Thoughts?