### PR TITLE
Support unsigned netCDF types

### DIFF
--- a/netcdf/README.md
+++ b/netcdf/README.md
@@ -1,0 +1,14 @@
+# latis3-netcdf
+
+The latis3-netcdf subproject provides support for reading and writing netCDF files using the NetCDF-Java library (https://docs.unidata.ucar.edu/netcdf-java/current/userguide/). As such, this also supports reading HDF and other formats supported by NetCDF-Java.
+
+## Data Types
+
+The NetcdfAdapter tries to validate that the model (e.g. from fdml) matches the contents of the netCDF file. It is strict in the matching of scalar data types. Most are an obvious mapping to the netCDF data types (https://docs.unidata.ucar.edu/netcdf-java/current/javadoc/ucar/ma2/DataType.html). The unsigned integer types must be expressed using the next larger type:
+
+    UBYTE  -> short
+    USHORT -> int
+    UINT   -> long
+    ULONG  -> double
+
+`ENUM`, `OPAQUE`, `SEQUENCE`, and `STRUCTURE` types are not currently supported, largely because I have seen no examples in the wild.

--- a/netcdf/src/main/scala/latis/input/NetcdfValidator.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfValidator.scala
@@ -112,14 +112,17 @@ object NetcdfValidator {
 
   /** Determines if the model and file types are consistent. */
   private def matchTypes(latisType: ValueType, ncType: NcType): Boolean = {
-    //TODO: support unsigned types
     (latisType, ncType) match {
       case (BooleanValueType, NcType.BOOLEAN) => true
       case (ByteValueType,    NcType.BYTE)    => true
+      case (ShortValueType,   NcType.UBYTE)   => true
       case (CharValueType,    NcType.CHAR)    => true
       case (ShortValueType,   NcType.SHORT)   => true
+      case (IntValueType,     NcType.USHORT)  => true
       case (IntValueType,     NcType.INT)     => true
+      case (LongValueType,    NcType.UINT)    => true
       case (LongValueType,    NcType.LONG)    => true
+      case (DoubleValueType,  NcType.ULONG)   => true
       case (DoubleValueType,  NcType.DOUBLE)  => true
       case (FloatValueType,   NcType.FLOAT)   => true
       case (StringValueType,  NcType.STRING)  => true


### PR DESCRIPTION
The netcdf-java API will pretty much let you get any variable type as the type you want via things like `getDouble`. We use a validator to safely model scalar types that match the file. Adding validation for the unsigned types lets the NetcdfWrapper get the types we want.

I opted to require `double` for `ULONG`. As their docs say, "Theres not much to do in a general way with unsigned longs, as there is no primitive type that can hold 64 bits of precision."