### PR TITLE
Fix some granule dataset bugs

### DIFF
--- a/core/src/main/scala/latis/input/HttpStreamSource.scala
+++ b/core/src/main/scala/latis/input/HttpStreamSource.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import fs2.Stream
 import org.http4s.Request
 import org.http4s.Uri
+import org.http4s.client.middleware.FollowRedirect
 import org.http4s.ember.client.EmberClientBuilder
 
 /**
@@ -30,6 +31,7 @@ class HttpStreamSource extends StreamSource {
       val request = Request[IO](uri = Uri.unsafeFromString(uri.toString))
       val client = EmberClientBuilder.default[IO].build
       val stream = Stream.resource(client)
+        .map(FollowRedirect(maxRedirects = 3))
         .flatMap(_.stream(request))
         .flatMap(_.body)
       Option(stream)

--- a/core/src/main/scala/latis/input/StreamSource.scala
+++ b/core/src/main/scala/latis/input/StreamSource.scala
@@ -21,6 +21,7 @@ import latis.util.LatisException
  * if the source is valid.
  */
 trait StreamSource {
+  //TODO: return Option[Either[LatisException, Stream...]] so we can capture errors before streaming?
 
   /**
    * Generate an fs2.Stream for the data identified by the given URI.

--- a/core/src/main/scala/latis/input/StreamingAdapter.scala
+++ b/core/src/main/scala/latis/input/StreamingAdapter.scala
@@ -30,6 +30,12 @@ trait StreamingAdapter[R] extends Adapter {
    * Note that this approach is limited to a single traversal.
    */
   def getData(uri: URI, ops: Seq[Operation] = Seq.empty): SampledFunction =
-    StreamFunction(recordStream(uri).map(parseRecord).unNone)
+    StreamFunction(
+      recordStream(uri)
+        .map(parseRecord)
+        //TODO: debug log, return Either from parseRecord so we can capture error
+        //.evalTap(a => if (a.isEmpty) IO.println("Dropping bad record") else IO.unit)
+        .unNone // Drops invalid samples
+    )
 
 }

--- a/core/src/test/scala/latis/input/GranuleListGeneratorSuite.scala
+++ b/core/src/test/scala/latis/input/GranuleListGeneratorSuite.scala
@@ -24,7 +24,7 @@ class GranuleListGeneratorSuite extends munit.CatsEffectSuite {
     val adapter = {
       val config = Config(
         LocalDateTime.of(2022, 1, 1, 0, 0, 0),
-        LocalDateTime.of(2022, 1, 4, 0, 0, 0),
+        Some(LocalDateTime.of(2022, 1, 4, 0, 0, 0)),
         Duration.fromIsoString("P1D").getOrElse(
           fail("Failed to construct Duration")
         ),
@@ -76,7 +76,7 @@ class GranuleListGeneratorSuite extends munit.CatsEffectSuite {
 
     val expected = Config(
       LocalDateTime.of(2022, 1, 2, 3, 4, 5),
-      LocalDateTime.of(2023, 5, 4, 3, 2, 1),
+      Some(LocalDateTime.of(2023, 5, 4, 3, 2, 1)),
       Duration.fromIsoString("P1D").getOrElse(
         fail("Failed to construct Duration")
       ),
@@ -87,10 +87,8 @@ class GranuleListGeneratorSuite extends munit.CatsEffectSuite {
   }
 
   test("config: end time is optional") {
-    val now = LocalDateTime.of(2022, 1, 3, 0, 0, 0)
 
     val conf = Config.fromConfigLike(
-      now,
       AdapterConfig(
         "class" -> "",
         "start" -> "2022-01-02T03:04:05",
@@ -101,7 +99,7 @@ class GranuleListGeneratorSuite extends munit.CatsEffectSuite {
 
     val expected = Config(
       LocalDateTime.of(2022, 1, 2, 3, 4, 5),
-      now,
+      None,
       Duration.fromIsoString("P1D").getOrElse(
         fail("Failed to construct Duration")
       ),
@@ -161,4 +159,3 @@ class GranuleListGeneratorSuite extends munit.CatsEffectSuite {
     assert(conf.isLeft)
   }
 }
-

--- a/core/src/test/scala/latis/input/StreamSourceSuite.scala
+++ b/core/src/test/scala/latis/input/StreamSourceSuite.scala
@@ -1,7 +1,8 @@
 package latis.input
 
-import java.io.FileNotFoundException
+import java.net.UnknownHostException
 import java.net.URI
+import java.nio.file.NoSuchFileException
 
 import munit.CatsEffectSuite
 
@@ -9,15 +10,31 @@ import latis.util.LatisException
 
 class StreamSourceSuite extends CatsEffectSuite {
 
-  test("delay throwing an exception for file not found") {
-    val s = StreamSource.getStream(new URI("file:///not/found"))
-
-    s.compile.toList.intercept[FileNotFoundException]
+  test("Delay throwing an exception for file not found") {
+    StreamSource.getStream(new URI("file:///not/found"))
+      .compile.toList.intercept[NoSuchFileException]
   }
 
-  test("delay throwing an exception for s3 object not found") {
-    val s = StreamSource.getStream(new URI("s3://not/found"))
-
-    s.compile.toList.intercept[LatisException]
+  test("Delay throwing an exception for 404".ignore) {
+    StreamSource.getStream(new URI("https://github.com/latis-data/not/found"))
+      .compile.toList.intercept[NoSuchFileException]
   }
+
+  test("Delay throwing an exception for unknown host") {
+    StreamSource.getStream(new URI("https://not.found"))
+      .compile.toList.intercept[UnknownHostException]
+  }
+
+  test("Redirect") {
+    StreamSource.getStream(new URI("http://github.com/"))
+      .compile.toList.map { l =>
+        assert(l.nonEmpty)
+      }
+  }
+
+  test("Delay throwing an exception for unsupported URI scheme") {
+    StreamSource.getStream(new URI("foo://not.found"))
+      .compile.toList.intercept[LatisException]
+  }
+
 }


### PR DESCRIPTION
The `GranuleListGenerator` was using the time of creation for the default end time. Since the Dataset persists in the catalog, it never updated the end time. This change gets the latest time each time the dataset is requested.

I also uncovered bugs where a missing granule would raise an exception in the Stream, blowing up the request and failing to find additional files. It now handles the error by returning an empty Stream. In the cases of failing to read a source (file or http), it now prints an error to the console, in lieu of better types (e.g. an Either that could propagate an error) or logging, a problem for another ticket. I opted to not log every failed record parsing, but I left the logic there so we can easily enable it.

While I was in there, I also added support for HTTP redirects.