### PR TITLE
Increase max response header size for HTTP client

### DIFF
--- a/core/src/main/scala/latis/input/HttpStreamSource.scala
+++ b/core/src/main/scala/latis/input/HttpStreamSource.scala
@@ -29,7 +29,9 @@ class HttpStreamSource extends StreamSource {
   def getStream(uri: URI): Option[Stream[IO, Byte]] =
     if (uri.isAbsolute && supportsScheme(uri.getScheme)) {
       val request = Request[IO](uri = Uri.unsafeFromString(uri.toString))
-      val client = EmberClientBuilder.default[IO].build
+      val client = EmberClientBuilder.default[IO]
+        .withMaxResponseHeaderSize(8192)
+        .build
       val stream = Stream.resource(client)
         .map(FollowRedirect(maxRedirects = 3))
         .flatMap(_.stream(request))


### PR DESCRIPTION
Increases the max response header size to 8k.

Fixes #671.