### PR TITLE
Time conversion with leap seconds

### DIFF
--- a/core/src/main/scala/latis/ops/ConvertTime.scala
+++ b/core/src/main/scala/latis/ops/ConvertTime.scala
@@ -6,8 +6,8 @@ import latis.data.*
 import latis.model.DataType
 import latis.model.StringValueType
 import latis.time.Time
+import latis.time.TimeConverter
 import latis.time.TimeScale
-import latis.units.UnitConverter
 import latis.util.LatisException
 
 /**
@@ -26,7 +26,7 @@ case class ConvertTime(scale: TimeScale) extends TimeOperation {
     // be applied to every Sample.
 
     // Define the numeric unit converter
-    val converter = UnitConverter(t.timeScale, scale)
+    val converter = TimeConverter(t.timeScale, scale)
 
     // Add special handling for formatted times.
     t.valueType match {
@@ -36,7 +36,7 @@ case class ConvertTime(scale: TimeScale) extends TimeOperation {
           case Text(s) =>
             format.parse(s)
               .map(t => converter.convert(t.toDouble))
-              .flatMap(Data.fromValue(_))
+              .flatMap(Data.fromValue)
               .fold(throw _, identity)
           case _ => throw new LatisException(s"Data does not match string value type: $d")
         }

--- a/core/src/main/scala/latis/ops/FormatTime.scala
+++ b/core/src/main/scala/latis/ops/FormatTime.scala
@@ -6,9 +6,9 @@ import latis.data.*
 import latis.model.DataType
 import latis.model.StringValueType
 import latis.time.Time
+import latis.time.TimeConverter
 import latis.time.TimeFormat
 import latis.time.TimeScale
-import latis.units.UnitConverter
 import latis.util.LatisException
 
 /**
@@ -40,7 +40,7 @@ case class FormatTime(format: TimeFormat) extends TimeOperation {
         }
       case _: NumericType =>
         // Define the numeric unit converter to the default TimeScale
-        val converter = UnitConverter(t.timeScale, TimeScale.Default)
+        val converter = TimeConverter(t.timeScale, TimeScale.Default)
         (d: Datum) => d match {
           case Number(d) =>
             Data.fromValue(format.format(round(converter.convert(d)))).fold(throw _, identity)

--- a/core/src/main/scala/latis/ops/FormatTime.scala
+++ b/core/src/main/scala/latis/ops/FormatTime.scala
@@ -33,20 +33,20 @@ case class FormatTime(format: TimeFormat) extends TimeOperation {
         (d : Datum) => d match {
           case Text(s) =>
             fmt.parse(s)
-              .map(format.format(_))
-              .flatMap(Data.fromValue(_))
+              .map(format.format)
+              .flatMap(Data.fromValue)
               .fold(throw _, identity)
-          case _ => throw new LatisException(s"Data does not match string value type: $d")
+          case _ => throw LatisException(s"Data does not match string value type: $d")
         }
-      case _ =>
+      case _: NumericType =>
         // Define the numeric unit converter to the default TimeScale
-        //TODO: use unit converter only if needed
         val converter = UnitConverter(t.timeScale, TimeScale.Default)
-        (d : Datum) => d match {
+        (d: Datum) => d match {
           case Number(d) =>
-            Data.fromValue(format.format(converter.convert(d).toLong)).fold(throw _, identity)
-          case _ => throw new LatisException(s"Data is not a numeric value type: $d")
+            Data.fromValue(format.format(round(converter.convert(d)))).fold(throw _, identity)
+          case _ => throw LatisException(s"Data is not a numeric value type: $d")
         }
+      case t => throw LatisException(s"Invalid type for Time: $t") //bug
     }
   }
 

--- a/core/src/main/scala/latis/ops/FormatTime.scala
+++ b/core/src/main/scala/latis/ops/FormatTime.scala
@@ -1,10 +1,11 @@
 package latis.ops
 
+import java.lang.Math.*
+
 import cats.syntax.all.*
 
 import latis.data.*
-import latis.model.DataType
-import latis.model.StringValueType
+import latis.model.*
 import latis.time.Time
 import latis.time.TimeConverter
 import latis.time.TimeFormat

--- a/core/src/main/scala/latis/time/Time.scala
+++ b/core/src/main/scala/latis/time/Time.scala
@@ -14,7 +14,6 @@ import latis.model.ScalarFactory
 import latis.model.StringValueType
 import latis.model.ValueType
 import latis.units.MeasurementScale
-import latis.units.UnitConverter
 import latis.util.Identifier
 import latis.util.LatisException
 
@@ -78,7 +77,7 @@ class Time protected (
           Data.StringValue(format.format(ms)).asRight
         case _ =>
           // Convert to this Time's numeric units
-          val t = UnitConverter(TimeScale.Default, timeScale).convert(ms.toDouble)
+          val t = TimeConverter(TimeScale.Default, timeScale).convert(ms.toDouble)
           Either.fromOption(
             valueType.convertDouble(t),
             LatisException(s"Failed to convert time value: $value")

--- a/core/src/main/scala/latis/time/TimeConverter.scala
+++ b/core/src/main/scala/latis/time/TimeConverter.scala
@@ -1,0 +1,152 @@
+package latis.time
+
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Date
+
+import scala.collection.immutable.SortedMap
+
+import latis.time.TimeScaleType._
+import latis.units.UnitConverter
+
+/**
+ * The TimeConverter is a UnitConverter that converts values from one TimeScale
+ * to another.
+ *
+ * This accounts for leap second adjustments when dealing with TAI TimeScales.
+ * The UTC time scale, which does not count leap seconds, is aligned with the
+ * default Java time scale, which simply ignores leap seconds. The UTC time
+ * scale effectively pausing during a leap second. When converting with TAI
+ * time scales, which do count leap seconds, we must make adjustments to
+ * account for the different accounting of leap seconds.
+ *
+ * Note that this assumes zero leap seconds before 1972, when UTC was defined,
+ * then starting with 10 leap seconds at 1970:01:01T00:00:00.
+ */
+case class TimeConverter(ts1: TimeScale, ts2: TimeScale) extends UnitConverter(ts1, ts2) {
+
+  import TimeConverter._
+
+  /**
+   * Converts the given time from the first TimeScale to the second
+   * with a leaps second adjustment as needed.
+   */
+  override def convert(time: Double): Double = _convert(time)
+
+  /**
+   * Defines a function that converts a time from ts1 to ts2.
+   *
+   * This only invokes leap second configuration if there is a TAI TimeScale
+   * involved.
+   */
+  private val _convert: Double => Double = {
+    if (ts1.timeScaleType == TAI || ts2.timeScaleType == TAI)
+      (time: Double) => super.convert(time) + leapSecondAdjustment(time)
+    else (time: Double) => super.convert(time)
+  }
+
+  /**
+   * Returns the leap second adjustment for the given time.
+   *
+   * The given time is expected to be in the units of the input TimeScale.
+   * The resulting adjustment will be in the units of the target TimeScale.
+   */
+  private def leapSecondAdjustment(time: Double): Double =
+    leapSecondAdjustmentMap.rangeTo(time).lastOption.map(_._2).get
+
+  /**
+   * Constructs a sorted map from the time of a leap second in the first TimeScale
+   * to the leap second adjustment in the units of the second TimeScale.
+   *
+   * This is designed to optimize the lookup of leap second adjustments
+   * for repeated conversions performed by this TimeConverter.
+   */
+  private lazy val leapSecondAdjustmentMap: SortedMap[Double, Double] = {
+    // This is lazy since it is not needed by all conversions AND
+    //   it prevents a stack overflow since the internal TimeConverter
+    //   would in turn try to construct this map. Because this is lazy,
+    //   the loop will short-circuit when converting the UTC date to a
+    //   UTC time scale which does not need a leap second adjustment.
+    // Note that this adds an adjustment for any time before 1972.
+
+    // Function to convert a Date to the incoming TimeScale
+    val convertDate: Date => Double = {
+      val converter = TimeConverter(TimeScale.Default, ts1)
+      (date: Date) => converter.convert(date.getTime.toDouble)
+    }
+
+    (leapSeconds.map { case (date, ls) =>
+      (convertDate(date), computeAdjustment(ls))
+    }).concat(List((Double.MinValue, computeAdjustment(0))))
+  }
+
+  /**
+   * Computes the leap second adjustment based on the TimeScale types.
+   *
+   * The given leap second count is combined with leap second counts at
+   * TimeScale epochs as needed. The adjustment is converted to the target
+   * TimeScale's units.
+   */
+  private def computeAdjustment(ls: Int): Double =
+    (ts1.timeScaleType, ts2.timeScaleType) match {
+      // leap second difference between TAI epochs
+      case (TimeScaleType.TAI, TimeScaleType.TAI) =>
+        (getLeapSeconds(ts1.epoch) - getLeapSeconds(ts2.epoch)).toDouble / ts2.baseMultiplier
+      // subtract leap seconds before target TAI epoch
+      case (TimeScaleType.UTC, TimeScaleType.TAI) =>
+        (ls - getLeapSeconds(ts2.epoch)).toDouble / ts2.baseMultiplier
+      // subtract leap seconds on incoming TAI TimeScale
+      case (TimeScaleType.TAI, TimeScaleType.UTC) =>
+        (getLeapSeconds(ts1.epoch) - ls).toDouble / ts2.baseMultiplier
+      case _ => 0d
+    }
+}
+
+object TimeConverter {
+
+  /**
+   * Returns the accumulated number of leap seconds for a given Date.
+   *
+   * This takes advantage of the ordering provided by a SortedMap to find the
+   * most recent (previous) entry. This will return 0 for times before 1972.
+   */
+  def getLeapSeconds(date: Date): Int =
+    leapSeconds.rangeTo(date).lastOption.map(_._2).getOrElse(0)
+
+  /**
+   * Defines a SortedMap with an entry for all leap seconds, mapping the Date
+   * of a leap second to the accumulated count of leap seconds at that Date.
+   */
+  val leapSeconds: SortedMap[Date, Int] = SortedMap(
+    ("1972-01-01", 10),
+    ("1972-07-01", 11),
+    ("1973-01-01", 12),
+    ("1974-01-01", 13),
+    ("1975-01-01", 14),
+    ("1976-01-01", 15),
+    ("1977-01-01", 16),
+    ("1978-01-01", 17),
+    ("1979-01-01", 18),
+    ("1980-01-01", 19),
+    ("1981-07-01", 20),
+    ("1982-07-01", 21),
+    ("1983-07-01", 22),
+    ("1985-07-01", 23),
+    ("1988-01-01", 24),
+    ("1990-01-01", 25),
+    ("1991-01-01", 26),
+    ("1992-07-01", 27),
+    ("1993-07-01", 28),
+    ("1994-07-01", 29),
+    ("1996-01-01", 30),
+    ("1997-07-01", 31),
+    ("1999-01-01", 32),
+    ("2006-01-01", 33),
+    ("2009-01-01", 34),
+    ("2012-07-01", 35),
+    ("2015-07-01", 36),
+    ("2017-01-01", 37)
+  ).map { case (date, ls) =>
+    (new Date(LocalDate.parse(date).atStartOfDay().toEpochSecond(ZoneOffset.UTC) * 1000), ls)
+  }
+}

--- a/core/src/main/scala/latis/time/TimeConverter.scala
+++ b/core/src/main/scala/latis/time/TimeConverter.scala
@@ -6,7 +6,7 @@ import java.util.Date
 
 import scala.collection.immutable.SortedMap
 
-import latis.time.TimeScaleType._
+import latis.time.TimeScaleType.*
 import latis.units.UnitConverter
 
 /**

--- a/core/src/main/scala/latis/time/TimeScale.scala
+++ b/core/src/main/scala/latis/time/TimeScale.scala
@@ -31,7 +31,7 @@ case class TimeScale(timeUnit: TimeUnit, epoch: Date) extends MeasurementScale {
 
   override def zero: Double = -epoch.getTime / 1000 / baseMultiplier
 
-  override def toString() = s"$timeUnit since ${TimeFormat.formatIso(epoch.getTime)}"
+  override def toString = s"$timeUnit since ${TimeFormat.formatIso(epoch.getTime)}"
 }
 
 object TimeScale {
@@ -40,7 +40,7 @@ object TimeScale {
    * Defines the default time scale as Java's default:
    * milliseconds since 1970.
    */
-  val Default: TimeScale = TimeScale(TimeUnit(0.001), new Date(0))
+  val Default: TimeScale = TimeScale(TimeUnit.Milliseconds, new Date(0))
 
   /**
    * Defines a TimeScale for Julian Date: days since noon UT on Jan 1, 4713 BC.
@@ -54,12 +54,12 @@ object TimeScale {
    * with "JD" since this epoch can not be represented with our default ISO
    * representation. This matches the units that LaTiS expects.
    */
-  lazy val JulianDate = {
+  lazy val JulianDate: TimeScale = {
     // Java's default calendar jumps from 1 BC to 1 AD, we need to use year -4712
     val cal = new GregorianCalendar(-4712, 0, 1, 12, 0)
     cal.setTimeZone(TimeZone.getTimeZone("GMT"))
-    new TimeScale(TimeUnit(86400), cal.getTime) {
-      override def toString() = "JD"
+    new TimeScale(TimeUnit.Days, cal.getTime) {
+      override def toString = "JD"
     }
   }
 

--- a/core/src/main/scala/latis/time/TimeScaleType.scala
+++ b/core/src/main/scala/latis/time/TimeScaleType.scala
@@ -1,0 +1,45 @@
+package latis.time
+
+/**
+ * Defines how a TimeScale deals with leap seconds.
+ */
+sealed trait TimeScaleType
+
+object TimeScaleType {
+
+  /**
+   * UTC time scales are adjusted for leap seconds, effectively not counting them.
+   *
+   * The UTC time scale is an imperfect attempt to align civil time with atomic
+   * time while remaining consistent with the rotation of the Earth. The Earth
+   * has been running a bit slow (until recently) so leap seconds have been added
+   * to give the UTC clock something else to do while the earth catches up.
+   *
+   * Due to the introduction of leap seconds, UTC is not a well-behaved scale
+   * in that a discontinuity must be handled somehow. Here, UTC is modeled by
+   * aligning with Unix/POSIX time as implemented in Java. It counts SI seconds
+   * at the same rate as a TAI time scale while maintaining exactly 86400
+   * seconds per day (instead of making the day one second longer or changing
+   * the length of a second). The leap second discontinuity is handled by
+   * replaying a leap second, effectively pausing the clock at midnight.
+   *
+   * Durations for UTC time scales will not include leap seconds.
+   */
+  case object UTC extends TimeScaleType
+
+  /**
+   * TAI time scales count all seconds, including leap seconds.
+   *
+   * TAI time scales are best for scientific use cases and spacecraft
+   * operations since they uniformly count all real SI seconds. (Relativistic
+   * effects are not accounted for here.) Unfortunately, many data managers
+   * tend to ignore leap seconds, putting differentiation at risk.
+   *
+   * Due to the dependence on the underlying Java time scale and the use of UTC
+   * timestamps as epochs, leap seconds must be considered when converting TAI
+   * time scales to and from UTC time scales and between TAI time scales with
+   * different epochs.
+   */
+  case object TAI extends TimeScaleType
+
+}

--- a/core/src/main/scala/latis/time/TimeScaleType.scala
+++ b/core/src/main/scala/latis/time/TimeScaleType.scala
@@ -8,38 +8,39 @@ sealed trait TimeScaleType
 object TimeScaleType {
 
   /**
-   * UTC time scales are adjusted for leap seconds, effectively not counting them.
+   * Civil time scales (e.g. UTC) are adjusted for leap seconds,
+   * effectively not counting them in this implementation.
    *
    * The UTC time scale is an imperfect attempt to align civil time with atomic
    * time while remaining consistent with the rotation of the Earth. The Earth
    * has been running a bit slow (until recently) so leap seconds have been added
-   * to give the UTC clock something else to do while the earth catches up.
+   * to give the civil UTC clock something else to do while the earth catches up.
    *
-   * Due to the introduction of leap seconds, UTC is not a well-behaved scale
-   * in that a discontinuity must be handled somehow. Here, UTC is modeled by
+   * Due to the introduction of leap seconds, civil time is not a well-behaved scale
+   * in that a discontinuity must be handled somehow. Here, civil time is modeled by
    * aligning with Unix/POSIX time as implemented in Java. It counts SI seconds
-   * at the same rate as a TAI time scale while maintaining exactly 86400
+   * at the same rate as an atomic time scale while maintaining exactly 86400
    * seconds per day (instead of making the day one second longer or changing
    * the length of a second). The leap second discontinuity is handled by
    * replaying a leap second, effectively pausing the clock at midnight.
    *
-   * Durations for UTC time scales will not include leap seconds.
+   * Durations for civil time scales will not include leap seconds.
    */
-  case object UTC extends TimeScaleType
+  case object Civil extends TimeScaleType
 
   /**
-   * TAI time scales count all seconds, including leap seconds.
+   * Atomic time scales (e.g. TAI) count all seconds, including leap seconds.
    *
-   * TAI time scales are best for scientific use cases and spacecraft
+   * Atomic time scales are best for scientific use cases and spacecraft
    * operations since they uniformly count all real SI seconds. (Relativistic
    * effects are not accounted for here.) Unfortunately, many data managers
    * tend to ignore leap seconds, putting differentiation at risk.
    *
    * Due to the dependence on the underlying Java time scale and the use of UTC
-   * timestamps as epochs, leap seconds must be considered when converting TAI
-   * time scales to and from UTC time scales and between TAI time scales with
+   * timestamps as epochs, leap seconds must be considered when converting atomic
+   * time scales to and from civil time scales and between atomic time scales with
    * different epochs.
    */
-  case object TAI extends TimeScaleType
+  case object Atomic extends TimeScaleType
 
 }

--- a/core/src/main/scala/latis/time/TimeUnit.scala
+++ b/core/src/main/scala/latis/time/TimeUnit.scala
@@ -11,7 +11,7 @@ import latis.util.LatisException
 case class TimeUnit(baseMultiplier: Double) {
 
   /** Represents a TimeUnit as a String */
-  override def toString() = baseMultiplier match {
+  override def toString: String = baseMultiplier match {
     case 1e-9     => "nanoseconds"
     case 1e-6     => "microseconds"
     case 0.001    => "milliseconds"
@@ -27,26 +27,29 @@ case class TimeUnit(baseMultiplier: Double) {
 
 object TimeUnit {
 
-  /**
-   * Base time unit of seconds.
-   */
-  val Base = TimeUnit(1.0)
+  val Nanoseconds  = TimeUnit(1e-9)
+  val Microseconds = TimeUnit(1e-6)
+  val Milliseconds = TimeUnit(1e-3)
+  val Seconds      = TimeUnit(1d)
+  val Minutes      = TimeUnit(60d)
+  val Hours        = TimeUnit(3600d)
+  val Days         = TimeUnit(86400d)
+  val Weeks        = TimeUnit(7d * 86400)
+  val Years        = TimeUnit(365d * 86400)
 
   /**
    * Returns a TimeUnit given the unit's name.
    */
   def fromName(unit: String): Either[LatisException, TimeUnit] = unit match {
-    case "nanoseconds"  => TimeUnit(1e-9).asRight
-    case "microseconds" => TimeUnit(1e-6).asRight
-    case "milliseconds" => TimeUnit(0.001).asRight
-    case "seconds"      => Base.asRight
-    case "minutes"      => TimeUnit(60).asRight
-    case "hours"        => TimeUnit(3600).asRight
-    case "days"         => TimeUnit(86400).asRight
-    case "weeks"        => TimeUnit(7 * 86400).asRight
-    case "years"        => TimeUnit(365 * 86400).asRight
+    case "nanoseconds"  => Nanoseconds.asRight
+    case "microseconds" => Microseconds.asRight
+    case "milliseconds" => Milliseconds.asRight
+    case "seconds"      => Seconds.asRight
+    case "minutes"      => Minutes.asRight
+    case "hours"        => Hours.asRight
+    case "days"         => Days.asRight
+    case "weeks"        => Weeks.asRight
+    case "years"        => Years.asRight
     case _ => LatisException(s"Invalid TimeUnit: $unit").asLeft
   }
-
-  //TODO: make enumeration of units for safer general usage
 }

--- a/core/src/main/scala/latis/units/MeasurementScale.scala
+++ b/core/src/main/scala/latis/units/MeasurementScale.scala
@@ -3,11 +3,11 @@ package latis.units
 //TODO: See squants
 
 /**
- * A MeasurementScale defines how values of physical
- * quantities should be interpreted. This term was chosen over
- * the commonly used "unit of measure" to emphasize that
- * measurements require a zero in addition to the size of a unit.
- * This approach facilitates generalized affine unit conversions.
+ * A MeasurementScale defines how values of physical quantities should be interpreted.
+ *
+ * This term was chosen over the commonly used "unit of measure" to emphasize that
+ * measurements require a zero in addition to the size of a unit. This approach
+ * facilitates generalized affine unit conversions.
  */
 trait MeasurementScale {
   def unitType: MeasurementType

--- a/core/src/main/scala/latis/units/UnitConverter.scala
+++ b/core/src/main/scala/latis/units/UnitConverter.scala
@@ -1,12 +1,29 @@
 package latis.units
 
-case class UnitConverter(from: MeasurementScale, to: MeasurementScale) {
-  //TODO: error if not the same UnitType
+import cats.syntax.all._
+
+import latis.time.TimeConverter
+import latis.time.TimeScale
+import latis.util.LatisException
+
+class UnitConverter protected (from: MeasurementScale, to: MeasurementScale) {
 
   private val scaleFactor: Double = from.baseMultiplier / to.baseMultiplier
 
   private val offset: Double = from.zero * scaleFactor - to.zero
 
   def convert(value: Double): Double = value * scaleFactor - offset
-  //TODO: define as function, Id for same scales
+}
+
+object UnitConverter {
+
+  /** Constructs a UnitConverter from two MeasurementScales. */
+  def fromScales(
+    from: MeasurementScale,
+    to: MeasurementScale
+  ): Either[LatisException, UnitConverter] = (from, to) match {
+    case _ if (from.unitType != to.unitType) => LatisException("Incompatible measurement types").asLeft
+    case (ts1: TimeScale, ts2: TimeScale) => TimeConverter(ts1, ts2).asRight
+    case _ => new UnitConverter(from, to).asRight
+  }
 }

--- a/core/src/test/scala/latis/time/LeapSecondSuite.scala
+++ b/core/src/test/scala/latis/time/LeapSecondSuite.scala
@@ -1,0 +1,44 @@
+package latis.time
+
+import java.util.Date
+
+import scala.collection.SortedSet
+
+import munit.FunSuite
+
+class LeapSecondSuite extends FunSuite {
+
+  private def makeDate(iso: String): Date = {
+    TimeFormat.parseIso(iso)
+      .map(new Date(_))
+      .fold(fail(s"Invalid ISO 8601 time: $iso", _), identity)
+  }
+
+  // Confirm that we can use Date as a key in a SortedMap
+  test("Date ordering") {
+    val set = SortedSet(new Date(2), new Date(3), new Date(4), new Date(1))
+    assertEquals(set.head, new Date(1))
+    assertEquals(set.last, new Date(4))
+  }
+
+  test("at leap second") {
+    val ls = TimeConverter.getLeapSeconds(makeDate("2009-01-01"))
+    assertEquals(ls, 34)
+  }
+
+  test("before leap second") {
+    val ls = TimeConverter.getLeapSeconds(makeDate("2008-12-31T23:59:59"))
+    assertEquals(ls, 33)
+  }
+
+  test("before UTC") {
+    val ls = TimeConverter.getLeapSeconds(makeDate("1970-01-01"))
+    assertEquals(ls, 0)
+  }
+
+  test("future") {
+    val nextYear = new Date(new Date().getTime() + 31536000000L)
+    val ls = TimeConverter.getLeapSeconds(nextYear)
+    assertEquals(ls, 37)
+  }
+}

--- a/core/src/test/scala/latis/time/TimeConverterSuite.scala
+++ b/core/src/test/scala/latis/time/TimeConverterSuite.scala
@@ -1,0 +1,220 @@
+package latis.time
+
+import java.util.Date
+
+import munit.FunSuite
+
+class TimeConverterSuite extends FunSuite {
+
+  private def makeDate(iso: String): Date = {
+    TimeFormat.parseIso(iso)
+      .map(new Date(_))
+      .fold(fail(s"Invalid ISO 8601 time: $iso", _), identity)
+  }
+
+  private val gpsEpoch  = makeDate("1980-01-06")
+  private val epoch1981 = makeDate("1981-06-30") // day before leap second
+  private val epoch1982 = makeDate("1982-06-30") // day before leap second
+
+  private val gpsMicros = TimeScale(TimeUnit.Microseconds, gpsEpoch, TimeScaleType.TAI)
+  private val utc1981 = TimeScale(TimeUnit.Seconds, epoch1981, TimeScaleType.UTC)
+  private val utc1982 = TimeScale(TimeUnit.Seconds, epoch1982, TimeScaleType.UTC)
+  private val tai1981 = TimeScale(TimeUnit.Seconds, epoch1981, TimeScaleType.TAI)
+  private val tai1982 = TimeScale(TimeUnit.Seconds, epoch1982, TimeScaleType.TAI)
+
+  /*
+    These tests emphasize the handling of leap seconds between epochs and
+    before the target time. Note that the epochs used for most of these tests
+    are one year apart and one day prior to a leap second being introduced.
+    Note also that epochs are tied to the native time scale which aligns with
+    the UTC time scale.
+
+    The diagrams for each test show time lines (not to scale) extending to the
+    right for the two time scales used in the conversion.
+      "|" indicates the epoch (zero) of a time scale.
+      "x" indicates the time being converted (necessarily aligned between the scales).
+      "^" indicates the location of leap seconds.
+      "+" indicates where a leap second is counted in a TAI time scale.
+   */
+
+  /*
+    |--------x-->
+         |---x-->
+      ^    ^
+   */
+  test("No leap seconds for UTC to UTC conversions") {
+    val converter = TimeConverter(utc1981, utc1982)
+    val t = converter.convert(367d * 86400) // year + 2 days
+    assertEquals(t, 2d * 86400) // 2 days, no leap seconds
+  }
+
+  /*
+  |------------x-->
+          |-+--x-->
+    ^       ^
+  */
+  test("UTC to TAI with time after later epoch") {
+    val converter = TimeConverter(utc1981, tai1982)
+    val t = converter.convert(367d * 86400) // year + 2 days
+    assertEquals(t, 2d * 86400 + 1) // 2 days + leap second
+  }
+
+  /*
+  |---x----------->
+      x   |-+----->
+    ^       ^
+  */
+  test("UTC to TAI with time before later epoch") {
+    val converter = TimeConverter(utc1981, tai1982)
+    val t = converter.convert(2d * 86400) // 2 days
+    assertEqualsDouble(t, - 363d * 86400 + 1, 1) // -year + 2 days + leap second between epochs
+  }
+
+  /*
+          |----x-->
+  |-+-------+--x-->
+    ^       ^
+  */
+  test("UTC to TAI with earlier epoch") {
+    val converter = TimeConverter(utc1982, tai1981)
+    val t = converter.convert(2d * 86400) // 2 days
+    assertEquals(t, 367d * 86400 + 2) // year + 2 days + 2 leap seconds
+  }
+
+  /*
+      x   |------->
+  |-+-x-----+----->
+    ^       ^
+  */
+  test("UTC to TAI with earlier epoch, negative") {
+    val converter = TimeConverter(utc1982, tai1981)
+    val t = converter.convert(- 363d * 86400) // 1 year ago + 2 days
+    assertEquals(t, 2d * 86400 + 1) // 2 days + leap second
+  }
+
+  /*
+  |-+-------+--x-->
+          |----x-->
+    ^       ^
+  */
+  test("TAI to UTC with time after later epoch") {
+    val converter = TimeConverter(tai1981, utc1982)
+    val t = converter.convert(367d * 86400 + 2) // year + 2 days + 2 ls
+    assertEquals(t, 2d * 86400) // 2 days
+  }
+
+  /*
+  |-+-x-----+----->
+      x   |------->
+    ^       ^
+  */
+  test("TAI to UTC with time before later epoch") {
+    val converter = TimeConverter(tai1981, utc1982)
+    val t = converter.convert(2d * 86400 + 1) // 2 days + 1 ls
+    assertEquals(t, - 363d * 86400) // -year + 2 days
+  }
+
+  /*
+          |-+-x--->
+  |-----------x--->
+    ^       ^
+  */
+  test("TAI to UTC with earlier epoch") {
+    val converter = TimeConverter(tai1982, utc1981)
+    val t = converter.convert(2d * 86400 + 1) // 2 days + 1 ls
+    assertEquals(t, 367d * 86400) // year + 2 days
+  }
+
+  /*
+      x   |-+----->
+  |---x------------>
+    ^       ^
+  */
+  test("TAI to UTC with earlier epoch, negative") {
+    val converter = TimeConverter(tai1982, utc1981)
+    val t = converter.convert(-363d * 86400) // -year + 2 days
+    assertEquals(t, 2d * 86400) // 2 days
+  }
+
+  /*
+  |-+-------+--x--->
+          |-+--x-->
+    ^       ^
+  */
+  test("TAI to TAI with time after later epoch") {
+    val converter = TimeConverter(tai1981, tai1982)
+    val t = converter.convert(367d * 86400 + 2) // year + 2 days + 2 ls
+    assertEquals(t, 2d * 86400 + 1) // 2 days + 1 ls
+  }
+
+  /*
+  |-+--x----+------>
+       x  |-+----->
+    ^       ^
+  */
+  test("TAI to TAI with time before later epoch") {
+    val converter = TimeConverter(tai1981, tai1982)
+    val t = converter.convert(2d * 86400 + 1) // 2 days + 1 ls
+    assertEquals(t, -363d * 86400) // -year + 2 days
+  }
+
+  /*
+          |-+--x-->
+  |-+-------+--x--->
+    ^       ^
+  */
+  test("TAI to TAI with earlier epoch") {
+    val converter = TimeConverter(tai1982, tai1981)
+    val t = converter.convert(2d * 86400 + 1) // 2 days + 1 ls
+    assertEquals(t, 367d * 86400 + 2) // year + 2 days + 2 ls
+  }
+
+  /*
+       x  |-+----->
+  |-+--x----+------>
+    ^       ^
+  */
+  test("TAI to TAI with earlier epoch, negative") {
+    val converter = TimeConverter(tai1982, tai1981)
+    val t = converter.convert(-363d * 86400) // -year + 2 days
+    assertEquals(t, 2d * 86400 + 1) // 2 days + ls
+  }
+
+  /*
+  |x+-------+----->
+   x      |-+----->
+    ^       ^
+  */
+  test("time between epochs before leap second") {
+    val converter = TimeConverter(tai1981, tai1982)
+    val t = converter.convert(0.5 * 86400) // 1/2 day, before leap second
+    assertEqualsDouble(t, -364.5 * 86400 - 1, 0.1) // -year + 1/2 day - ls
+  }
+
+  /*
+   x      |-+----->
+  |x+-------+----->
+    ^       ^
+  */
+  test("time between epochs before leap second, negative") {
+    val converter = TimeConverter(tai1982, tai1981)
+    val t = converter.convert(-364.5 * 86400 -1) // -year + 1/2 day - ls
+    assertEqualsDouble(t, 0.5 * 86400, 0.1) // -year + 1/2 days
+  }
+
+  test("Unix epoch to GPS") {
+    /*
+      -(10 years, 5 days, 2 leap days), minus 19 leap seconds
+      (-(10 * 365 + 5 + 2) * 86400 - 19) * 1000000 = -3.15964819e14
+     */
+    val converter = TimeConverter(TimeScale.Default, gpsMicros)
+    val t = converter.convert(0d)
+    assertEquals(t, -3.15964819e14)
+  }
+
+  test("GPS to Unix epoch") {
+    val converter = TimeConverter(gpsMicros, TimeScale.Default)
+    val t = converter.convert(-3.15964819e14)
+    assertEquals(t, 0d)
+  }
+}

--- a/core/src/test/scala/latis/time/TimeFormatSuite.scala
+++ b/core/src/test/scala/latis/time/TimeFormatSuite.scala
@@ -1,5 +1,9 @@
 package latis.time
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.ResolverStyle
+
 import munit.FunSuite
 
 class TimeFormatSuite extends FunSuite {
@@ -161,5 +165,22 @@ class TimeFormatSuite extends FunSuite {
       TimeFormat.fromExpression("y [ ]M d").flatMap(_.parse("1970  1 01")),
       Right(0L)
     )
+  }
+
+  test("fail to parse leap second") {
+    // DateTimeFormatter fails to parse a leap second if not using LENIENT resolver.
+    assert(TimeFormat.parseIso("2016-12-31T23:59:60").isLeft)
+  }
+
+  test("leniently parse leap second") {
+    // With LENIENT resolution, DateTimeFormatter will simply roll a leap
+    //   second over to the next day.
+    // Note that the DateTimeFormatter.parsedLeapSecond TemporalQuery
+    //   says that it will replace the "60" with "59", counter to this
+    //   lenient resolution.
+    val formatter = DateTimeFormatter.ISO_DATE_TIME.withResolverStyle(ResolverStyle.LENIENT)
+    val t1 = LocalDateTime.parse("2016-12-31T23:59:60.123", formatter)
+    val t2 = LocalDateTime.parse("2017-01-01T00:00:00.123", formatter)
+    assertEquals(t1, t2)
   }
 }

--- a/core/src/test/scala/latis/time/TimeScaleSuite.scala
+++ b/core/src/test/scala/latis/time/TimeScaleSuite.scala
@@ -39,6 +39,18 @@ class TimeScaleSuite extends FunSuite {
     assertEquals(numericTimeScale.zero, -24.0)
   }
 
+  private lazy val gpsTimeScale =
+    TimeScale
+      .fromExpression("TAI microseconds since 1980-01-06")
+      .getOrElse(fail("failed to create GPS TimeScale"))
+
+  test("make TAI time scale") {
+    assertEquals(gpsTimeScale.timeScaleType, TimeScaleType.TAI)
+  }
+
+  test("default time scale type is UTC") {
+    assertEquals(numericTimeScale.timeScaleType, TimeScaleType.UTC)
+  }
 
   private lazy val timeConverter = UnitConverter(
     TimeScale

--- a/core/src/test/scala/latis/time/TimeScaleSuite.scala
+++ b/core/src/test/scala/latis/time/TimeScaleSuite.scala
@@ -41,15 +41,15 @@ class TimeScaleSuite extends FunSuite {
 
   private lazy val gpsTimeScale =
     TimeScale
-      .fromExpression("TAI microseconds since 1980-01-06")
+      .fromExpression("Atomic microseconds since 1980-01-06")
       .getOrElse(fail("failed to create GPS TimeScale"))
 
-  test("make TAI time scale") {
-    assertEquals(gpsTimeScale.timeScaleType, TimeScaleType.TAI)
+  test("make Atomic time scale") {
+    assertEquals(gpsTimeScale.timeScaleType, TimeScaleType.Atomic)
   }
 
-  test("default time scale type is UTC") {
-    assertEquals(numericTimeScale.timeScaleType, TimeScaleType.UTC)
+  test("default time scale type is Civil") {
+    assertEquals(numericTimeScale.timeScaleType, TimeScaleType.Civil)
   }
 
   private lazy val timeConverter = (for {

--- a/core/src/test/scala/latis/units/UnitConverterSuite.scala
+++ b/core/src/test/scala/latis/units/UnitConverterSuite.scala
@@ -12,6 +12,9 @@ class UnitConverterSuite extends FunSuite {
       .fromExpression("seconds since 1970")
       .getOrElse(fail("failed to create TimeScale"))
 
-    assertEquals(UnitConverter(ts1, ts2).convert(1000), 1.0)
+    UnitConverter.fromScales(ts1, ts2).fold(
+      le => fail(le.message, le),
+      c  => assertEquals(c.convert(1000), 1.0)
+    )
   }
 }


### PR DESCRIPTION
I've decided that we really don't need to capture the distinction between the "naive" Java/Unix/POSIX time scale and UTC like we do in latis2. They both count the same other than UTC going off in some dimension to count a leap second (waiting for Earth to catch up) while the former just ignores the leap second and allows NTP to keep it synced. Actually, part of my confusion has been due to the fact that UTC isn't really a "scale" in that there is not a continuous accumulation of fixed size steps. I'm coming to think of UTC as the formatted time string that points to a point on the time line instead of a count (which is why we can use it as an epoch). So, we'll use Java time to manage the counting and format mapping (and throw an error if anyone tries to give us 23:59:60 as implemented by Java's DateTimeFormatter without the LENIENT setting).

Since we are heavily dependent on the Java time implementation, I am content to lean on the replay of the leap second, rather than smear the leap second (change the length of a second) or make a day 86401 seconds long. I confirmed that with a LENIENT DateTimeFormatter, you can represent a leap second with 23:59:60 but I think it simply rolls over to the 00:00:00 of the next day. Then when 00:00:00 plays out, it will return to the first second of the day that it just played. 

My other concern had been about durations. The implementations that I've looked at, including Java's, do not include leap seconds when computing a duration. So, I'm content to say that our default time scale type is UTC which remains aligned with Unix time and ignores leap seconds (least surprising). If users want accurate durations, they should be using a TAI time scale.

The logic for the time conversions is hard to reason about, so I would lean on the tests. (I felt like there were so many more that I could write.) Keep in mind that I am creating a sorted map as a lookup table. It is optimized by having already converted the keys/values to the units of the inputs/outputs.