### PR TITLE
Put subcatalogs in IO

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -51,7 +51,7 @@ class Dap2Service(catalog: Catalog, operationRegistry: OperationRegistry)
           // Dataset path should not end with slash
           if (path.endsWithSlash) NotFound(s"Resource not found: $path")
           else datasetResponse(ds, ext, query)
-        case None     => catalog.findCatalog(id) match {
+        case None     => catalog.findCatalog(id).flatMap {
           case Some(cat) => catalogResponse(cat, headers)
           case None      => NotFound(s"Resource not found: $path")
         }

--- a/dap2-service/src/main/scala/latis/service/dap2/HtmlCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/HtmlCatalogEncoder.scala
@@ -73,7 +73,7 @@ object HtmlCatalogEncoder {
 
   /** Provides a recursive HTML table representation of a Catalog's sub-catalogs */
   private[dap2] def subcatalogTable(catalog: Catalog, prefix: String = ""): IO[Text.TypedTag[String]] = {
-    val catalogs = Stream.emits(catalog.catalogs.toList)
+    val catalogs = Stream.eval(catalog.catalogs).flatMap(sub => Stream.emits(sub.toList))
     catalogs.evalMap { c =>
       val id = c._1.asString
       val cat = c._2

--- a/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
@@ -15,7 +15,8 @@ object JsonCatalogEncoder {
   /** Provides a JSON representation of a Catalog for a dap2 response. */
   def encode(catalog: Catalog, id: Option[Identifier] = None): IO[Json] =
     for {
-      cats <- catalog.catalogs.toList.traverse { case (id, cat) => encode(cat, Some(id)) }
+      subs <- catalog.catalogs
+      cats <- subs.toList.traverse { case (id, cat) => encode(cat, Some(id)) }
       dss  <- catalog.datasets.compile.toList.map(dss => dss.map(datasetToJson))
     } yield {
       val fields = List(


### PR DESCRIPTION
This commit changes the type of a catalog's subcatalogs from a map to an IO computation that produces a map to allow more flexibility in how subcatalogs are defined.