### PR TITLE
Bin width

### DIFF
--- a/core/src/main/scala/latis/model/ScalarAlgebra.scala
+++ b/core/src/main/scala/latis/model/ScalarAlgebra.scala
@@ -94,6 +94,14 @@ trait ScalarAlgebra { scalar: Scalar =>
       }
     }
   }
+  
+  /** 
+   * Determines if this Scalar represents binned (not instantaneous) values. 
+   * 
+   * This is currently based on the existence of the `binWidth` property.
+   * This may evolve as additional bin semantics are supported.
+   */
+  def isBinned: Boolean = binWidth.nonEmpty
 
   /** Defines the string representation as the Scalar id. */
   override def toString: String = id.asString

--- a/core/src/main/scala/latis/model/ScalarFactory.scala
+++ b/core/src/main/scala/latis/model/ScalarFactory.scala
@@ -35,6 +35,7 @@ trait ScalarFactory {
         fillValue <- getFillValue(metadata, valueType)
         precision <- getPrecision(metadata, valueType)
         ascending <- getAscending(metadata)
+        binWidth  <- getBinWidth(metadata, valueType)
       } yield new Scalar(
         metadata,
         id,
@@ -44,7 +45,8 @@ trait ScalarFactory {
         missingValue = missValue,
         fillValue = fillValue,
         precision = precision,
-        ascending = ascending
+        ascending = ascending,
+        binWidth = binWidth
       )
     } //TODO: other properties
 
@@ -95,4 +97,13 @@ trait ScalarFactory {
       case "desc" => false.asRight
       case _      => LatisException("Order must be 'asc' or 'desc'").asLeft
     }
+    
+  protected def getBinWidth(metadata: Metadata,  valueType: ValueType): Either[LatisException, Option[Double]] =
+    //TODO: enforce NumericType, override in Time for StringType (ms) and ISO 8601 duration
+    metadata.getProperty("binWidth").traverse { s =>
+      //if (valueType.isInstanceOf[NumericType]) {
+        s.toDoubleOption.toRight(LatisException("Could not parse binWidth"))
+      //} else LatisException("Only numeric Scalars support binWidth").asLeft
+    }
+    
 }

--- a/core/src/main/scala/latis/model/dataType.scala
+++ b/core/src/main/scala/latis/model/dataType.scala
@@ -25,7 +25,8 @@ class Scalar(
   val missingValue: Option[Data] = None,
   val fillValue: Option[Data] = None,
   val precision: Option[Int] = None,
-  val ascending: Boolean = true
+  val ascending: Boolean = true,
+  val binWidth: Option[Double] = None
 ) extends DataType with ScalarAlgebra
   //TODO: coverage, cadence, resolution, start, end,... (see fdml schema)
 

--- a/core/src/main/scala/latis/ops/Selection.scala
+++ b/core/src/main/scala/latis/ops/Selection.scala
@@ -161,13 +161,11 @@ object Selection {
 
     // Make lean predicate based on selection operator
     operator match {
-      case ast.Eq   => (d: Datum) => bounder(d).contains(dvalue)
-      case ast.EqEq => (d: Datum) => bounder(d).contains(dvalue)
-      case ast.NeEq => (d: Datum) => ! bounder(d).contains(dvalue)
-      case ast.Gt   => (d: Datum) => bounder(d).lower >  dvalue
-      case ast.GtEq => (d: Datum) => bounder(d).upper >  dvalue
-      case ast.Lt   => (d: Datum) => bounder(d).upper <= dvalue
-      case ast.LtEq => (d: Datum) => bounder(d).lower <= dvalue
+      case ast.Eq            => (d: Datum) => bounder(d).contains(dvalue)
+      case ast.EqEq          => (d: Datum) => bounder(d).contains(dvalue)
+      case ast.NeEq          => (d: Datum) => ! bounder(d).contains(dvalue)
+      case ast.Gt | ast.GtEq => (d: Datum) => bounder(d).upper >  dvalue
+      case ast.Lt | ast.LtEq => (d: Datum) => bounder(d).lower <= dvalue
       case _ => throw LatisException(s"Unsupported selection operator: $ast.prettyOp(operator)") //TODO: prevent by construction
     }
   }

--- a/core/src/main/scala/latis/time/Time.scala
+++ b/core/src/main/scala/latis/time/Time.scala
@@ -30,7 +30,8 @@ class Time protected (
   missingValue: Option[Data] = None,
   fillValue: Option[Data] = None,
   precision: Option[Int] = None,
-  ascending: Boolean = true
+  ascending: Boolean = true,
+  binWidth: Option[Double]
 ) extends Scalar(
   metadata,
   id,
@@ -40,7 +41,8 @@ class Time protected (
   missingValue = missingValue,
   fillValue = fillValue,
   precision = precision,
-  ascending = ascending
+  ascending = ascending,
+  binWidth = binWidth
 ) {
 
   /** Provides safe access to Time's MeasurementScale. */
@@ -159,6 +161,7 @@ object Time extends ScalarFactory {
       fillValue <- getFillValue(metadata, valueType)
       precision <- getPrecision(metadata, valueType)
       ascending <- getAscending(metadata)
+      binWidth  <- getBinWidth(metadata, valueType)
     } yield new Time(
       metadata + ("class" -> "latis.time.Time"),
       id,
@@ -169,7 +172,8 @@ object Time extends ScalarFactory {
       missingValue = missValue,
       fillValue = fillValue,
       precision = precision,
-      ascending = ascending
+      ascending = ascending,
+      binWidth = binWidth
     )
   }
 

--- a/core/src/test/scala/latis/ops/SelectionSuite.scala
+++ b/core/src/test/scala/latis/ops/SelectionSuite.scala
@@ -48,13 +48,13 @@ class SelectionSuite extends FunSuite {
     val value = Data.DoubleValue(0.5)
     assert(Selection.datumPredicateWithBinning(binnedScalar, ast.Gt, value)(datum))
   }
-  test("bin not gt start") {
+  test("bin gt start") {
     val value = Data.DoubleValue(1.0)
-    assert(! Selection.datumPredicateWithBinning(binnedScalar, ast.Gt, value)(datum))
+    assert(Selection.datumPredicateWithBinning(binnedScalar, ast.Gt, value)(datum))
   }
-  test("bin not gt in bin") {
+  test("bin gt in bin") {
     val value = Data.DoubleValue(1.5)
-    assert(! Selection.datumPredicateWithBinning(binnedScalar, ast.Gt, value)(datum))
+    assert(Selection.datumPredicateWithBinning(binnedScalar, ast.Gt, value)(datum))
   }
   test("bin not gt end") {
     val value = Data.DoubleValue(2.0)
@@ -90,13 +90,13 @@ class SelectionSuite extends FunSuite {
     val value = Data.DoubleValue(0.5)
     assert(! Selection.datumPredicateWithBinning(binnedScalar, ast.Lt, value)(datum))
   }
-  test("bin not lt start") {
+  test("bin lt start") {
     val value = Data.DoubleValue(1.0)
-    assert(! Selection.datumPredicateWithBinning(binnedScalar, ast.Lt, value)(datum))
+    assert(Selection.datumPredicateWithBinning(binnedScalar, ast.Lt, value)(datum))
   }
-  test("bin not lt in bin") {
+  test("bin lt in bin") {
     val value = Data.DoubleValue(1.5)
-    assert(! Selection.datumPredicateWithBinning(binnedScalar, ast.Lt, value)(datum))
+    assert(Selection.datumPredicateWithBinning(binnedScalar, ast.Lt, value)(datum))
   }
   test("bin lt end") {
     val value = Data.DoubleValue(2.0)


### PR DESCRIPTION
This adds `binWidth` as a first class property of a `Scalar` variable instead of relying on the mere presence of an uncontrolled `binWidth` in the metadata. This current change is slightly better than the existing behavior but no worse other than making `binWidth` explicit might suggest more robust support. Yet to do: Make `Scalar` construction with `binWidth` more robust (e.g. `NumericType`) and add support for `Time` variables with string types (defaulting to ms) and ISO 8601 durations. We also need to make sure that operations that change the units (e.g. `ConvertTime`) will also change the binWidth.

This also changes the behavior of the exclusive `>` and `<` selection operators. These need to match partially overlapping bins to support granule list datasets. We are currently losing all the matching samples from a file when the selected value is within its time bounds.