### PR TITLE
Address NetCDF deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,10 +230,7 @@ lazy val netcdf = project
     ),
     resolvers ++= Seq(
       "Unidata" at "https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases"
-    ),
-    scalacOptions --= {
-      if (insideCI.value) Seq("-Wconf:any:e") else Seq()
-    }
+    )
   )
 
 lazy val jdbc = project

--- a/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
+++ b/netcdf/src/main/scala/latis/output/NetcdfEncoder.scala
@@ -279,13 +279,13 @@ object NetcdfEncoder {
   private def build(
     builder: NetcdfFormatWriter.Builder
   ): Resource[IO, NetcdfFormatWriter] =
-    Resource.fromAutoCloseable(IO(builder.build()))
+    Resource.fromAutoCloseable(IO.blocking(builder.build()))
 
   private def write(
     writer: NetcdfFormatWriter,
     varName: String,
     data: NcArray
-  ): IO[Unit] = IO { writer.write(varName, data) }
+  ): IO[Unit] = IO.blocking(writer.write(varName, data))
 
   private def addGlobalAttribute(
     builder: NetcdfFormatWriter.Builder,


### PR DESCRIPTION
These changes address all of the deprecation warnings from the NetCDF library and ensure that methods that will block threads are wrapped in `IO.blocking`.