### PR TITLE
Set default database fetch size

### DIFF
--- a/jdbc/src/main/scala/latis/input/JdbcAdapter.scala
+++ b/jdbc/src/main/scala/latis/input/JdbcAdapter.scala
@@ -255,7 +255,7 @@ object JdbcAdapter extends AdapterFactory {
   def apply(model: DataType, config: AdapterConfig): JdbcAdapter =
     new JdbcAdapter(model, JdbcAdapter.Config(config.properties *))
 
-  private val defaultFetchSize: Int = 100
+  private val defaultFetchSize: Int = 8192
 
   /**
    * Defines a JdbcAdapter specific configuration with type-safe accessors.


### PR DESCRIPTION
Typical usage is for large time series datasets which perform much better with a larger fetch size that 100. A fetch size larger than 8192 can perform a little better but at the risk of higher memory usage.