### PR TITLE
Data Model Complexity

### DIFF
--- a/core/src/main/scala/latis/ops/FlatMapOperation.scala
+++ b/core/src/main/scala/latis/ops/FlatMapOperation.scala
@@ -14,7 +14,7 @@ import latis.model.*
  * into a stream of Samples.
  */
 trait FlatMapOperation extends StreamOperation {
-  
+
   /**
    * Defines a function that generates a SampledFunction
    * from a Sample.

--- a/core/src/main/scala/latis/output/JsonEncoder.scala
+++ b/core/src/main/scala/latis/output/JsonEncoder.scala
@@ -7,6 +7,7 @@ import io.circe.syntax.*
 
 import latis.dataset.*
 import latis.ops.Uncurry
+import latis.util.LatisException
 
 class JsonEncoder extends Encoder[IO, Json] {
   //TODO: use Scalar.formatValue so we can apply precision...
@@ -14,10 +15,21 @@ class JsonEncoder extends Encoder[IO, Json] {
   /**
    * Encodes the Stream of Samples from the given Dataset as a Stream
    * of JSON arrays.
+   *
+   * If the Dataset represents a simply nested Function, it will be flattened
+   * with the Uncurry operation. A complex nested Function (e.g. Tuple
+   * containing a Function) will throw a LatisException (until we improve our types).
    */
   override def encode(dataset: Dataset): Stream[IO, Json] = {
-    val uncurriedDataset = dataset.withOperation(Uncurry())
+
+    if (dataset.model.isComplex)
+      throw LatisException(s"JsonEncoder does not support complex model: ${dataset.model}")
+
+    val flatDataset =
+      if (dataset.model.isSimplyNested) dataset.withOperation(Uncurry())
+      else dataset
+
     // Encode each Sample as a String in the Stream
-    uncurriedDataset.samples.map(_.asJson)
+    flatDataset.samples.map(_.asJson)
   }
 }

--- a/core/src/test/scala/latis/model/DataTypeSuite.scala
+++ b/core/src/test/scala/latis/model/DataTypeSuite.scala
@@ -140,4 +140,44 @@ class DataTypeSuite extends FunSuite {
   test("self exists") {
     assert(f.exists(_.isInstanceOf[Function]))
   }
+
+  //---- simply nested function ---//
+
+  test("scalar is not simply nested") {
+    assert(! x.isSimplyNested)
+  }
+
+  test("tuple is not simply nested") {
+    assert(! namedTup.isSimplyNested)
+  }
+
+  test("nested function is simply nested") {
+    assert(nestedF.isSimplyNested)
+  }
+
+  test("complex nested function is not simply nested") {
+    assert(! nestedFInTup.isSimplyNested)
+  }
+
+  //---- complexity ----//
+
+  test("scalar is not complex") {
+    assert(! x.isComplex)
+  }
+
+  test("nested tuple is not complex") {
+    assert(! nestedTup.isComplex)
+  }
+
+  test("tuple with function is complex") {
+    assert(tupWithF.isComplex)
+  }
+
+  test("simply nested function is not complex") {
+    assert(! nestedF.isComplex)
+  }
+
+  test("complex nested function is complex") {
+    assert(nestedFInTup.isComplex)
+  }
 }

--- a/netcdf/src/test/scala/latis/output/NetcdfEncoderSuite.scala
+++ b/netcdf/src/test/scala/latis/output/NetcdfEncoderSuite.scala
@@ -165,7 +165,7 @@ class NetcdfEncoderSuite extends CatsEffectSuite {
 
   tempFile.test("include global metadata in the file") { file =>
     val enc              = NetcdfEncoder(file)
-    val expectedMetadata = Metadata(id"dataset_with_metadata") + ("globalFoo" -> "globalBar") + ("history" -> "Uncurry()")
+    val expectedMetadata = Metadata(id"dataset_with_metadata") + ("globalFoo" -> "globalBar")
 
     enc.encode(dataset_with_metadata).compile.onlyOrError.flatMap { file =>
       Resource.fromAutoCloseable(


### PR DESCRIPTION
This adds methods to DataType to assess the complexity of a data model.

- **isSimplyNested**: indicates whether the data model has nested Functions that are the sole variable in another Function's range, which can be flattened with Uncurry.
- **isComplex**: indicates whether the data model has Functions within Tuples, which prevents application of many Operations and Encoders.

These properties arose out of the need to avoid using Uncurry when not needed. Uncurry uses a Stream.flatMap which yields many small chunks, presumably impacting IO buffering performance. I did experiment with rechunking to 8k samples. That improved the Uncurry throughput by a factor of 5, but not calling Uncurry at all was 10 times faster. We should revisit how we can better manage chunk sizes.

I also took this opportunity to do more robust checking if an Encoder is applicable, as opposed to letting it fail as it may. We need to rethink the Encoder API to capture these errors before streaming without throwing.
