### PR TITLE
Error messages

### DIFF
--- a/core/src/main/scala/latis/ops/MapOperation.scala
+++ b/core/src/main/scala/latis/ops/MapOperation.scala
@@ -40,7 +40,7 @@ trait MapOperation extends StreamOperation { self =>
         }.evalTapChunk {
           case Left(t) =>
             cntRef.updateAndGet(_ + 1).flatMap { cnt =>
-              if ((cnt & (cnt - 1)) == 0) {
+              if ((cnt & (cnt - 1)) == 0) { // true for powers of 2
                 val msg = s"MapOperation warning #$cnt: Sample dropped. $t"
                 IO.println(msg) //TODO: log
               } else IO.unit


### PR DESCRIPTION
Instead of printing a message for every failed sample in the MapOperation, use exponential backoff printing every 2^nth message. 

This adds similar "logging" for the Filter operation. It got a bit messier since the predicate construction returns an Either. (Some day I'd like to fail to construct a Filter when it can't make a predicate for a given Dataset's model.) The only way I could figure to intervene with an error message from a predicate application was to use `map` instead of `filter` then collect the true samples.