### PR TITLE
Combine subcatalogs

### DIFF
--- a/core/src/main/scala/latis/catalog/Catalog.scala
+++ b/core/src/main/scala/latis/catalog/Catalog.scala
@@ -136,7 +136,7 @@ object Catalog {
     def empty: Catalog = Catalog.empty
 
     def combine(x: Catalog, y: Catalog): Catalog = new Catalog {
-      //TODO: deal with duplicate dataset ids, keep last like Map?
+
       override val datasets: Stream[IO, Dataset] = x.datasets ++ y.datasets
 
       // Catalogs with the same identifier will have their elements combined

--- a/core/src/main/scala/latis/catalog/Catalog.scala
+++ b/core/src/main/scala/latis/catalog/Catalog.scala
@@ -136,7 +136,12 @@ object Catalog {
     def empty: Catalog = Catalog.empty
 
     def combine(x: Catalog, y: Catalog): Catalog = new Catalog {
+      //TODO: deal with duplicate dataset ids, keep last like Map?
       override val datasets: Stream[IO, Dataset] = x.datasets ++ y.datasets
+
+      // Catalogs with the same identifier will have their elements combined
+      override def catalogs: IO[Map[Identifier, Catalog]] =
+        (x.catalogs, y.catalogs).mapN(_ |+| _)
 
       override def findDataset(name: Identifier): IO[Option[Dataset]] =
         (OptionT(x.findDataset(name)) <+> OptionT(y.findDataset(name))).value

--- a/core/src/test/scala/latis/catalog/CatalogSuite.scala
+++ b/core/src/test/scala/latis/catalog/CatalogSuite.scala
@@ -96,4 +96,28 @@ class CatalogSuite extends CatsEffectSuite {
   test("filter(_ => false) removes all datasets") {
     listAll(nested.filter(_ => false)).map(_.isEmpty).assert
   }
+
+  test("combined catalogs with same dataset id keeps the last".ignore) {
+    val dsdup = DatasetGenerator("x: double -> y: double", id"ds1")
+    val catWithDup = Catalog(dsdup)
+    val cat = c1 |+| catWithDup
+    //listAll(cat).map(_.foreach(println))
+    cat.datasets.compile.toList.map { dss =>
+      assertEquals(dss.size, 2)
+    }
+  }
+
+  test("combined nested catalogs with the same id are merged") {
+    val cat1 = Catalog.empty.withCatalogs(id"a" -> Catalog(ds1))
+    val cat2 = Catalog.empty.withCatalogs(id"a" -> Catalog(ds2))
+    val cat = cat1 |+| cat2
+    for {
+      cats <- cat.catalogs
+      dss  <- cats(id"a").datasets.compile.toList
+    } yield {
+      assertEquals(cats.size, 1) // just the single "a" catalog
+      assertEquals(dss.size, 2)  // merged catalog has both datasets
+    }
+  }
+
 }

--- a/core/src/test/scala/latis/catalog/CatalogSuite.scala
+++ b/core/src/test/scala/latis/catalog/CatalogSuite.scala
@@ -7,6 +7,7 @@ import munit.CatsEffectSuite
 
 import latis.dataset.Dataset
 import latis.dsl.DatasetGenerator
+import latis.model.*
 import latis.util.Identifier.*
 
 class CatalogSuite extends CatsEffectSuite {
@@ -97,13 +98,17 @@ class CatalogSuite extends CatsEffectSuite {
     listAll(nested.filter(_ => false)).map(_.isEmpty).assert
   }
 
-  test("combined catalogs with same dataset id keeps the last".ignore) {
+  test("combined catalogs with same dataset id finds the first") {
     val dsdup = DatasetGenerator("x: double -> y: double", id"ds1")
     val catWithDup = Catalog(dsdup)
     val cat = c1 |+| catWithDup
-    //listAll(cat).map(_.foreach(println))
-    cat.datasets.compile.toList.map { dss =>
-      assertEquals(dss.size, 2)
+    cat.findDataset(id"ds1").map {
+      case Some(ds) => ds.model match {
+        case Function(s: Scalar, _) =>
+          assertEquals(s.id, id"a")
+        case _ => fail("Unexpected model")
+      }
+      case _ => fail("Failed to find dataset")
     }
   }
 


### PR DESCRIPTION
Subcatalogs with the same identifier will have their contents combined. This notes that there is a problem when combining catalogs with datasets that have the same identifier. #781