### PR TITLE
Order subcatalogs by id in JSON encoding

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
@@ -16,7 +16,9 @@ object JsonCatalogEncoder {
   def encode(catalog: Catalog, id: Option[Identifier] = None): IO[Json] =
     for {
       subs <- catalog.catalogs
-      cats <- subs.toList.traverse { case (id, cat) => encode(cat, Some(id)) }
+      cats <- subs.toList.sortBy(_._1).traverse { 
+        case (id, cat) => encode(cat, Some(id)) 
+      }
       dss  <- catalog.datasets.compile.toList.map(dss => dss.map(datasetToJson))
     } yield {
       val fields = List(

--- a/dap2-service/src/test/scala/latis/service/dap2/JsonCatalogEncoderSuite.scala
+++ b/dap2-service/src/test/scala/latis/service/dap2/JsonCatalogEncoderSuite.scala
@@ -15,11 +15,11 @@ class JsonCatalogEncoderSuite extends CatsEffectSuite {
 
   private lazy val catalog: Catalog = {
     Catalog(ds0)
-      .addCatalog(id"cat1", Catalog(ds1))
       .addCatalog(id"cat2", Catalog(ds2))
+      .addCatalog(id"cat1", Catalog(ds1))
   }
 
-  test("json catalog") {
+  test("json catalog with ordering") {
     val expected =
       """{
         |  "catalog" : [

--- a/macros/src/main/scala/latis/util/identifier.scala
+++ b/macros/src/main/scala/latis/util/identifier.scala
@@ -26,6 +26,9 @@ object Identifier {
       ${IdentifierLiteral('ctx, 'args)}
   }
 
+  given Ordering[Identifier] with
+    def compare(x: Identifier, y: Identifier): Int = x.compareTo(y)
+
   /**
    * Returns whether the String is a regex "word" that doesn't start
    * with a digit (may also contain dots).

--- a/macros/src/test/scala/latis/util/IdentifierSuite.scala
+++ b/macros/src/test/scala/latis/util/IdentifierSuite.scala
@@ -44,4 +44,8 @@ class IdentifierSuite extends FunSuite {
     )
   }
 
+  test("identifier ordering") {
+    val ids = List(id"b", id"a").sorted
+    assertEquals(ids.head, id"a")
+  }
 }


### PR DESCRIPTION
I added an Ordering for Identifier to make this a bit cleaner and for potential future use. 

I can image the need for a different ordering for subcatalogs, such as "by title" or "as added". Arguably, it should be up to the client to decide how to show the subcatalogs, but this seems like a good default that will make it easier to inspect. Clients should not *expect* the subcatalogs to be ordered by id, so we have the freedom to change this behavior.
We can revisit this for a Catalog refactor where we may want to use something other than a `Map` for subcatalogs.