### PR TITLE
Improve DataType equality check

### DIFF
--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -40,7 +40,7 @@ case class Projection(ids: Identifier*) extends MapOperation {
       //TODO: if Cartesian, replace each non-projected domain scalar with index
       applyToVariable(domain) match {
         // Domain unchanged
-        case Some(d) if (d == domain) =>
+        case Some(d) if (equivalentScalarIds(d, domain)) =>
           applyToVariable(range) match {
             case Some(r) => Some(Function.from(domain, r).fold(throw _, identity))
             // If no range variables projected, put domain in range and make index domain
@@ -58,6 +58,16 @@ case class Projection(ids: Identifier*) extends MapOperation {
             Function.from(makeIndex(domain), r).fold(throw _, identity)
           }
       }
+  }
+
+  /**
+   * Determines if two variables are effectively equivalent in the context of
+   * projections by comparing the contained Scalar variable ids.
+   */
+  private def equivalentScalarIds(v1: DataType, v2: DataType): Boolean = {
+    val vs1 = v1.getScalars
+    val vs2 = v2.getScalars
+    (vs1.length == vs2.length) && vs1.zip(vs2).forall(p => p._1.id == p._2.id)
   }
 
   override def mapFunction(model: DataType): Sample => Sample = {

--- a/core/src/test/scala/latis/ops/ProjectionSuite.scala
+++ b/core/src/test/scala/latis/ops/ProjectionSuite.scala
@@ -108,4 +108,12 @@ class ProjectionSuite extends CatsEffectSuite {
       Sample(List.empty, List(0.0))
     )
   }
+
+  test("Project all 2D domain variables and range subset") {
+    val ds = DatasetGenerator("(x, y) -> (a, b)")
+      .project("x,y,a")
+    ds.samples.take(1).compile.lastOrError.assertEquals(
+      Sample(List(0, 0), List(0))
+    )
+  }
 }

--- a/dap2-service/src/test/scala/latis/service/dap2/AtomicTypeSuite.scala
+++ b/dap2-service/src/test/scala/latis/service/dap2/AtomicTypeSuite.scala
@@ -1,7 +1,8 @@
 package latis.service.dap2
 
+import java.net.URI
+
 import munit.CatsEffectSuite
-import java.net.URL
 
 import latis.service.dap2.AtomicType.*
 
@@ -27,7 +28,7 @@ class AtomicTypeSuite extends CatsEffectSuite {
     assertEquals(Float32.asDasString(13.14159265359f), "13.1416")
     assertEquals(Float64.asDasString(13.14159265359), "13.1416")
     assertEquals(String.asDasString("test\\string\"quote\""), "\"test\\\\string\\\"quote\\\"\"")
-    assertEquals(Url.asDasString(new URL("https://lasp.colorado.edu")), "\"https://lasp.colorado.edu\"")
+    assertEquals(Url.asDasString(URI.create("https://lasp.colorado.edu").toURL()), "\"https://lasp.colorado.edu\"")
   }
 
   test("asDasString correctly maps out-of-range UInts to the correct min/max") {


### PR DESCRIPTION
This allows us to project all variables in a (n>1)D domain and a subset of range variables. Otherwise (due to the previous DataType equality check) we get the error about projecting just part of a domain.