### PR TITLE
Add S3 module with utilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val `aws-lambda` = project
     }
   )
 
-lazy val S3 = project
+lazy val s3 = project
   .in(file("s3"))
   .dependsOn(core)
   .settings(commonSettings)
@@ -99,21 +99,6 @@ lazy val S3 = project
       "com.github.fs2-blobstore" %% "s3" % "0.9.15",
       "software.amazon.awssdk" % "s3" % "2.31.59",
       "com.dimafeng" %% "testcontainers-scala-localstack-v2" % "0.43.0" % Test
-    )
-  )
-
-lazy val awsS3 = project
-  .in(file("aws-s3"))
-  .dependsOn(core)
-  .settings(commonSettings)
-  .settings(
-    name := "latis3-aws-s3",
-    libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-core" % "1.12.746" % Test,
-      "ch.qos.logback" % "logback-classic" % logbackVersion % Test,
-      "com.github.fs2-blobstore" %% "s3" % "0.9.14",
-      "software.amazon.awssdk" % "s3" % "2.26.5",
-      "com.dimafeng" %% "testcontainers-scala-localstack-v2" % "0.41.4" % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,36 @@ lazy val `aws-lambda` = project
     }
   )
 
+lazy val S3 = project
+  .in(file("s3"))
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    name := "latis3-s3",
+    libraryDependencies ++= Seq(
+      "com.amazonaws" % "aws-java-sdk-core" % "1.12.785" % Test,
+      "ch.qos.logback" % "logback-classic" % logbackVersion % Test,
+      "com.github.fs2-blobstore" %% "s3" % "0.9.15",
+      "software.amazon.awssdk" % "s3" % "2.31.59",
+      "com.dimafeng" %% "testcontainers-scala-localstack-v2" % "0.43.0" % Test
+    )
+  )
+
+lazy val awsS3 = project
+  .in(file("aws-s3"))
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    name := "latis3-aws-s3",
+    libraryDependencies ++= Seq(
+      "com.amazonaws" % "aws-java-sdk-core" % "1.12.746" % Test,
+      "ch.qos.logback" % "logback-classic" % logbackVersion % Test,
+      "com.github.fs2-blobstore" %% "s3" % "0.9.14",
+      "software.amazon.awssdk" % "s3" % "2.26.5",
+      "com.dimafeng" %% "testcontainers-scala-localstack-v2" % "0.41.4" % Test
+    )
+  )
+
 lazy val core = project
   .dependsOn(`dap2-parser`)
   .dependsOn(macros)

--- a/s3/src/main/scala/latis/input/S3GranuleListAdapter.scala
+++ b/s3/src/main/scala/latis/input/S3GranuleListAdapter.scala
@@ -1,0 +1,18 @@
+package latis.input
+
+import java.net.URI
+
+import cats.effect.IO
+
+import latis.data.*
+import latis.model.*
+
+class S3GranuleListAdapter(
+  model: DataType,
+  config: FileListAdapter.Config
+) extends StreamingAdapter[String] {
+
+  def recordStream(uri: URI): fs2.Stream[IO, String] = ???
+
+  def parseRecord(r: String): Option[Sample] = ???
+}

--- a/s3/src/main/scala/latis/util/S3Utils.scala
+++ b/s3/src/main/scala/latis/util/S3Utils.scala
@@ -21,12 +21,12 @@ object S3Utils {
   //  Do we need to traverse directories and order as we go?
 
   /** Makes an S3 client. */
-  def makeClient(region: Region = Region.US_EAST_1): S3Client =
+  def makeClient(region: Region): S3Client =
     S3Client.builder.region(region).build
 
   /** Makes an effectful S3 client. */
   //TODO: Async here? delay?
-  def makeClientF[F[_] : Async](region: Region = Region.US_EAST_1): F[S3AsyncClient] =
+  def makeClientF[F[_] : Async](region: Region): F[S3AsyncClient] =
     Async[F].delay(S3AsyncClient.builder.region(region).build)
 
   /** Returns an Iterator of keys for the objects in an S3 bucket. */

--- a/s3/src/main/scala/latis/util/S3Utils.scala
+++ b/s3/src/main/scala/latis/util/S3Utils.scala
@@ -1,0 +1,57 @@
+package latis.util
+
+import scala.jdk.CollectionConverters.*
+
+import blobstore.s3.S3Store
+import blobstore.url.*
+import cats.effect.Async
+import cats.syntax.all.*
+import fs2.*
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+
+object S3Utils {
+  //TODO: generalize for any supported blobstore: azure, box, gcs (google), sftp
+  //TODO: special concerns for directory buckets?
+  //  https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+  //  "For general purpose buckets, ListObjectsV2 returns objects in lexicographical order based on their key names."
+  //  "For directory buckets, ListObjectsV2 does not return objects in lexicographical order."
+  //  Do we need to traverse directories and order as we go?
+
+  /** Makes an S3 client. */
+  def makeClient(region: Region = Region.US_EAST_1): S3Client =
+    S3Client.builder.region(region).build
+
+  /** Makes an effectful S3 client. */
+  //TODO: Async here? delay?
+  def makeClientF[F[_] : Async](region: Region = Region.US_EAST_1): F[S3AsyncClient] =
+    Async[F].delay(S3AsyncClient.builder.region(region).build)
+
+  /** Returns an Iterator of keys for the objects in an S3 bucket. */
+  def getKeys(client: S3Client, bucket: String, prefix: String): Iterator[String] = {
+    val request = ListObjectsV2Request.builder
+      .bucket(bucket)
+      .prefix(prefix)
+      .build
+
+    client.listObjectsV2Paginator(request).iterator.asScala
+      .flatMap(resp => resp.contents.asScala.map(_.key))
+  }
+
+  /** Effectfully gets a Stream of keys from an S3 bucket. */
+  //TODO: take advantage of S3Client's startAfter (e.g. polling for updates), not in S3Store?
+  //TODO: optional prefix? default = "/"?
+  def getKeysF[F[_] : Async](client: S3AsyncClient, bucketName: String, prefix: String): F[Stream[F, String]] = {
+    for {
+      // Just keeping the first error out of possibly many. //TODO: risk missing useful error?
+      store <- S3Store.builder[F](client).build.leftMap(_.head).liftTo[F]
+      host  <- Hostname.parseF[F](bucketName)
+    } yield {
+      val url = Url("s3", Authority(host), Path(prefix))
+      store.list(url, true).map(_.representation.key)
+    }
+  }
+
+}

--- a/s3/src/test/resources/logback-test.xml
+++ b/s3/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+  <appender name="STDOUT" class="ConsoleAppender">
+    <encoder class="PatternLayoutEncoder">
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="error">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/s3/src/test/scala/latis/util/S3UtilsSuite.scala
+++ b/s3/src/test/scala/latis/util/S3UtilsSuite.scala
@@ -8,6 +8,7 @@ import com.dimafeng.testcontainers.LocalStackV2Container
 import munit.catseffect.IOFixture
 import org.testcontainers.containers.localstack.LocalStackContainer.Service
 import software.amazon.awssdk.core.async.AsyncRequestBody
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
@@ -81,7 +82,7 @@ class S3UtilsSuite extends munit.CatsEffectSuite {
       }
     }
   }
-  
+
   //=== Test with NOAA data ===//
 
   val bucket = "noaa-nesdis-swfo-ccor-1-pds"
@@ -90,14 +91,14 @@ class S3UtilsSuite extends munit.CatsEffectSuite {
     "sci_ccor1-l3_g19_s20250225T000020Z_e20250225T000048Z_p20250401T234952Z_pub.fits"
 
   test("pure client") {
-    val client = makeClient()
+    val client = makeClient(Region.US_EAST_1)
     val key = getKeys(client, bucket, prefix).toList.head
     assertEquals(first, key)
   }
 
   test("effectful client") {
     for {
-      client <- makeClientF[IO]()
+      client <- makeClientF[IO](Region.US_EAST_1)
       keys   <- getKeysF[IO](client, bucket, prefix)
       last   <- keys.head.compile.last
       key    <- IO.fromOption(last)(fail("Empty list of keys")) //TODO: does this failure work?
@@ -108,7 +109,7 @@ class S3UtilsSuite extends munit.CatsEffectSuite {
 
   test("chunk size") {
     for {
-      client <- makeClientF[IO]()
+      client <- makeClientF[IO](Region.US_EAST_1)
       keys   <- getKeysF[IO](client, bucket, prefix)
       last   <- keys.chunks.head.compile.last
       chunk  <- IO.fromOption(last)(fail("Empty list of keys")) //TODO: does this failure work?

--- a/s3/src/test/scala/latis/util/S3UtilsSuite.scala
+++ b/s3/src/test/scala/latis/util/S3UtilsSuite.scala
@@ -1,0 +1,120 @@
+package latis.util
+
+import scala.concurrent.duration.Duration
+
+import cats.effect.IO
+import cats.effect.Resource
+import com.dimafeng.testcontainers.LocalStackV2Container
+import munit.catseffect.IOFixture
+import org.testcontainers.containers.localstack.LocalStackContainer.Service
+import software.amazon.awssdk.core.async.AsyncRequestBody
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+
+import latis.util.S3Utils.*
+
+class S3UtilsSuite extends munit.CatsEffectSuite {
+
+  //Starting the test container is slow.
+  override val munitIOTimeout: Duration = Duration(1, "minute")
+
+  private def makeBucket(client: S3AsyncClient, bucket: String) = {
+    IO.fromCompletableFuture {
+      IO {
+        client.createBucket(
+          CreateBucketRequest.builder().bucket(bucket).build()
+        )
+      }
+    }
+  }
+
+  private def putEmpty(client: S3AsyncClient, bucket: String, key: String) =
+    IO.fromCompletableFuture {
+      IO {
+        client.putObject(
+          PutObjectRequest.builder().bucket(bucket).key(key).build(),
+          AsyncRequestBody.empty()
+        )
+      }
+    }
+
+  val s3Client: IOFixture[S3AsyncClient] = {
+    val localStack: Resource[IO, LocalStackV2Container] = {
+      val mkContainer = IO {
+        LocalStackV2Container(services = List(Service.S3))
+      }.flatTap(container => IO(container.start()))
+      Resource.make(mkContainer)(container => IO(container.stop()))
+    }
+
+    val client: Resource[IO, S3AsyncClient] = localStack.flatMap { ls =>
+      val mkClient = IO {
+        S3AsyncClient
+          .builder()
+          .endpointOverride(ls.endpointOverride(Service.S3))
+          .credentialsProvider(ls.staticCredentialsProvider)
+          .region(ls.region)
+          .build()
+      }
+      Resource.make(mkClient)(client => IO(client.close()))
+    }.evalTap { client =>
+      makeBucket(client, "foobar")
+        >> putEmpty(client, "foobar", "foo")
+        >> putEmpty(client, "foobar", "bar")
+        >> makeBucket(client, "barfoo")
+        >> putEmpty(client, "foobar", "bar")
+        >> putEmpty(client, "foobar", "foo")
+    }
+
+    ResourceSuiteLocalFixture("s3-client", client)
+  }
+
+  override val munitFixtures = List(s3Client)
+
+  test("ordering") {
+    IO(s3Client()).flatTap { client =>
+      getKeysF[IO](client, "foobar", "/").flatMap { stream =>
+        stream.compile.toList.map {
+          case "bar" :: "foo" :: Nil => ()
+          case _ => fail("Objects not ordered as expected.")
+        }
+      }
+    }
+  }
+  
+  //=== Test with NOAA data ===//
+
+  val bucket = "noaa-nesdis-swfo-ccor-1-pds"
+  val prefix = "SWFO/GOES-19/CCOR-1/ccor1-l3_science/"
+  val first = "SWFO/GOES-19/CCOR-1/ccor1-l3_science/2025/02/25/" +
+    "sci_ccor1-l3_g19_s20250225T000020Z_e20250225T000048Z_p20250401T234952Z_pub.fits"
+
+  test("pure client") {
+    val client = makeClient()
+    val key = getKeys(client, bucket, prefix).toList.head
+    assertEquals(first, key)
+  }
+
+  test("effectful client") {
+    for {
+      client <- makeClientF[IO]()
+      keys   <- getKeysF[IO](client, bucket, prefix)
+      last   <- keys.head.compile.last
+      key    <- IO.fromOption(last)(fail("Empty list of keys")) //TODO: does this failure work?
+    } yield {
+      assertEquals(first, key)
+    }
+  }
+
+  test("chunk size") {
+    for {
+      client <- makeClientF[IO]()
+      keys   <- getKeysF[IO](client, bucket, prefix)
+      last   <- keys.chunks.head.compile.last
+      chunk  <- IO.fromOption(last)(fail("Empty list of keys")) //TODO: does this failure work?
+    } yield {
+      assertEquals(1000, chunk.size)
+    }
+  }
+
+}


### PR DESCRIPTION
I've started making some utilities for working with S3 buckets, initially to support an S3 granule list adapter (coming soon). I decided to play with both the "regular" and the effectful approach. I have a number of `TODO`s for issues that we can discuss.

The testing also raises some questions. The first time I ran with localstack, it did take about a minute for it to start up. Subsequent runs were much faster. Not sure how it managed that. I wonder how it would play out in CI. I'd hate to slow down the tests too much. Note that I also tested with real buckets, breaking my "rule" for external dependencies.