### PR TITLE
Constrain Bounds

### DIFF
--- a/core/src/main/scala/latis/util/Bounds.scala
+++ b/core/src/main/scala/latis/util/Bounds.scala
@@ -6,7 +6,7 @@ package latis.util
  * It enforces that the upper bound is strictly greater than
  * the lower bound.
  */
-final class Bounds[T] private (val lower: T, val upper: T)(ord: Ordering[T]) {
+final case class Bounds[T] private (val lower: T, val upper: T)(ord: Ordering[T]) {
 
   /**
    * Tests whether the given value falls within this [[Bounds]].
@@ -37,7 +37,4 @@ object Bounds {
       case _ => None
     }
 
-  /** Extracts the lower and upper bounds. */
-  def unapplySeq[T](bounds: Bounds[T]): Option[Seq[T]] =
-    Some(Seq(bounds.lower, bounds.upper))
 }

--- a/core/src/main/scala/latis/util/Bounds.scala
+++ b/core/src/main/scala/latis/util/Bounds.scala
@@ -6,7 +6,7 @@ package latis.util
  * It enforces that the upper bound is strictly greater than
  * the lower bound.
  */
-final case class Bounds[T] private (val lower: T, val upper: T)(ord: Ordering[T]) {
+final case class Bounds[T] private (lower: T, upper: T)(ord: Ordering[T]) {
 
   /**
    * Tests whether the given value falls within this [[Bounds]].
@@ -22,6 +22,34 @@ final case class Bounds[T] private (val lower: T, val upper: T)(ord: Ordering[T]
     //Note that the default Double.TotalOrdering (unlike IeeeOrdering) will treat
     // NaN greater than other values but the less than test will be false.
     ord.gteq(value, lower) && (ord.lt(value, upper) || (inclusive && ord.equiv(value, upper)))
+  }
+
+  /**
+   * Constrains the lower bound.
+   *
+   * This optionally returns a new Bounds if the given value is greater than
+   * the current lower bound. Otherwise, it returns itself. If the bounds
+   * become invalid: lower > upper, this will return None.
+   *
+   * @param value the potentially new lower bound
+   */
+  def constrainLower(value: T): Option[Bounds[T]] = {
+    if (ord.gt(value, lower)) Bounds.of(value, upper)(ord)
+    else Some(this)
+  }
+
+  /**
+   * Constrains the upper bound.
+   *
+   * This optionally returns a new Bounds if the given value is less than the
+   * current upper bound. Otherwise, it returns itself. If the bounds become
+   * invalid: lower > upper, this will return None.
+   *
+   * @param value the potentially new upper bound
+   */
+  def constrainUpper(value: T): Option[Bounds[T]] = {
+    if (ord.lt(value, upper)) Bounds.of(lower, value)(ord)
+    else Some(this)
   }
 }
 

--- a/core/src/test/scala/latis/util/BoundsSuite.scala
+++ b/core/src/test/scala/latis/util/BoundsSuite.scala
@@ -68,9 +68,48 @@ class BoundsSuite extends FunSuite {
   test("extract bounds") {
     bounds match {
       case Bounds(l, u) =>
-        assert(l == -1)
-        assert(u == 2)
-      case _ => fail("")
+        assert(l == -1D)
+        assert(u == 2D)
     }
+  }
+
+  test("constrain lower bound") {
+    bounds.constrainLower(0).get match {
+      case Bounds(v, _) => assert(v == 0D)
+    }
+  }
+
+  test("don't constrain lower bound") {
+    bounds.constrainLower(-2).get match {
+      case Bounds(v, _) => assert(v == -1D)
+    }
+  }
+
+  test("constrain upper bound") {
+    bounds.constrainUpper(1).get match {
+      case Bounds(_, v) => assert(v == 1D)
+    }
+  }
+
+  test("don't constrain upper bound") {
+    bounds.constrainUpper(3).get match {
+      case Bounds(_, v) => assert(v == 2D)
+    }
+  }
+
+  test("lower constraint greater that upper bound") {
+    assert(bounds.constrainLower(3).isEmpty)
+  }
+
+  test("upper constraint lower that lower bound") {
+    assert(bounds.constrainUpper(-2).isEmpty)
+  }
+
+  test("Bound equality") {
+    assert(bounds == Bounds.of(-1, 2).get)
+  }
+
+  test("to string") {
+    assert(Bounds.of('a', 'c').get.toString == "Bounds(a,c)")
   }
 }


### PR DESCRIPTION
Inspire by the need to manage time ranges in some adapters, this adds the ability to constrain lower and upper bounds while not allowing invalid bounds: lower >= upper.