### PR TITLE
Propagate correlation ID to `LatisErrorHandler`

### DIFF
--- a/server/src/main/scala/latis/server/LatisServiceLogger.scala
+++ b/server/src/main/scala/latis/server/LatisServiceLogger.scala
@@ -1,11 +1,10 @@
 package latis.server
 
-import java.util.UUID
-
 import cats.data.Kleisli
 import cats.effect.Async
 import cats.effect.Clock
-import cats.effect.Sync
+import cats.effect.std.SecureRandom
+import cats.effect.std.UUIDGen
 import cats.syntax.all.*
 import fs2.Stream
 import org.http4s.HttpApp
@@ -21,12 +20,12 @@ import org.typelevel.log4cats.StructuredLogger
  */
 object LatisServiceLogger {
 
-  def apply[F[_]: Async](
+  def apply[F[_]: Async: SecureRandom](
     app: HttpApp[F],
     logger: StructuredLogger[F]
   ): HttpApp[F] = Kleisli { req =>
     for {
-      id       <- Sync[F].delay(UUID.randomUUID().toString())
+      id       <- UUIDGen.fromSecureRandom.randomUUID.map(_.toString())
       ctxLogger = StructuredLogger.withContext(logger)(Map("request-id" -> id))
       _        <- Http4sLogger.logMessage[F, Request[F]](req)(
         logHeaders = true, logBody = false


### PR DESCRIPTION
This PR propagates the correlation ID generated for each request to `LatisErrorHandler`.

The correlation ID is generated by `LatisServiceLogger` and is used in the logs it writes. Prior to these changes, there was no mechanism to use the correlation ID elsewhere, so logs made by `LatisErrorHandler` (and elsewhere) did not include the correlation ID.

The mechanism used to propagate the correlation ID here is the fiber-local environment provided by [`IOLocal`](https://typelevel.org/cats-effect/docs/core/io-local). An environment associated with a fiber works well for this use case because a fiber is spawned for each request being handled, and by holding the correlation ID in the fiber's environment we can make use of it at any point.

`IOLocal` is a concrete implementation of an environment associated with a fiber. [`Ask`](https://typelevel.org/cats-mtl/mtl-classes/ask.html) and [`Local`](https://typelevel.org/cats-mtl/mtl-classes/local.html) (from [Cats MTL](https://typelevel.org/cats-mtl/)) are the interfaces used to interact with an environment. `Ask` provides the ability to retrieve the environment. `Local` provides the ability to modify the environment for a subcomputation.

`LatisServiceLogger` now requires `Local` so it can add the correlation ID to the environment used by the rest of the response. `LatisErrorHandler` now requires `Ask` so it can retrieve the correlation ID and include it in logs. We need something that implements both `Local` and `Ask`, so we create an `IOLocal` (`IO.local[A]` actually produces a `Local[IO, A]` that wraps an `IOLocal` because that interface is safer to use) and make it available in implicit scope for both `LatisServiceLogger` and `LatisErrorHandler` (in `Latis3ServerBuilder`).

This approach requires that we add `Ask` to anything that would want to write logs that include the correlation ID. A slightly different approach would be to make a wrapper around loggers that handles the `Ask` part. I didn't do that here because this only adds correlation IDs for one logger and it looks like Log4Cats will hopefully be adding such a feature themselves sometime in the near future.

I also changed the UUID generation to use what's provided by Cats Effect instead of wrapping the Java `UUID` class.