### PR TITLE
Improve string representation of history

### DIFF
--- a/core/src/main/scala/latis/dataset/AbstractDataset.scala
+++ b/core/src/main/scala/latis/dataset/AbstractDataset.scala
@@ -24,11 +24,11 @@ abstract class AbstractDataset(
     val provenance: String =
       operations
         .map(_.provenance)
-        .mkString(System.lineSeparator)
+        .mkString("; ")
 
     // Update the provenance metadata
     val history = _metadata.getProperty("history") match {
-      case Some(h) => h + System.lineSeparator + provenance
+      case Some(h) => s"$h; $provenance"
       case None    => provenance
     }
     _metadata + ("history" -> history)

--- a/core/src/main/scala/latis/ops/Contains.scala
+++ b/core/src/main/scala/latis/ops/Contains.scala
@@ -58,6 +58,8 @@ case class Contains(id: Identifier, values: String*) extends Filter {
         }
     }
   }
+  
+  override def toString = s"${id.asString} contains (${values.mkString(",")})"
 
 }
 

--- a/core/src/main/scala/latis/ops/ConvertBinary.scala
+++ b/core/src/main/scala/latis/ops/ConvertBinary.scala
@@ -55,6 +55,8 @@ case class ConvertBinary(id: Identifier, base: Base) extends MapOperation {
         Scalar.fromMetadata(md).fold(throw _, identity) //should be safe
       case dt => dt
     }.asRight
+    
+  override def toString = s"ConvertBinary(${id.asString}, $base)"
 }
 
 object ConvertBinary {

--- a/core/src/main/scala/latis/ops/CountBy.scala
+++ b/core/src/main/scala/latis/ops/CountBy.scala
@@ -14,6 +14,11 @@ import latis.util.LatisException
 class CountBy(ids: NonEmptyList[Identifier]) extends GroupByVariable(ids.toList *) {
 
   override def aggregation: Aggregation = CountAggregation()
+
+  override def toString: String = {
+    val list = ids.toList.map(id => id.asString).mkString(",")
+    s"group by $list with count"
+  }
 }
 
 object CountBy {

--- a/core/src/main/scala/latis/ops/DefaultAggregation2.scala
+++ b/core/src/main/scala/latis/ops/DefaultAggregation2.scala
@@ -38,4 +38,5 @@ class DefaultAggregation2() extends Aggregation2 {
       }
   }
   
+  override def toString = "nested function"
 }

--- a/core/src/main/scala/latis/ops/GroupByBinWidth.scala
+++ b/core/src/main/scala/latis/ops/GroupByBinWidth.scala
@@ -66,6 +66,8 @@ class GroupByBinWidth private (
     val meta = s.metadata + ("binWidth" -> width.toString)
     Scalar.fromMetadata(meta).fold(throw _, identity) //should be safe
   }
+
+  override def toString = s"GroupByBinWidth($width) with $aggregation"
 }
 
 object GroupByBinWidth {

--- a/core/src/main/scala/latis/ops/GroupByVariable.scala
+++ b/core/src/main/scala/latis/ops/GroupByVariable.scala
@@ -67,6 +67,7 @@ case class GroupByVariable(ids: Identifier*) extends GroupOperation {
       Option(DomainData(data))
     }
 
+  override def toString = s"GroupByVariable(${ids.map(_.asString).mkString(",")})"
 }
 
 object GroupByVariable {

--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -58,6 +58,7 @@ case class Projection(ids: Identifier*) extends MapOperation {
             Function.from(makeIndex(domain), r).fold(throw _, identity)
           }
       }
+
   }
 
   /**
@@ -131,6 +132,7 @@ case class Projection(ids: Identifier*) extends MapOperation {
     case _: Function => ??? //Function not allowed in domain
   }
 
+  override def toString = s"Projection(${ids.map(_.asString).mkString(",")})"
 }
 
 object Projection {

--- a/core/src/main/scala/latis/ops/Rename.scala
+++ b/core/src/main/scala/latis/ops/Rename.scala
@@ -30,6 +30,8 @@ case class Rename(origId: Identifier, newId: Identifier) extends UnaryOperation 
    */
   def applyToData(data: Data, model: DataType): Either[LatisException, Data] =
     data.asRight
+
+  override def toString = s"Rename(${origId.asString}, ${newId.asString})"
 }
 
 object Rename {

--- a/core/src/main/scala/latis/ops/StatsAggregation.scala
+++ b/core/src/main/scala/latis/ops/StatsAggregation.scala
@@ -53,6 +53,8 @@ class StatsAggregation() extends Aggregation2 {
       Scalar(id"max",   DoubleValueType),
       Scalar(id"count", LongValueType)
     )
+
+  override def toString = "statistics"
 }
 
 object StatsAggregation {

--- a/core/src/main/scala/latis/ops/Stride.scala
+++ b/core/src/main/scala/latis/ops/Stride.scala
@@ -31,6 +31,7 @@ case class Stride(stride: Seq[Int]) extends StreamOperation {
   // A Stride does not affect the model.
   def applyToModel(model: DataType): Either[LatisException, DataType] = Right(model)
 
+  override def toString = s"Stride(${stride.mkString(",")})"
 }
 
 object Stride {


### PR DESCRIPTION
The default string representation of some Operations is not pretty. I cleaned most up a bit and the way we present them in the history metadata.

Some of these are up for debate, but it's much better than it was. 