### PR TITLE
Add operations to support discrete data thinning

### DIFF
--- a/core/src/main/scala/latis/ops/Interpolation.scala
+++ b/core/src/main/scala/latis/ops/Interpolation.scala
@@ -1,0 +1,270 @@
+package latis.ops
+
+import cats.syntax.all.*
+
+import latis.data.*
+import latis.model.*
+import latis.ops.Interpolation.*
+import latis.util.*
+
+/**
+ * Trait for interpolation algorithms.
+ *
+ * Given a list of Samples, returns a single Sample based on
+ * the given domain value.
+ *
+ * This requires a 1D domain and expects the value type to
+ * be consistent with the domain Scalar.
+ */
+sealed trait Interpolation {
+
+  def interpolate(
+    model: DataType,
+    samples: List[Sample],
+    value: Datum
+  ): Either[LatisException, Sample]
+
+}
+
+object Interpolation {
+
+  /**
+   * Constructs an Interpolation by its (case-insensitive) name.
+   *
+   * Supported interpolation strategies:
+   *  - `floor`: Returns the "lowest" of the bounding Samples
+   *  - `linear`: Computes a linear interpolation between the bounding Samples
+   *  - `near/nearest`: Returns the nearest of the bounding Samples
+   *  - `none`: No interpolation will be done, Sample must match
+   */
+  def fromName(name: String): Either[LatisException, Interpolation] =
+    name.toLowerCase match {
+      case "floor" => FloorInterpolation().asRight
+      case "linear" => LinearInterpolation().asRight
+      case "near" | "nearest" => NearestInterpolation().asRight
+      case "none" => NoInterpolation().asRight
+      case s => LatisException(s"Unsupported interpolation type: $s").asLeft
+    }
+
+  //---- Utility Methods ----//
+
+  /** Extracts the domain Scalar assuming a 1D, non-Index Function. */
+  def getDomainVar(model: DataType): Either[LatisException, Scalar] =
+    model match {
+      case Function(scalar: Scalar, _) if (! scalar.isInstanceOf[Index]) =>
+        scalar.asRight
+      case _ =>
+        LatisException("Interpolation expects a 1D non-index domain").asLeft
+    }
+
+  /** Extracts the domain data from an assumed arity-1 Sample as a Datum */
+  def getDomainData(sample: Sample): Either[LatisException, Datum] =
+    sample match {
+      case Sample((d: Datum) :: Nil, _) => d.asRight
+      case _ =>
+        LatisException("Interpolation expects a 1D non-index domain").asLeft
+    }
+}
+
+//==== No Interpolation (equality only) ====//
+
+/** Returns a Sample only if its domain value is equivalent */
+case class NoInterpolation() extends Interpolation {
+
+  override def interpolate(
+    model: DataType,
+    samples: List[Sample],
+    value: Datum
+  ): Either[LatisException, Sample] = {
+    for {
+      domainVar <- getDomainVar(model)
+      ordering   = domainVar.ordering
+      before    <- samples.filterA { sample =>
+        getDomainData(sample).map(ordering.lteq(_, value))
+      }
+      last      <- before.lastOption.toRight {
+        LatisException("Interpolation cannot extrapolate")
+      }
+      sample    <- getDomainData(last).flatMap { n =>
+        if (ordering.equiv(n, value)) last.asRight
+        else LatisException("NoInterpolation will not interpolate").asLeft
+      }
+    } yield sample
+  }
+}
+
+//==== Floor (round down) Interpolation ====//
+
+/** Returns the Sample that would immediately precede or equal the given domain value */
+case class FloorInterpolation() extends Interpolation {
+  //TODO: error if no greater sample? essentially extrapolation
+
+  override def interpolate(
+    model: DataType,
+    samples: List[Sample],
+    value: Datum
+  ): Either[LatisException, Sample] = {
+    for {
+      domainVar <- getDomainVar(model)
+      ordering   = domainVar.ordering
+      before    <- samples.filterA { sample =>
+        getDomainData(sample).map(ordering.lteq(_, value))
+      }
+      last      <- before.lastOption.toRight {
+        LatisException("Interpolation cannot extrapolate")
+      }
+    } yield Sample(DomainData(value), last.range)
+  }
+}
+
+//==== Nearest Neighbor Interpolation ====//
+
+/**
+ * Returns the Sample closest to the given domain value,
+ * rounding up if equidistant.
+ */
+case class NearestInterpolation() extends Interpolation {
+
+  override def interpolate(
+    model: DataType,
+    samples: List[Sample],
+    value: Datum
+  ): Either[LatisException, Sample] = {
+    for {
+      number <- value match {
+        case num: Number => num.asRight
+        case _ =>
+          val msg = "Nearest neighbor interpolation requires a numeric value"
+          LatisException(msg).asLeft
+      }
+      domainVar <- getDomainVar(model)
+      ordering = domainVar.ordering
+      before <- samples.filterA { sample =>
+        getDomainData(sample).map(ordering.lteq(_, number))
+      }
+      after <- samples.filterA { sample =>
+        getDomainData(sample).map(ordering.gt(_, number))
+      }
+      s1 <- before.lastOption
+        .toRight(LatisException("Interpolation cannot extrapolate"))
+      s2 <- after.headOption match {
+        case Some(s) => s.asRight
+        case None => getDomainData(s1).flatMap { d =>
+          // If no samples greater than, see if number matches last sample
+          if (ordering.equiv(d, number)) s1.asRight
+          else LatisException("Interpolation cannot extrapolate").asLeft
+        }
+      }
+      d1 <- getDomainData(s1).flatMap {
+        case num: Number => num.asDouble.asRight
+        case _ =>
+          val msg = "Nearest neighbor interpolation requires numeric data"
+          LatisException(msg).asLeft
+      }
+      d2 <- getDomainData(s2).flatMap {
+        case num: Number => num.asDouble.asRight
+        case _ =>
+          val msg = "Nearest neighbor interpolation requires numeric data"
+          LatisException(msg).asLeft
+      }
+    } yield {
+      val dd1 = math.abs(d1 - number.asDouble)
+      val dd2 = math.abs(d2 - number.asDouble)
+      // Note: rounds up if eq, consistent with math.round
+      if (dd1 < dd2) Sample(DomainData(number), s1.range)
+      else Sample(DomainData(number), s2.range)
+    }
+  }
+}
+
+//==== Linear Interpolation ====//
+
+/**
+ * Interpolates the given samples for the given domain value using
+ * linear interpolation between bounding samples.
+ *
+ * All range variables must be of type Real (with floating point
+ * values) since a new value will be computed as a double and can't
+ * safely be converted to a non-real data type. The domain data
+ * can be any numeric variable since it is only used in the
+ * computation.
+ *
+ * TODO: use fill values for non-Real data?
+ */
+case class LinearInterpolation() extends Interpolation {
+
+  override def interpolate(
+    model: DataType,
+    samples: List[Sample],
+    value: Datum
+  ): Either[LatisException, Sample] = {
+    for {
+      number <- value match {
+        case num: Number => num.asRight
+        case _ =>
+          val msg = "Linear interpolation requires a numeric domain"
+          LatisException(msg).asLeft
+      }
+      domainVar <- getDomainVar(model)
+      ordering   = domainVar.ordering
+      before    <- samples.filterA { sample =>
+        getDomainData(sample).map(ordering.lteq(_, number))
+      }
+      after <- samples.filterA { sample =>
+        getDomainData(sample).map(ordering.gt(_, number))
+      }
+      s1 <- before.lastOption.toRight(LatisException("Interpolation cannot extrapolate"))
+      s2 <- after.headOption match {
+        case Some(s) => s.asRight
+        case None    => getDomainData(s1).flatMap { d =>
+          // If no samples greater than, see if number matches last sample
+          if (ordering.equiv(d, number)) s1.asRight
+          else LatisException("Interpolation cannot extrapolate").asLeft
+        }
+      }
+      d1 <- getDomainData(s1).flatMap {
+        case num: Number => num.asDouble.asRight
+        case _ =>
+          val msg = "Linear interpolation requires numeric domain"
+          LatisException(msg).asLeft
+      }
+      d2 <- getDomainData(s2).flatMap {
+        case num: Number => num.asDouble.asRight
+        case _ =>
+          val msg = "Linear interpolation requires numeric domain"
+          LatisException(msg).asLeft
+      }
+      sample <-
+        // Don't interp if number equals domain value
+        if (d1 == number.asDouble) s1.asRight
+        else if (d2 == number.asDouble) s2.asRight
+        else interp(model, s1, s2, number)
+    } yield sample
+  }
+
+  private def interp(model: DataType, s1: Sample, s2: Sample, num: Number): Either[LatisException, Sample] = {
+    for {
+      x1 <- getDomainData(s1).flatMap(getDoubleVal)
+      x2 <- getDomainData(s2).flatMap(getDoubleVal)
+      ds <- (model.getScalars.tail, s1.range, s2.range).traverseN {
+        case (s: Scalar, Real(d1), Real(d2)) =>
+          val d = (d2 - d1) * (num.asDouble - x1) / (x2 - x1) + d1
+          s.valueType.convertDouble(d).get.asRight
+        case _ =>
+          val msg = "Linear interpolation required floating point data"
+          LatisException(msg).asLeft
+      }
+    } yield {
+      Sample(DomainData(num), RangeData(ds))
+    }
+  }
+
+  private def getDoubleVal(data: Datum): Either[LatisException, Double] = {
+    data match {
+      case Number(d) => d.asRight
+      case _ =>
+        val msg = "Numeric data expected"
+        LatisException(msg).asLeft
+    }
+  }
+}

--- a/core/src/main/scala/latis/ops/MaxGap.scala
+++ b/core/src/main/scala/latis/ops/MaxGap.scala
@@ -1,0 +1,100 @@
+package latis.ops
+
+import cats.effect.IO
+import cats.syntax.all.*
+import fs2.*
+
+import latis.data.*
+import latis.model.*
+import latis.util.LatisException
+
+/**
+ * Inserts Samples such that the domain values have no gap greater
+ * than the given [[gapSize]], using the given Interpolation algorithm.
+ * The resulting cadence will be the gap size.
+ *
+ * Requires an arity-1 Function with a numeric domain variable, and
+ * assumes the gap size is in the numeric units of that variable.
+ * Text Time variables will expect epoch milliseconds. ISO 8601 durations
+ * for time variables are not yet supported.
+ */
+class MaxGap private (gapSize: Double, interp: Interpolation) extends StreamOperation {
+
+  def pipe(model: DataType): Pipe[IO, Sample, Sample] = stream => {
+
+    val domainVar: Scalar = model match {
+      case Function(domain: Scalar, _)
+        if (domain.valueType.isInstanceOf[NumericType]) => domain
+      case _ => throw LatisException("MaxGap requires a single numeric domain variable")
+    }
+
+    // Define multiplier to support descending order
+    val order = if (domainVar.ascending) 1.0 else -1.0
+
+    // Loop, dropping samples that have the same target variable value.
+    def go(prev: Sample, rest: Stream[IO, Sample]): Pull[IO, Sample, Unit] = {
+      rest.pull.uncons1.flatMap {
+        case Some((curr, tail)) =>
+          //Note that an invalid sample will result in a NaN
+          //  which will fail the gap test thus no sample added.
+          val d0 = domainVar.valueAsDouble(getDomainData(prev))
+          val d1 = domainVar.valueAsDouble(getDomainData(curr))
+          if (math.abs(d1 - d0) > gapSize) {
+            val d = domainVar.valueType.convertDouble(d0 + order * gapSize).map {
+              case num: Number => num
+              case _ => throw LatisException("MaxGap data must be numeric")
+            }.getOrElse(throw LatisException("MaxGap unable to make new sample"))
+            val insert = interp.interpolate(model, List(prev, curr), d)
+              .fold(throw _, identity) //invalid sample or bug
+            Pull.output1(insert) >> go(insert, Stream.emit(curr) ++ tail)
+          } else Pull.output1(curr) >> go(curr, tail)
+        case None =>
+          Pull.done
+      }
+    }
+
+    // Get and emit first sample then start iterating
+    stream.pull.uncons1.flatMap {
+      case Some((first, tail)) =>
+        Pull.output1(first) >> go(first, tail)
+      case None =>
+        Pull.done
+    }.stream
+  }
+
+  // Get the Data object of the domain variable from a Sample
+  private def getDomainData(sample: Sample): Datum = sample match {
+    case Sample(d :: Nil, _) => d
+    case _ => throw LatisException("MaxGap expects a 1D domain")
+  }
+
+  // Model is unchanged
+  override def applyToModel(model: DataType): Either[LatisException, DataType] =
+    model.asRight
+}
+
+object MaxGap {
+
+  def builder: OperationBuilder = (args: List[String]) => fromArgs(args)
+
+  def fromArgs(args: List[String]): Either[LatisException, MaxGap] = args match {
+    case s1 :: s2 :: Nil =>
+      for {
+        value  <- parseGapSize(s1)
+        interp <- parseInterpolation(s2)
+      } yield MaxGap(value, interp)
+    case _ => LatisException("MaxGap requires a gap size and interpolation").asLeft
+  }
+
+  private def parseGapSize(s: String): Either[LatisException, Double] = {
+    //TODO: support ISO 8601 duration, need model to get units right
+    s.toDoubleOption.filter(_ > 0)
+      .toRight(LatisException("Gap size must be a positive number"))
+  }
+
+  private def parseInterpolation(s: String): Either[LatisException, Interpolation] =
+    Interpolation.fromName(s).flatMap {
+      case NoInterpolation() => LatisException("MaxGap requires interpolation").asLeft
+      case interp => interp.asRight
+    }
+}

--- a/core/src/main/scala/latis/ops/OnChange.scala
+++ b/core/src/main/scala/latis/ops/OnChange.scala
@@ -1,0 +1,95 @@
+package latis.ops
+
+import cats.effect.IO
+import cats.syntax.all.*
+import fs2.*
+
+import latis.data.Datum
+import latis.data.Sample
+import latis.data.SamplePosition
+import latis.model.DataType
+import latis.util.Identifier
+import latis.util.LatisException
+
+/**
+ * Keep only samples where the given variable changes value.
+ *
+ * This keeps the first sample and drops any subsequent sample where the
+ * given variable value is repeated, keeping only the samples where the
+ * variable changes value. To preserve the coverage extents, the last
+ * sample will be kept.
+ *
+ * This requires a flat dataset (no nested Functions). It doesn't really
+ * make sense to apply to the domain, but could fix "broken" data with
+ * non-distinct domain values (e.g. time series with duplicate times).
+ */
+class OnChange private (variableID: Identifier) extends StreamOperation {
+
+  def pipe(model: DataType): Pipe[IO, Sample, Sample] = {
+    // Get the variable position in a Sample. Must not be nested.
+    val position = model.findPath(variableID) match {
+      case Some(pos :: Nil) => pos
+      case Some(path) if (path.size > 1) =>
+        val msg = "OnChange variable must not be nested"
+        throw LatisException(msg)
+      case _ =>
+        val msg = s"OnChange variable not found: ${variableID.asString}"
+        throw LatisException(msg)
+    }
+
+    // Define Pipe
+    (stream: Stream[IO, Sample]) => {
+      // Loop, dropping samples that have the same target variable value.
+      def go(prev: Sample, rest: Stream[IO, Sample]): Pull[IO, Sample, Unit] = {
+        rest.pull.uncons1.flatMap {
+          case Some((curr, tail)) =>
+            if (getValue(prev, position) != getValue(curr, position)) {
+              Pull.output1(curr) >> go(curr, tail)
+            } else {
+              // Unchanged, make sure to keep last sample to preserve coverage
+              tail.pull.peek1.flatMap {
+                case Some(_) => go(curr, tail)
+                case None    => Pull.output1(curr) >> Pull.done
+              }
+            }
+          case None => Pull.done
+        }
+      }
+
+      // Get and emit first sample then start iterating
+      stream.pull.uncons1.flatMap {
+        case Some((first, tail)) =>
+          Pull.output1(first) >> go(first, tail)
+        case None =>
+          Pull.done
+      }.stream
+    }
+  }
+
+  // Get the variable data from a Sample given its position
+  private def getValue(sample: Sample, position: SamplePosition): Any =
+    sample.getValue(position) match {
+      case Some(d: Datum) => d.value
+      case _ =>
+        val msg = "OnChange variable value must be a Datum"
+        throw LatisException(msg)
+    }
+
+  // Model is unchanged
+  override def applyToModel(model: DataType): Either[LatisException, DataType] =
+    model.asRight
+}
+
+object OnChange {
+
+  def builder: OperationBuilder = (args: List[String]) => fromArgs(args)
+
+  def fromArgs(args: List[String]): Either[LatisException, OnChange] = args match {
+    case name :: Nil =>
+      Identifier.fromString(name).map(OnChange(_))
+        .toRight(LatisException("OnChange: Invalid identifier"))
+    case _ =>
+      val msg = "OnChange requires a single variable argument"
+      LatisException(msg).asLeft
+  }
+}

--- a/core/src/main/scala/latis/ops/OperationRegistry.scala
+++ b/core/src/main/scala/latis/ops/OperationRegistry.scala
@@ -31,6 +31,8 @@ object OperationRegistry {
       "groupByBinWidth" -> GroupByBinWidth.builder,
       "head"            -> Head.builder,
       "last"            -> Last.builder,
+      "maxGap"          -> MaxGap.builder,
+      "onChange"        -> OnChange.builder,
       "pivot"           -> Pivot.builder,
       "project"         -> Projection.builder,
       "rename"          -> Rename.builder,

--- a/core/src/test/scala/latis/ops/InterpolationSuite.scala
+++ b/core/src/test/scala/latis/ops/InterpolationSuite.scala
@@ -1,0 +1,142 @@
+package latis.ops
+
+import munit.FunSuite
+
+import latis.data.*
+import latis.data.Data.*
+import latis.model.*
+import latis.util.Identifier.id
+
+class InterpolationSuite extends FunSuite {
+
+  private val model = Function.from(Scalar(id"x", IntValueType), Scalar(id"y", IntValueType))
+    .fold(throw _, identity)
+  private val samples = List(
+    Sample(DomainData(0), RangeData(0)),
+    Sample(DomainData(3), RangeData(3))
+  )
+
+  test("Nearest interpolation will round up") {
+    val interp = NearestInterpolation()
+    val z = interp.interpolate(model, samples, IntValue(2))
+      z.fold(_ => fail("Failed to interpolate"), identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(r: IntValue)) =>
+        assertEquals(d.value, 2)
+        assertEquals(r.value, 3)
+    }
+  }
+
+  test("Floor interpolation") {
+    val interp = FloorInterpolation()
+    interp.interpolate(model, samples, IntValue(2))
+      .fold(_ => fail("Failed to interpolate"), identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(r: IntValue)) =>
+        assertEquals(d.value, 2)
+        assertEquals(r.value, 0)
+    }
+  }
+
+  test("first sample matches") {
+    val interp = NearestInterpolation()
+    interp.interpolate(model, samples, IntValue(0))
+      .fold(_ => fail("Failed to interpolate"), identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(r: IntValue)) =>
+        assertEquals(d.value, 0)
+        assertEquals(r.value, 0)
+    }
+  }
+
+  test("last sample matches") {
+    val interp = NearestInterpolation()
+    interp.interpolate(model, samples, IntValue(3))
+      .fold(_ => fail("Failed to interpolate"), identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(r: IntValue)) =>
+        assertEquals(d.value, 3)
+        assertEquals(r.value, 3)
+    }
+  }
+
+  test("Can't extrapolate") {
+    val interp = NearestInterpolation()
+    val s = interp.interpolate(model, samples, IntValue(-1))
+    assert(s.isLeft)
+  }
+
+  test("No interpolation with matching sample") {
+    val interp = NoInterpolation()
+    interp.interpolate(model, samples, IntValue(0))
+      .fold(_ => fail("Failed to interpolate"), identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(r: IntValue)) =>
+        assertEquals(d.value, 0)
+        assertEquals(r.value, 0)
+    }
+  }
+
+  test("No interpolation fails with no match") {
+    val interp = NoInterpolation()
+    val s = interp.interpolate(model, samples, IntValue(1))
+    assert(s.isLeft)
+  }
+
+  test("Floor interpolation with string domain") {
+    val model = Function.from(Scalar(id"x", StringValueType), Scalar(id"y", IntValueType))
+      .fold(throw _, identity)
+    val samples = List(
+      Sample(DomainData("A"), RangeData(0)),
+      Sample(DomainData("C"), RangeData(3))
+    )
+    val interp = FloorInterpolation()
+    interp.interpolate(model, samples, StringValue("B"))
+      .fold(_ => fail("Failed to interpolate"), identity) match {
+      case Sample(DomainData(d: StringValue), RangeData(r: IntValue)) =>
+        assertEquals(d.value, "B")
+        assertEquals(r.value, 0)
+    }
+  }
+
+  test("Linear interpolation") {
+    val model = Function.from(Scalar(id"x", DoubleValueType), Scalar(id"y", DoubleValueType))
+      .fold(throw _, identity)
+    val samples = List(
+      Sample(DomainData(1.0), RangeData(1.0)),
+      Sample(DomainData(2.0), RangeData(2.0))
+    )
+    LinearInterpolation().interpolate(model, samples, DoubleValue(1.5))
+      .fold(throw _, identity) match {
+      case Sample(DomainData(Number(d)), RangeData(Number(r))) =>
+        assertEquals(d, 1.5)
+        assertEquals(r, 1.5)
+    }
+  }
+
+  test("Linear interpolation matches first") {
+    val model = Function.from(Scalar(id"x", IntValueType), Scalar(id"y", DoubleValueType))
+      .fold(throw _, identity)
+    val samples = List(
+      Sample(DomainData(1), RangeData(1.0)),
+      Sample(DomainData(2), RangeData(2.0))
+    )
+    LinearInterpolation().interpolate(model, samples, IntValue(1))
+      .fold(throw _, identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(Number(r))) =>
+        assertEquals(d.value, 1)
+        assertEquals(r, 1.0)
+    }
+  }
+
+  test("Linear interpolation matches last") {
+    val model = Function.from(Scalar(id"x", IntValueType), Scalar(id"y", DoubleValueType))
+      .fold(throw _, identity)
+    val samples = List(
+      Sample(DomainData(1), RangeData(1.0)),
+      Sample(DomainData(2), RangeData(2.0))
+    )
+    LinearInterpolation().interpolate(model, samples, IntValue(2))
+      .fold(throw _, identity) match {
+      case Sample(DomainData(d: IntValue), RangeData(Number(r))) =>
+        assertEquals(d.value, 2)
+        assertEquals(r, 2.0)
+    }
+  }
+
+}

--- a/core/src/test/scala/latis/ops/MaxGapSuite.scala
+++ b/core/src/test/scala/latis/ops/MaxGapSuite.scala
@@ -1,0 +1,94 @@
+package latis.ops
+
+import munit.CatsEffectSuite
+
+import latis.data.DomainData
+import latis.data.RangeData
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.dataset.MemoizedDataset
+import latis.dsl.*
+import latis.metadata.Metadata
+import latis.util.Identifier.id
+
+class MaxGapSuite extends CatsEffectSuite {
+
+  private val md = Metadata(id"test")
+  private val model = ModelParser.parse("x -> y").fold(throw _, identity)
+
+  private def makeDataset(data: (Int, Int) *) = {
+    val samples = data.map { (d, r) =>
+      Sample(DomainData(d), RangeData(r))
+    }
+    new MemoizedDataset(md, model, SampledFunction(samples))
+  }
+
+  test("insert single sample for small gap") {
+    val ds = makeDataset(
+      (0, 0),
+      (3, 3)
+    )
+    val mg = MaxGap.fromArgs(List("2", "floor"))
+      .fold(_ => fail("Failed to make MaxGap"), identity)
+    val samples = ds.withOperation(mg).samples.compile.toList
+    samples.assertEquals(
+      List(
+        Sample(DomainData(0), RangeData(0)),
+        Sample(DomainData(2), RangeData(0)), //range from previous sample
+        Sample(DomainData(3), RangeData(3))
+      )
+    )
+  }
+
+  test("insert single sample with nearest interpolation") {
+    val ds = makeDataset(
+      (0, 0),
+      (3, 3)
+    )
+    val mg = MaxGap.fromArgs(List("2", "near"))
+      .fold(_ => fail("Failed to make MaxGap"), identity)
+    val samples = ds.withOperation(mg).samples.compile.toList
+    samples.assertEquals(
+      List(
+        Sample(DomainData(0), RangeData(0)),
+        Sample(DomainData(2), RangeData(3)), //range from nearest sample
+        Sample(DomainData(3), RangeData(3))
+      )
+    )
+  }
+
+  test("insert multiple samples for large gap") {
+    val ds = makeDataset(
+      (0, 0),
+      (5, 5)
+    )
+    val mg = MaxGap.fromArgs(List("2", "floor"))
+      .fold(_ => fail("Failed to make MaxGap"), identity)
+    val samples = ds.withOperation(mg).samples.compile.toList
+    samples.assertEquals(
+      List(
+        Sample(DomainData(0), RangeData(0)),
+        Sample(DomainData(2), RangeData(0)),
+        Sample(DomainData(4), RangeData(0)),
+        Sample(DomainData(5), RangeData(5))
+      )
+    )
+  }
+
+  test("don't insert if gap equals max") {
+    val ds = makeDataset(
+      (0, 0),
+      (2, 2)
+    )
+    val mg = MaxGap.fromArgs(List("2", "floor"))
+      .fold(_ => fail("Failed to make MaxGap"), identity)
+    val samples = ds.withOperation(mg).samples.compile.toList
+    samples.assertEquals(
+      List(
+        Sample(DomainData(0), RangeData(0)),
+        Sample(DomainData(2), RangeData(2))
+      )
+    )
+  }
+
+}

--- a/core/src/test/scala/latis/ops/OnChangeSuite.scala
+++ b/core/src/test/scala/latis/ops/OnChangeSuite.scala
@@ -1,0 +1,85 @@
+package latis.ops
+
+import munit.CatsEffectSuite
+
+import latis.data.DomainData
+import latis.data.RangeData
+import latis.data.Sample
+import latis.data.SampledFunction
+import latis.dataset.MemoizedDataset
+import latis.dsl.*
+import latis.metadata.Metadata
+import latis.util.Identifier.id
+
+class OnChangeSuite extends CatsEffectSuite {
+
+  private val model = ModelParser.parse("x -> y").fold(throw _, identity)
+
+  // samples with some non-changing range values
+  private val samples = List(
+    Sample(DomainData(0), RangeData(0)),
+    Sample(DomainData(1), RangeData(0)),
+    Sample(DomainData(2), RangeData(0)),
+    Sample(DomainData(3), RangeData(1)),
+    Sample(DomainData(4), RangeData(1)),
+    Sample(DomainData(5), RangeData(1)),
+  )
+
+  private val ds = new MemoizedDataset(
+    Metadata(id"test"),
+    model,
+    SampledFunction(samples)
+  )
+
+  test("on change, keeping last unchanged sample") {
+    val oc = OnChange.fromArgs(List("y"))
+      .fold(_ => fail("Failed to make OnChange"), identity)
+    val samples = ds.withOperation(oc).samples.compile.toList
+    samples.assertEquals(
+      List(
+        Sample(DomainData(0), RangeData(0)),
+        Sample(DomainData(3), RangeData(1)),
+        Sample(DomainData(5), RangeData(1)),
+      )
+    )
+  }
+
+  test("on change keeps last sample when changed") {
+    val oc = OnChange.fromArgs(List("y"))
+      .fold(_ => fail("Failed to make OnChange"), identity)
+    val samples = List(
+      Sample(DomainData(0), RangeData(0)),
+      Sample(DomainData(1), RangeData(1)),
+      Sample(DomainData(2), RangeData(2))
+    )
+
+    val ds = new MemoizedDataset(
+      Metadata(id"test"),
+      model,
+      SampledFunction(samples)
+    )
+    ds.withOperation(oc).samples.compile.toList.assertEquals(
+      List(
+        Sample(DomainData(0), RangeData(0)),
+        Sample(DomainData(1), RangeData(1)),
+        Sample(DomainData(2), RangeData(2))
+      )
+    )
+  }
+
+  // Duplicate domain values is not allowed in the FDM,
+  // but this shows that it can fix "broken" datasets
+  // that we have no control of.
+  test("duplicate domain value") {
+    val oc = OnChange.fromArgs(List("x"))
+      .fold(_ => fail("Failed to make OnChange"), identity)
+    val ds = MemoizedDataset(
+      Metadata(id"test"),
+      model,
+      SampledFunction(samples :+ Sample(DomainData(5), RangeData(2)))
+    )
+    ds.withOperation(oc).samples.compile.toList.map(_.length)
+      .assertEquals(7)
+  }
+
+}


### PR DESCRIPTION
`OnChange` will drop any sample that has the same value as the previous for a given variable. It is common for state telemetry to remain in the same state resulting in a lot of duplicate data. Traditionally, discrete telemetry has been managed by keeping only the changed data plus a sample every 5 minutes (to reassure users that there is no missing data). Recently, we have had to deal with full resolution data which has had complications.

`MaxGap` will create samples to fill gaps in the domain values (e.g. time)  that exceed the given gap size. The cadence of the generated samples (with a given interpolation strategy) will be that of the gap size. Using this after `OnChange` with "floor" interpolation will result in the thinning expected by users of discrete data.

`Interpolation` defines various interpolation strategies for filling gaps in the domain values. Given a list of samples, it will return a single sample for a given domain value.
    `none`: No interpolation will happen. This will result in an error if the given value does not already exist.
    `floor`: The new sample will have the range of the lower of the two bounding samples.
    `near`: The new sample will have the range from the nearest of the two bounding samples.
    `linear`: The range of the new sample will be the linear interpolation between the bounding samples.
Any domain value outside the sample coverage will fail since this does not support extrapolation.
