### PR TITLE
Improve the projection operation and add explicit validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The following sections describe how to filter and operate on datasets.
 
 #### Projections
 
-A projection allows you to subset the variables returned by a query. Only variables that appear in a projection will appear in the result.
+A projection allows you to limit the set of variables returned by a query. Only variables that appear in a projection will appear in the result. Projecting variable that do not appear in the dataset will result in an error.
 
 A projection is written as a comma-separated list of the variable names to keep in the result. This will give you the temperature as a function of time:
 

--- a/core/src/main/scala/latis/model/DataTypeAlgebra.scala
+++ b/core/src/main/scala/latis/model/DataTypeAlgebra.scala
@@ -37,10 +37,6 @@ trait DataTypeAlgebra { dataType: DataType =>
    * Returns a List of Scalars in the (depth-first) order
    * that they appear in the model.
    */
-  //TODO: deprecate to find potential unsafe
-  //  Risk of overlooking tuples and functions nested in tuples
-  //  Risk of being inconsistent with arity vs dimensionality
-  // use "scalars", "nonIndexScalars" to migrate from getScalars?
   def getScalars: List[Scalar] = {
     def go(dt: DataType): List[Scalar] = dt match {
       case s: Scalar      => List(s)
@@ -49,6 +45,10 @@ trait DataTypeAlgebra { dataType: DataType =>
     }
     go(dataType)
   }
+  
+  /** Returns Scalars in the model that are not an Index. */
+  def nonIndexScalars: List[Scalar] =
+    getScalars.filterNot(_.isInstanceOf[Index])
 
   /** Replaces the identifier of this DataType. */
   def rename(id: Identifier): DataType = dataType match {

--- a/core/src/main/scala/latis/ops/Projection.scala
+++ b/core/src/main/scala/latis/ops/Projection.scala
@@ -1,5 +1,6 @@
 package latis.ops
 
+import cats.data.ValidatedNel
 import cats.syntax.all.*
 
 import latis.data.*
@@ -8,36 +9,57 @@ import latis.util.Identifier
 import latis.util.LatisException
 
 /**
- * Operation to project only a given set of variables in a Dataset.
- * Domain variables will be included, for now.
+ * Operation to include only a given set of variables in a Dataset.
+ *
+ * The order of the projected ids is ignored (unlike SQL) to ensure
+ * the integrity of the model (e.g. preserve domain).
+ * All given variables (by id) must appear in the top level of the
+ * model, not in nested Functions unless all variables are projected.
+ * If the domain variable(s) (all or none, for now) are not projected,
+ * they will be replaced by an Index placeholder variable. If only the
+ * domain is projected, it will become the range with the domain
+ * replaced by an Index. If all variables are projected, the processing
+ * will be skipped.
+ *
+ * @params ids Identifiers of the Scalar variable to keep
  */
 case class Projection(ids: Identifier*) extends MapOperation {
+  //TODO: use NonEmpty, rely on validator for now
+  //  or Set since order does not matter?
+  //  or should we allow an empty projection, Monoid, need NullDataType?
   //TODO: support named tuples and functions
+  //TODO: support dot notation for elements of nested tuples
   //TODO: support nested Functions
-  //TODO: support aliases, hasName
-  //TODO: support dot notation for nested tuples
-  //TODO: if Cartesian keep separate Index variable for each dimension
+  //TODO: if Cartesian, keep separate Index variable for each dimension
   //TODO: support partial domain projection:
-  // if not Cartesian, move vars to range and replace domain with Index
-  //TODO: reorder ids to be consistent with model (after we have model validation...)
+  //  if Cartesian, replace non-projected variables with Index
+  //  if not Cartesian, move vars to range and replace domain with Index
+  //    otherwise lose ordering
 
-  override def applyToModel(model: DataType): Either[LatisException, DataType] =
-    applyToVariable(model).toRight(LatisException("Nothing projected"))
+  /** Apply projection to model */
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = {
+    validate(model)
+      .leftMap(es => es.head).toEither // Only one Exception
+      .flatMap { proj =>
+        if (allProjected(model)) model.asRight //no-op
+        else proj.applyToVariable(model)
+          .toRight(LatisException("Bug: Nothing projected, shouldn't have validated"))
+      }
+  }
 
-  /** Recursive method to apply the projection. */
+  /** Recursive method to apply the projection to a variable type. */
   private def applyToVariable(v: DataType): Option[DataType] = v match {
     case s: Scalar =>
       if (ids.contains(s.id)) Some(s) else None
     case t: Tuple =>
       val vs = t.elements.flatMap(applyToVariable)
       vs.length match {
-        case 0 => None // drop empty Tuple
+        case 0 => None          // drop empty Tuple
         case 1 => Some(vs.head) // reduce Tuple of one
         case _ => Some(Tuple.fromSeq(vs).fold(throw _, identity))
       }
     case Function(domain, range) =>
       // Behavior depends on whether domain variables are projected
-      //TODO: if Cartesian, replace each non-projected domain scalar with index
       applyToVariable(domain) match {
         // Domain unchanged
         case Some(d) if (equivalentScalarIds(d, domain)) =>
@@ -48,17 +70,14 @@ case class Projection(ids: Identifier*) extends MapOperation {
           }
         // Not all domain variables projected.
         case Some(_) =>
-          //TODO: Move remaining vars to range and replace domain with single index.
           throw LatisException("Partial domain projection not yet supported.")
         // No domain variable projected
         case None =>
           // Replace domain with Index
-          // None if no variables projected
           applyToVariable(range).map { r =>
             Function.from(makeIndex(domain), r).fold(throw _, identity)
           }
       }
-
   }
 
   /**
@@ -71,52 +90,51 @@ case class Projection(ids: Identifier*) extends MapOperation {
     (vs1.length == vs2.length) && vs1.zip(vs2).forall(p => p._1.id == p._2.id)
   }
 
+  /** Apply projection to data */
   override def mapFunction(model: DataType): Sample => Sample = {
-    // Get the sample positions of the projected variables.
-    // Assumes Scalar projection only, for now.
-    // Does not support nested Function, for now.
-    val positions = model
-      .getScalars                //start here so we preserve variable order
-      .map(_.id)
-      .filter(ids.contains(_))   //keep the projected ids
-      .map(model.findPath(_).get) //findPath should be safe since we just got the id from the model
-      .map {
-        case p :: Nil => p
-        case _ :: _   => throw LatisException("Can't project within nested Function.")
-        case _        => ??? //shouldn't happen
-      }
-    // Separate domain and range positions
-    val (dpos, rpos): (List[DomainPosition], List[RangePosition]) =
-      positions.foldLeft((List[DomainPosition](), List[RangePosition]())) {
-        (p, pos) => pos match {
-          case dp: DomainPosition => ((p._1 :+ dp), p._2)
-          case rp: RangePosition => (p._1, (p._2 :+ rp))
+    // Bail early if the projection is not valid
+    // Hopefully caught at model application, but...
+    if (validate(model).isInvalid) throw LatisException("Bad projection")
+
+    if (allProjected(model)) identity //no-op
+    else {
+      // Get the sample positions of the projected variables.
+      // Assumes Scalar projection only, for now.
+      // Does not support nested Function, for now.
+      val positions = model
+        .nonIndexScalars //start here so we preserve variable order
+        .map(_.id)
+        .filter(ids.contains)
+        .map(model.findPath(_).get) //safe since id is from the model
+        .map {
+          case p :: Nil => p
+          case _ => throw LatisException("Bug: Projection validation failed")
         }
+
+      // Separate domain and range position indices
+      val (domainIndices, rangeIndices) = positions.partitionMap {
+        case DomainPosition(i) => i.asLeft
+        case RangePosition(i) => i.asRight
       }
 
-    val domainIndices: List[Int] = dpos.map {
-      case DomainPosition(i) => i
-    }
-    val rangeIndices: List[Int] = rpos.map {
-      case RangePosition(i) => i
-    }
-
-    if (rangeIndices.isEmpty) {
-      (sample: Sample) =>
-        Sample(DomainData(), domainIndices.map(sample.domain))
-    } else {
-      (sample: Sample) =>
-        Sample(domainIndices.map(sample.domain), rangeIndices.map(sample.range))
+      if (rangeIndices.isEmpty) {
+        (sample: Sample) =>
+          Sample(DomainData(), domainIndices.map(sample.domain))
+      } else {
+        (sample: Sample) =>
+          Sample(domainIndices.map(sample.domain), rangeIndices.map(sample.range))
+      }
     }
   }
 
   /**
-   * Makes an Index to replace a variable.
+   * Makes an Index to replace a non-projected domain variable.
+   *
    * This is used when a domain variable needs a placeholder
    * when it is not projected. The identifier for the Index
    * will be the original identifier prepended with "_i".
    * If the variable does not have an id (e.g. anonymous tuple),
-   * a random unique id will be generated.
+   * an id will be generated using its member Scalar ids.
    * Note that no other metadata is preserved.
    */
   private def makeIndex(v: DataType): Index = v match {
@@ -127,12 +145,53 @@ case class Projection(ids: Identifier*) extends MapOperation {
       Index(Identifier.fromString("_i" + id.asString).get) //safely valid
     }.getOrElse {
       // Derive id by combining scalar ids with "_"
-      Index(Identifier.fromString("_i" + v.getScalars.map(_.id.asString).mkString("_")).get)
+      Index(Identifier.fromString("_i" + v.getScalars.map(_.id).mkString("_")).get)
     }
-    case _: Function => ??? //Function not allowed in domain
+    case _: Function =>
+      //Function not allowed in domain
+      throw LatisException("Can't replace a Function with an Index")
   }
 
-  override def toString = s"Projection(${ids.map(_.asString).mkString(",")})"
+  /** Make sure this projection can be applied to the given model. */
+  def validate(model: DataType): ValidatedNel[LatisException, Projection] = {
+    // Some variables have been projected
+    def nonEmpty =
+      if (ids.isEmpty) LatisException("No variables projected").invalidNel
+      else this.valid
+
+    // All projected variables are non-Index Scalars in the model
+    def variablesDefined = {
+      val scalarIds = model.nonIndexScalars.map(_.id)
+      ids.filter(id => !scalarIds.contains(id)) match {
+        case Nil => this.valid
+        case id :: Nil =>
+          val msg = s"Projected Scalar does not exist: $id"
+          LatisException(msg).invalidNel
+        case ids =>
+          val badIds = ids.mkString(", ")
+          val msg = s"Projected Scalars do not exist: $badIds"
+          LatisException(msg).invalidNel
+      }
+    }
+
+    // No projected variables are in a nested Function unless all are projected
+    def noNestingUnlessAll = {
+      if (allProjected(model)) this.valid
+      else if (ids.forall(model.findPath(_).get.size == 1)) this.valid
+      else {
+        val msg = "Projected variables may not be in nested Functions"
+        LatisException(msg).invalidNel
+      }
+    }
+
+    nonEmpty.andThen(_ => variablesDefined).andThen(_ => noNestingUnlessAll)
+  }
+
+  /** Are all variables in the dataset projected */
+  private def allProjected(model: DataType): Boolean =
+    model.getScalars.forall(s => ids.contains(s.id))
+
+  override def toString = s"Projection(${ids.mkString(",")})"
 }
 
 object Projection {

--- a/core/src/main/scala/latis/output/BinaryEncoder.scala
+++ b/core/src/main/scala/latis/output/BinaryEncoder.scala
@@ -66,7 +66,7 @@ class BinaryEncoder(val dataCodec: Scalar => Codec[Data] = DataCodec.defaultData
         val tuples: List[Scalar] = t.flatElements.collect { case s: Scalar => s }
         (List[Scalar](), tuples)
       case Function(d, r) =>
-        (d.getScalars.filterNot(_.isInstanceOf[Index]), r.getScalars)
+        (d.nonIndexScalars, r.getScalars)
     }
     val domainList: List[Codec[Datum]] = domainScalars.map(s => dataCodec(s).downcast[Datum])
     val rangeList: List[Codec[Data]] = rangeScalars.map(s => dataCodec(s))

--- a/core/src/main/scala/latis/output/CsvEncoder.scala
+++ b/core/src/main/scala/latis/output/CsvEncoder.scala
@@ -39,8 +39,7 @@ class CsvEncoder(header: Dataset => Stream[IO, String]) extends Encoder[IO, Stri
     val scalars = NonEmptyList.fromList(
       flatDataset
         .model
-        .getScalars
-        .filterNot(_.isInstanceOf[Index])
+        .nonIndexScalars
     )
 
     // Encode each Sample as a String in the Stream
@@ -85,7 +84,7 @@ object CsvEncoder {
 
   def withColumnName: CsvEncoder = {
     def header(dataset: Dataset): String =
-      dataset.model.getScalars.filterNot(_.isInstanceOf[Index]).map(_.id.asString).mkString(",")
+      dataset.model.nonIndexScalars.map(_.id.asString).mkString(",")
     CsvEncoder.withHeader(header)
   }
 }

--- a/core/src/test/scala/latis/model/TupleSuite.scala
+++ b/core/src/test/scala/latis/model/TupleSuite.scala
@@ -83,4 +83,9 @@ class TupleSuite extends FunSuite {
     val tuple = Tuple.fromElements(id"t", a, b).fold(fail("failed to construct tuple", _), identity)
     assertEquals(tuple.id, Option(id"t"))
   }
+
+  test("no duplicate ids") {
+    val tuple = Tuple.fromElements(a, a)
+    assert(tuple.isLeft)
+  }
 }

--- a/core/src/test/scala/latis/output/BinaryEncoderSuite.scala
+++ b/core/src/test/scala/latis/output/BinaryEncoderSuite.scala
@@ -132,7 +132,7 @@ class BinaryEncoderSuite extends CatsEffectSuite {
         Scalar(id"r2", DoubleValueType),
         Scalar.fromMetadata(
           Metadata(
-            "id" -> "r2",
+            "id" -> "r3",
             "type" -> "string",
             "size" -> "2"
           )
@@ -161,7 +161,7 @@ class BinaryEncoderSuite extends CatsEffectSuite {
         Scalar(id"r2", DoubleValueType),
         Scalar.fromMetadata(
           Metadata(
-            "id" -> "r2",
+            "id" -> "r3",
             "type" -> "string",
             "size" -> "2"
           )

--- a/jdbc/src/main/scala/latis/input/JdbcAdapter.scala
+++ b/jdbc/src/main/scala/latis/input/JdbcAdapter.scala
@@ -71,7 +71,7 @@ case class JdbcAdapter(
     ops.foldLeft(model) { (mod, op) =>
       op.applyToModel(mod).fold(throw _, identity)
     } match {
-      case Function(d, r) => (d.getScalars.filterNot(_.isInstanceOf[Index]), r.getScalars)
+      case Function(d, r) => (d.nonIndexScalars, r.getScalars)
       case dt => (List(), dt.getScalars)
     }
   }

--- a/jdbc/src/main/scala/latis/util/SqlBuilder.scala
+++ b/jdbc/src/main/scala/latis/util/SqlBuilder.scala
@@ -51,7 +51,7 @@ case class SqlBuilder(
       val newModel = op.applyToModel(model).fold(throw _, identity)
       val newColumns = {
         //Need to preserve renames
-        val projected = newModel.getScalars.filterNot(_.isInstanceOf[Index]).map(_.id.asString)
+        val projected = newModel.nonIndexScalars.map(_.id.asString)
         columns.filter { col =>
           projected.contains(col.rename.getOrElse(col.name))
         }
@@ -135,7 +135,7 @@ object SqlBuilder {
     // We must do it here before they are projected away.
     val order = model match {
       case Function(domain, _) =>
-        domain.getScalars.filterNot(_.isInstanceOf[Index]).map(_.id.asString) match {
+        domain.nonIndexScalars.map(_.id.asString) match {
           case Nil  => ""
           case list => list.mkString(" ORDER BY ", ", ", " ASC")
         }
@@ -145,7 +145,7 @@ object SqlBuilder {
     // Define initial SqlBuilder with no operations applied.
     val init: SqlBuilder = SqlBuilder(
       table = table,
-      columns = model.getScalars.filterNot(_.isInstanceOf[Index]).map(s => Column(s.id.asString)),
+      columns = model.nonIndexScalars.map(s => Column(s.id.asString)),
       selections = List.empty,
       otherPredicate = otherPredicate,
       limit = None,

--- a/netcdf/src/main/scala/latis/input/NetcdfValidator.scala
+++ b/netcdf/src/main/scala/latis/input/NetcdfValidator.scala
@@ -59,7 +59,7 @@ object NetcdfValidator {
    * Assumes that the variable names have already been validated.
    */
   private def validateTypes(ncFile: NetcdfFile, model: DataType): Either[List[String], Unit] =
-    model.getScalars.filterNot(_.isInstanceOf[Index]).map { s =>
+    model.nonIndexScalars.map { s =>
       val name = s.ncName
       val v = ncFile.findVariable(name)
       if (matchTypes(s.valueType, v.getDataType)) None

--- a/server/src/test/scala/latis/server/ConfSuite.scala
+++ b/server/src/test/scala/latis/server/ConfSuite.scala
@@ -1,6 +1,6 @@
 package latis.server
 
-import java.net.URL
+import java.net.URI
 
 import com.comcast.ip4s.port
 import fs2.io.file.Path
@@ -66,7 +66,7 @@ class ConfSuite extends munit.FunSuite {
   }
 
   test("read JarServiceSpec") {
-    val path = URL("file://path/to/jar")
+    val path = URI("file://path/to/jar").toURL
     val prefix = "service"
     val clss = "ServiceClass"
 


### PR DESCRIPTION
The primary goal here is to make projection operations more robust. I added a `validate` method to encapsulate all the reasons that a projection is not compatible with a dataset's model. One breaking change is that this will not allow a projection for an undefined variable. This is consistent with relational algebra and SQL. I also cleaned up and clarified a few things.

We might want to use this validation pattern for all `Operation`s, calling `validate` when applying them to a dataset. Otherwise, I've thought about constructing the operations with the model so we can make them safe by construction.

I also paid off some debt by beefing up `Tuple` construction to disallow elements with duplicate ids and adding a `nonIndexScalars` method for `DataType`s to clean up all the places that filter was being used. And fixed a deprecation.