### PR TITLE
Add operation to curry on the right

### DIFF
--- a/core/src/main/scala/latis/dsl/package.scala
+++ b/core/src/main/scala/latis/dsl/package.scala
@@ -32,6 +32,7 @@ package object dsl {
     def stride(s: Int, ss: Int*): Dataset          = dataset.withOperation(Stride((s +: ss).toIndexedSeq))
     def uncurry(): Dataset                         = dataset.withOperation(Uncurry())
     def curry(n: Int): Dataset                     = dataset.withOperation(Curry(n))
+    def curryRight(n: Int): Dataset                = dataset.withOperation(CurryRight(n))
     def groupByVariable(ids: Identifier*): Dataset = dataset.withOperation(new GroupByVariable(ids *))
     def groupByBin(set: DomainSet, agg: Aggregation = DefaultAggregation()): Dataset =
       dataset.withOperation(GroupByBin(set, agg))

--- a/core/src/main/scala/latis/dsl/package.scala
+++ b/core/src/main/scala/latis/dsl/package.scala
@@ -41,7 +41,8 @@ package object dsl {
       dataset.withOperation(Contains(id, values *))
     def rename(id: Identifier, newId: Identifier): Dataset =
       dataset.withOperation(Rename(id, newId))
-    def eval(value: String): Dataset               = dataset.withOperation(Evaluation(value))
+    def eval(id: Identifier, value: String): Dataset =
+      dataset.withOperation(Evaluation(id, value))
     def withReader(reader: DatasetReader): Dataset = dataset.withOperation(ReaderOperation(reader))
     def drop(n: Long): Dataset                     = dataset.withOperation(Drop(n))
     def dropLast(): Dataset                        = dataset.withOperation(DropLast())

--- a/core/src/main/scala/latis/ops/Cartesianator.scala
+++ b/core/src/main/scala/latis/ops/Cartesianator.scala
@@ -1,0 +1,111 @@
+package latis.ops
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+import cats.effect.IO
+import cats.syntax.all.*
+import cats.Eq
+import cats.kernel.PartialOrder
+import fs2.*
+
+import latis.data.*
+import latis.model.*
+import latis.util.*
+
+/**
+ * Modify a Dataset such that the domain set is Cartesian.
+ *
+ * This gets all the distinct values for each domain variable in the
+ * outer domain, makes a Cartesian product set, then fills each domain
+ * point with an existing Sample or fill data. The result is a Cartesian
+ * dataset (that could be rather sparse).
+ *
+ * This reads all Samples into a List so there is risk of large
+ * memory usage. This could be used to ensure that we have a Cartesian
+ * dataset as required by some operation, but at a cost.
+ */
+case class Cartesianator() extends StreamOperation {
+  //TODO: no-op for 1D
+
+  override def pipe(model: DataType): Pipe[IO, Sample, Sample] = {
+
+    // Get the domain scalars and range type
+    val (scalars, range) = model match {
+      case Function(domain, range) => (domain.getScalars, range)
+      case _ => ??? //not a Function, shouldn't validate
+    }
+
+    // Define Eq for the outer domain, for finding matching samples
+    given Eq[DomainData] = PartialOrder.fromPartialOrdering {
+      CartesianDomainOrdering(scalars.map(_.ordering))
+    }
+
+    // Initial empty set of data for each domain scalar, for fold
+    val zero = scalars.map { scalar =>
+      val ord = LatisOrdering.partialToTotal(scalar.ordering)
+      mutable.SortedSet.empty[Datum](ord)
+    }
+
+    // Process samples
+    samples => {
+      // Use List to process samples since we need to traverse it twice
+      val io = samples.compile.toList.map { samples =>
+
+        // Build a sorted set of data values for each domain variable
+        val sets = samples.foldLeft(zero) {
+          case (acc, Sample(ds, _)) =>
+            //TODO: invalid sample with ds.size != ids.size
+            ds.zipWithIndex.foldLeft(acc) {
+              case (ss, (d, i)) => ss.updated(i, ss(i).addOne(d))
+            }
+        }
+
+        // Construct a list of DomainData as a product set of each
+        // set of domain scalar data values with the proper ordering.
+        // i.e. all possible coordinates in a Cartesian grid.
+        val dds = sets.foldLeft(List(List.empty[Datum])) { (acc, set) =>
+          acc.flatMap(ds => set.toList.map(ds.appended))
+        }
+
+        // For each Cartesian point, find a matching Sample or fill.
+        // Take advantage of ordering by pulling samples as needed.
+        // Accumulate Samples for each domain point until we find an
+        // existing Sample with that domain.
+        @tailrec
+        def go(pts: List[DomainData], orig: List[Sample], acc: List[Sample]): List[Sample] = {
+          orig match {
+            case (sample @ Sample(ds, _)) :: remainingSamples =>
+              val (tofill, remainingPts) = pts.span { pt =>
+                ! Eq[DomainData].eqv(ds, pt)
+              }
+              val fill = tofill.map { dd =>
+                Sample(dd, RangeData(range.fillData))
+              }
+
+              // Recurse with the remaining Cartesian set of domain points
+              // (minus the one we had a matching Sample for) pulling from
+              // the remaining samples and adding fill data as needed.
+              go(remainingPts.tail, remainingSamples, acc ++ fill :+ sample)
+
+            case Nil => //no more original samples but keep filling
+              acc ++ pts.map { dd =>
+                Sample(dd, RangeData(range.fillData))
+              }
+          }
+        }
+
+        go(dds, samples, List.empty)
+      }
+
+      // Put the complete set of samples back into a Stream
+      Stream.evals(io)
+    }
+  }
+
+  // Model is unchanged
+  //TODO: set Function topology to cartesian
+  override def applyToModel(model: DataType): Either[LatisException, DataType] =
+    model.asRight
+
+}

--- a/core/src/main/scala/latis/ops/Curry.scala
+++ b/core/src/main/scala/latis/ops/Curry.scala
@@ -25,6 +25,7 @@ case class Curry(arity: Int = 1) extends GroupOperation {
   //TODO: arity vs dimension/rank for nested tuples in the domain, ignoring nesting for now
   //TODO: Provide description for prov
   //TODO: avoid adding prov if this is a no-op
+  //TODO: do without sorting
 
   def groupByFunction(model: DataType): Sample => Option[DomainData] = {
     if (model.arity < arity) {

--- a/core/src/main/scala/latis/ops/CurryRight.scala
+++ b/core/src/main/scala/latis/ops/CurryRight.scala
@@ -1,0 +1,99 @@
+package latis.ops
+
+import cats.data.ValidatedNel
+import cats.effect.IO
+import cats.kernel.PartialOrder
+import cats.syntax.all.*
+import cats.Eq
+import fs2.Pipe
+
+import latis.data.*
+import latis.model.*
+import latis.util.CartesianDomainOrdering
+import latis.util.LatisException
+
+/**
+ * Make a nested Function using the right n domain variables.
+ *
+ * n must be greater than 0 and less than the arity of the Dataset.
+ * This requires a Cartesian Dataset to ensure that uniqueness
+ * and order are preserved.
+ */
+case class CurryRight(n: Int) extends StreamOperation {
+  //TODO: handle nested tuple in domain
+  //  note arity <= dimensionality
+  //TODO: impl Curry with this with arity - n
+  //  smart constructor, but need model
+  //TODO: does it make sense to support n = 0 or arity? no-op
+
+  override def pipe(model: DataType): Pipe[IO, Sample, Sample] = samples => {
+
+    // Define Eq for the new outer domain
+    given Eq[DomainData] = PartialOrder.fromPartialOrdering {
+      model match {
+        case Function(domain, _) =>
+          CartesianDomainOrdering(domain.getScalars.dropRight(n).map(_.ordering))
+        case _ => throw LatisException("Bug: validation should have caught this")
+      }
+    }
+
+    // Collect all the inner samples for each outer sample
+    // then make a new sample with a nested function
+    samples.groupAdjacentBy {
+      case Sample(ds, _) => ds.dropRight(n)
+    }.map {
+      case (domain, samples) =>
+        val innerSamples = samples.toList.map {
+          case Sample(d, r) => Sample(d.takeRight(n), r)
+        }
+        Sample(domain, RangeData(SampledFunction(innerSamples)))
+    }
+  }
+
+  // Reshape model with nested Function
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = {
+    validate(model).toEither.leftMap(_.head).flatMap { _ =>
+      model match {
+        case Function(domain, range) =>
+          val (ss1, ss2) = domain.getScalars.splitAt(n)
+          for {
+            d1 <- makeDomain(ss1)
+            d2 <- makeDomain(ss2)
+            in <- Function.from(d2, range)
+            f <- Function.from(d1, in)
+          } yield f
+        case _ => throw LatisException("Bug: validation should have caught this")
+      }
+    }
+  }
+
+  // Make a domain type from a list of Scalars
+  //TODO: util? we do this a lot
+  private def makeDomain(scalars: List[Scalar]) = scalars match {
+    case Nil => throw LatisException("Bug: validation should have caught this")
+    case s :: Nil => s.asRight
+    case ss => Tuple.fromSeq(ss)
+  }
+
+  def validate(model: DataType): ValidatedNel[LatisException, CurryRight] = {
+    //TODO: require topology = cartesian property on Function
+    model match {
+      case Function(domain, _) =>
+        if (n > 0 && n < domain.getScalars.size) this.validNel
+        else LatisException("n must be between 0 and the arity").invalidNel
+      case _ =>
+        LatisException("Curry expects a Function").invalidNel
+    }
+  }
+}
+
+object CurryRight {
+
+  def builder: OperationBuilder = (args: List[String]) => fromArgs(args)
+
+  def fromArgs(args: List[String]): Either[LatisException, CurryRight] = args match {
+    case n :: Nil => Either.catchOnly[NumberFormatException](CurryRight(n.toInt))
+      .leftMap(LatisException(_))
+    case _ => LatisException("CurryRight expects a single integer argument").asLeft
+  }
+}

--- a/core/src/main/scala/latis/ops/CurryRight.scala
+++ b/core/src/main/scala/latis/ops/CurryRight.scala
@@ -55,7 +55,8 @@ case class CurryRight(n: Int) extends StreamOperation {
     validate(model).toEither.leftMap(_.head).flatMap { _ =>
       model match {
         case Function(domain, range) =>
-          val (ss1, ss2) = domain.getScalars.splitAt(n)
+          val ss = domain.getScalars
+          val (ss1, ss2) = (ss.dropRight(n), ss.takeRight(n))
           for {
             d1 <- makeDomain(ss1)
             d2 <- makeDomain(ss2)

--- a/core/src/main/scala/latis/ops/Evaluation.scala
+++ b/core/src/main/scala/latis/ops/Evaluation.scala
@@ -1,36 +1,95 @@
 package latis.ops
 
+import cats.data.ValidatedNel
+import cats.effect.*
 import cats.syntax.all.*
+import fs2.*
 
 import latis.data.*
 import latis.model.*
+import latis.util.Identifier
 import latis.util.LatisException
 
 /**
  * Defines an operation that evaluates a Dataset at a given value
- * returning a new Dataset encapsulating the range value.
+ * for a given domain variable, returning a new Dataset keeping only
+ * the samples with that domain value. That domain dimension will be
+ * removed, reducing the arity of the dataset by one.
+ *
+ * This requires that the Dataset has a Function data model with
+ * the given id corresponding to a domain Scalar in the outer domain
+ * (not within a nested Function, for now). This requires that the
+ * domain set is Cartesian so uniqueness and ordering can be preserved.
  */
-case class Evaluation(value: String) extends UnaryOperation {
-  //TODO: assert that data is of the right type based on the model domain
-  //TODO: Allow parsing multiple values for higher arity datasets.
+case class Evaluation(id: Identifier, value: String) extends StreamOperation {
+  //TODO: allow interpolation?
 
-  def applyToModel(model: DataType): Either[LatisException, DataType] =
-    (model match {
-      case Function(_, r) => r
-      case _ => model
-    }).asRight
-
-
-  def applyToData(data: Data, model: DataType): Either[LatisException, Data] =
-    model.arity match {
-      case 0 => data.asRight
-      case 1 => for {
-        v  <- model.getScalars.head.parseValue(value)
-        dd <- DomainData.fromData(v)
-        rd <- data.eval(dd)
-      } yield Data.fromSeq(rd)
-      case _ => LatisException("Can't evaluate a multi-dimensional dataset").asLeft
+  // Remove the dimension being evaluated
+  def applyToModel(model: DataType): Either[LatisException, DataType] = {
+    validate(model).toEither.leftMap(_.head).flatMap { _ =>
+      val (domain, range) = model match {
+        case Function(domain, range) => (domain, range)
+        case _ => throw LatisException("Bug: Validation should have caught this")
+      }
+      val scalars = domain.getScalars.filterNot(_.id == id)
+      scalars.length match {
+        case 0 => range.asRight //no longer a Function
+        case 1 => Function.from(scalars.head, range)
+        case _ => Tuple.fromSeq(scalars).flatMap { domain =>
+          Function.from(domain, range)
+        }
+      }
     }
+  }
+
+  // Keep only the samples with the matching domain value
+  // and remove that element from the domain.
+  def pipe(model: DataType): Pipe[IO, Sample, Sample] = {
+    // Note, these should not throw if validation succeeded
+    val pos = domainPosition(model, id)
+    val domainVar = model.getScalars(pos)
+    val ordering = domainVar.ordering
+    val data = domainVar.parseValue(value).fold(throw _, identity) //validated
+
+    samples => samples.map {
+      case Sample(domain, range) =>
+        domain.get(pos) match {
+          case Some(d) =>
+            if (ordering.equiv(d, data)) {
+              val (before, after) = domain.splitAt(pos)
+              Sample(before ++ after.drop(1), range).some
+            } else None
+          case None => None //drop invalid sample, log?
+        }
+    }.unNone
+  }
+
+  // Get the sample position of the given variable in the model.
+  private def domainPosition(model: DataType, id: Identifier): Int =
+    model.findPath(id).get match {
+      case DomainPosition(p) :: Nil => p
+      case _ => throw LatisException("Bug: Validation should have caught this")
+    }
+
+  // Make sure this Operation is applicable for a Dataset with the given model
+  private def validate(model: DataType): ValidatedNel[LatisException, Evaluation] = {
+    model match {
+      case Function(domain, _) =>
+        domain.findVariable(id) match {
+          case Some(s: Scalar) =>
+            if (s.parseValue(value).isRight) this.validNel
+            else {
+              val msg = s"Invalid value: $value for variable $id"
+              LatisException(msg).invalidNel
+            }
+          case _ =>
+            val msg = s"Evaluation variable not found in domain: $id"
+            LatisException(msg).invalidNel
+        }
+      case _ => LatisException("Evaluation requires a Function").invalidNel
+    }
+  }
+
 }
 
 object Evaluation {
@@ -38,7 +97,10 @@ object Evaluation {
   def builder: OperationBuilder = (args: List[String]) => fromArgs(args)
 
   def fromArgs(args: List[String]): Either[LatisException, Evaluation] = args match {
-    case arg :: Nil => Right(Evaluation(arg))
-    case _ => Left(LatisException("Evaluation requires exactly one argument"))
+    case variable :: value :: Nil =>
+      Identifier.fromString(variable).map { id =>
+        Evaluation(id, value)
+      }.toRight(LatisException(s"Invalid identifier $variable"))
+    case _ => Left(LatisException("Evaluation requires a variable name and value"))
   }
 }

--- a/core/src/main/scala/latis/ops/Integration.scala
+++ b/core/src/main/scala/latis/ops/Integration.scala
@@ -1,0 +1,32 @@
+package latis.ops
+
+import cats.effect.IO
+import fs2.*
+
+import latis.data.*
+import latis.model.DataType
+import latis.util.Identifier
+import latis.util.LatisException
+
+/**
+ * reduce a function to a scalar or tuple, like agg but can't result in function
+ */
+case class Integration(id: Identifier) {
+  //TODO: sum, newton-cotes, ...
+  //  only last/inner dimension? for now
+  //  curry then agg
+
+  //override def aggregateFunction(model: DataType): Stream[IO, Sample] => IO[Data] = ???
+
+  //reuse to remove domain var, also for eval... curry?
+  //projection not suitable, no agg so needs placeholder
+  //
+  //diff aggs could have diff result types?
+  //  but not for this and eval
+  //  so can't use any agg here? we could support just the ones that make sense, subclasses of Integration trait
+  //  require curry to get 1D nested func? find integrand in nested func domain,
+  //  then no cartesian restriction here, just in curry, curryLast(n)?
+  //  * could we just curry and sum? compose?
+  //dropDimension? reduce?
+  //override def applyToModel(model: DataType): Either[LatisException, DataType] = ???
+}

--- a/core/src/main/scala/latis/ops/Integration.scala
+++ b/core/src/main/scala/latis/ops/Integration.scala
@@ -1,32 +1,89 @@
 package latis.ops
 
+import cats.data.ValidatedNel
 import cats.effect.IO
+import cats.syntax.all.*
 import fs2.*
 
 import latis.data.*
-import latis.model.DataType
+import latis.model.*
 import latis.util.Identifier
 import latis.util.LatisException
 
 /**
- * reduce a function to a scalar or tuple, like agg but can't result in function
+ * Reduces a Function to a Scalar or Tuple by applying an integration
+ * algorithm.
+ *
+ * This expects a (potentially nested) Function with the given Scalar
+ * (variable of integration) as the only domain variable. The range of
+ * said Function must have numeric Scalars only.
  */
-case class Integration(id: Identifier) {
-  //TODO: sum, newton-cotes, ...
-  //  only last/inner dimension? for now
-  //  curry then agg
+trait Integration extends StreamOperation {
+  //TODO: note similarity to Aggregation: samples => Data
 
-  //override def aggregateFunction(model: DataType): Stream[IO, Sample] => IO[Data] = ???
+  /** Variable of integration */
+  def id: Identifier
 
-  //reuse to remove domain var, also for eval... curry?
-  //projection not suitable, no agg so needs placeholder
-  //
-  //diff aggs could have diff result types?
-  //  but not for this and eval
-  //  so can't use any agg here? we could support just the ones that make sense, subclasses of Integration trait
-  //  require curry to get 1D nested func? find integrand in nested func domain,
-  //  then no cartesian restriction here, just in curry, curryLast(n)?
-  //  * could we just curry and sum? compose?
-  //dropDimension? reduce?
-  //override def applyToModel(model: DataType): Either[LatisException, DataType] = ???
+  /**
+   * Integration algorithm
+   *
+   * Reduce the samples into a single Data object.
+   * Should only be called for a 1D Function with numeric range data.
+   */
+  def integrate(model: DataType, samples: Stream[IO, Sample]): IO[Data]
+
+
+  override def pipe(model: DataType): Pipe[IO, Sample, Sample] = {
+    def go(model: DataType, samples: Stream[IO, Sample]): IO[Data] = {
+      model match {
+        case Function(domain: Scalar, range) if (domain.id == id) =>
+          integrate(model, samples)
+        case Function(domain, range: Function) =>
+          val ss = samples.flatMap {
+            case Sample(d, RangeData(f: SampledFunction)) =>
+              Stream.eval(go(range, f.samples).map(r => Sample(d, RangeData(r))))
+          }
+          // Memoize nested Function
+          ss.compile.toList.map(SampledFunction.apply)
+        case _ => ??? //bug, LatisException("Failed to find variable of integration").asLeft
+      }
+    }
+
+    samples => Stream.eval(go(model, samples)).flatMap(_.samples)
+  }
+
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = {
+    def go(model: DataType): Either[LatisException, DataType] = {
+      model match {
+        case Function(domain: Scalar, range) if (domain.id == id) => range.asRight
+        case Function(domain, range: Function) =>
+          go(range).flatMap(Function.from(domain, _))
+        case _ => LatisException("Failed to find variable of integration").asLeft
+      }
+    }
+
+    validate(model).toEither.leftMap(_.head).flatMap(_ => go(model))
+  }
+
+  def validate(model: DataType): ValidatedNel[LatisException, Integration] = {
+    def go(model: DataType): ValidatedNel[LatisException, Integration] = {
+      model match {
+        case Function(domain: Scalar, range) if (domain.id == id) =>
+          if (isNumeric(range)) this.validNel
+          else LatisException("Integration requires numeric range data").invalidNel
+        case Function(domain, range: Function) => go(range)
+        case _ => LatisException("Failed to find variable of integration").invalidNel
+      }
+    }
+    go(model)
+  }
+  
+  //TODO: util?
+  private def isNumeric(model: DataType): Boolean = {
+    model match {
+      case s: Scalar   => s.valueType.isInstanceOf[NumericType]
+      case Tuple(es *) => es.forall(isNumeric) //not tail recursive, but shallow 
+      case _: Function => false
+    }
+  }
 }

--- a/core/src/main/scala/latis/ops/OperationRegistry.scala
+++ b/core/src/main/scala/latis/ops/OperationRegistry.scala
@@ -20,6 +20,7 @@ object OperationRegistry {
       "count"           -> CountAggregation.builder,
       "countBy"         -> CountBy.builder,
       "curry"           -> Curry.builder,
+      "curryRight"      -> CurryRight.builder,
       "drop"            -> Drop.builder,
       "dropLast"        -> DropLast.builder,
       "dropRight"       -> DropRight.builder,

--- a/core/src/main/scala/latis/ops/SumIntegration.scala
+++ b/core/src/main/scala/latis/ops/SumIntegration.scala
@@ -1,0 +1,39 @@
+package latis.ops
+
+import cats.effect.IO
+import fs2.*
+
+import latis.data.*
+import latis.model.*
+import latis.util.Identifier
+
+/**
+ * Integrates by summing the range data
+ */
+case class SumIntegration(id: Identifier) extends Integration {
+  //TODO: use Sum operation
+  //TODO: value type promoted to long or double, preserve type? risky for sum
+
+  /**
+   * Sum the range values of the given samples.
+   * 
+   * The model is not needed for this case.
+   */
+  def integrate(model: DataType, samples: Stream[IO, Sample]): IO[Data] = {
+    samples.map(_.range).reduce(sum).compile.toList.map(_.head).map {
+      case r :: Nil => r
+      case rs       => TupleData(rs)
+    }
+  }
+
+  // Sum two RangeData objects, from Sum
+  private def sum(r1: RangeData, r2: RangeData): RangeData = {
+    // Note that types should align since these are from Samples of the same dataset
+    r1.zip(r2).map {
+      case (Integer(i1), Integer(i2)) => Data.LongValue(i1 + i2)
+      case (Number(n1), Number(n2)) => Data.DoubleValue(n1 + n2)
+      case _ => Data.DoubleValue(Double.NaN) //validation should prevent this
+    }
+  }
+  
+}

--- a/core/src/test/scala/latis/ops/CaresianatorSuite.scala
+++ b/core/src/test/scala/latis/ops/CaresianatorSuite.scala
@@ -1,0 +1,43 @@
+package latis.ops
+
+import cats.effect.*
+import fs2.Stream
+import munit.CatsEffectSuite
+
+import latis.data.*
+import latis.metadata.Metadata
+import latis.model.*
+import latis.util.Identifier.id
+
+class CaresianatorSuite extends CatsEffectSuite {
+
+  private val model = (for {
+    domain <- Tuple.fromElements(
+      Scalar(id"x", IntValueType),
+      Scalar(id"y", IntValueType)
+    )
+    a <- Scalar.fromMetadata(Metadata(
+      "id" -> "a",
+      "type" -> "int",
+      "fillValue" -> "-999"
+    ))
+    f <- Function.from(domain, a)
+  } yield f).fold(throw _, identity)
+
+  test("test") {
+    val samples = List(
+      Sample(DomainData(0,1), RangeData(1)),
+      Sample(DomainData(1,0), RangeData(2))
+    )
+    val expected = List(
+      Sample(DomainData(0,0), RangeData(-999)),
+      Sample(DomainData(0,1), RangeData(1)),
+      Sample(DomainData(1,0), RangeData(2)),
+      Sample(DomainData(1,1), RangeData(-999))
+    )
+    Cartesianator().pipe(model)(Stream.emits(samples)).compile.toList.map { ss =>
+      assertEquals(ss, expected)
+    }
+  }
+
+}

--- a/core/src/test/scala/latis/ops/CurryRightSuite.scala
+++ b/core/src/test/scala/latis/ops/CurryRightSuite.scala
@@ -42,4 +42,55 @@ class CurryRightSuite extends CatsEffectSuite {
     }
   }
 
+  test("Curry right 2, model") {
+    val model = ModelParser.unsafeParse("(x, y, z) -> a")
+    CurryRight(2).applyToModel(model).map { mod =>
+      assertEquals(
+        mod.toString,
+        "x -> (y, z) -> a"
+      )
+    }.fold(e => fail(e.message), identity)
+  }
+
+  test("Curry right 2, samples") {
+    val model = ModelParser.unsafeParse("(x, y, z) -> a")
+    val data = DatasetGenerator.generateData(model)
+    CurryRight(2).pipe(model)(data.samples).flatMap {
+      case Sample(DomainData(x: IntValue), RangeData(f: SampledFunction)) =>
+        f.samples.map {
+          case Sample(DomainData(y: IntValue, z: IntValue), RangeData(a: IntValue)) =>
+            (x.value, y.value, z.value, a.value)
+          case _ => fail("Curried Sample is wrong")
+        }
+      case _ => fail("Curried Sample is wrong")
+    }.compile.toList.map { obtained =>
+      val expected = List(
+        (0,0,0,0),
+        (0,0,1,1),
+        (0,0,2,2),
+        (0,0,3,3),
+        (0,1,0,4),
+        (0,1,1,5),
+        (0,1,2,6),
+        (0,1,3,7),
+        (0,2,0,8),
+        (0,2,1,9),
+        (0,2,2,10),
+        (0,2,3,11),
+        (1,0,0,12),
+        (1,0,1,13),
+        (1,0,2,14),
+        (1,0,3,15),
+        (1,1,0,16),
+        (1,1,1,17),
+        (1,1,2,18),
+        (1,1,3,19),
+        (1,2,0,20),
+        (1,2,1,21),
+        (1,2,2,22),
+        (1,2,3,23),
+      )
+      assertEquals(obtained, expected)
+    }
+  }
 }

--- a/core/src/test/scala/latis/ops/CurryRightSuite.scala
+++ b/core/src/test/scala/latis/ops/CurryRightSuite.scala
@@ -1,0 +1,45 @@
+package latis.ops
+
+import munit.CatsEffectSuite
+
+import latis.data.*
+import latis.data.Data.*
+import latis.dsl.*
+
+class CurryRightSuite extends CatsEffectSuite {
+
+  private val model = ModelParser.unsafeParse("(x, y) -> a")
+  private val data = DatasetGenerator.generateData(model)
+
+  test("curry right model") {
+    CurryRight(1).applyToModel(model).map { mod =>
+      assertEquals(
+        mod.toString,
+        "x -> y -> a"
+      )
+    }.fold(e => fail(e.message), identity)
+  }
+
+  test("curry right samples") {
+    CurryRight(1).pipe(model)(data.samples).flatMap {
+      case Sample(DomainData(x: IntValue), RangeData(f: SampledFunction)) =>
+        f.samples.map {
+          case Sample(DomainData(y: IntValue), RangeData(a: IntValue)) =>
+            (x.value, y.value, a.value)
+          case _ => fail("Curried Sample is wrong")
+        }
+      case _ => fail("Curried Sample is wrong")
+    }.compile.toList.map { obtained =>
+      val expected = List(
+        (0, 0, 0),
+        (0, 1, 1),
+        (0, 2, 2),
+        (1, 0, 3),
+        (1, 1, 4),
+        (1, 2, 5)
+      )
+      assertEquals(obtained, expected)
+    }
+  }
+
+}

--- a/core/src/test/scala/latis/ops/IntegrationSuite.scala
+++ b/core/src/test/scala/latis/ops/IntegrationSuite.scala
@@ -1,0 +1,66 @@
+package latis.ops
+
+import fs2.Stream
+import munit.CatsEffectSuite
+
+import latis.data.*
+import latis.data.Data.*
+import latis.dsl.*
+import latis.util.Identifier.*
+
+class IntegrationSuite extends CatsEffectSuite {
+
+  test("integrate flat function, model") {
+    val model = ModelParser.unsafeParse("x -> (a, b)")
+    val obtained = SumIntegration(id"x").applyToModel(model)
+      .fold(e => fail(e.message), identity)
+    assertEquals(obtained.toString, "(a, b)")
+  }
+
+  test("integrate nested function, model") {
+    val model = ModelParser.unsafeParse("x -> y -> (a, b)")
+    val obtained = SumIntegration(id"y").applyToModel(model)
+      .fold(e => fail(e.message), identity)
+    assertEquals(obtained.toString, "x -> (a, b)")
+  }
+
+  test("integrate flat function, samples") {
+    val model = ModelParser.unsafeParse("x -> (a, b)")
+    val samples = List(
+      Sample(DomainData(0), RangeData(0, 0)),
+      Sample(DomainData(1), RangeData(1, 2)),
+      Sample(DomainData(2), RangeData(2, 4))
+    )
+    val expected = RangeData(3L, 6L)
+
+    SumIntegration(id"x").pipe(model)(Stream.emits(samples))
+      .compile.toList.map { ss =>
+        ss.head match {
+          case Sample(DomainData(), rdata) =>
+            assertEquals(rdata, expected)
+        }
+      }
+  }
+
+  test("integrate nested function, samples") {
+    val model = ModelParser.unsafeParse("x -> y -> (a, b)")
+    val f1 = SampledFunction(List(
+      Sample(DomainData(0), RangeData(0, 0)),
+      Sample(DomainData(1), RangeData(1, 2)),
+      Sample(DomainData(2), RangeData(2, 4))
+    ))
+    val samples = List(
+      Sample(DomainData(0), RangeData(f1))
+    )
+    val expected = RangeData(3L, 6L)
+    SumIntegration(id"y").pipe(model)(Stream.emits(samples))
+      .compile.toList.map { ss =>
+        ss.head match {
+          case Sample(DomainData(x: IntValue), rdata) =>
+            assertEquals(x.value, 0)
+            assertEquals(rdata, expected)
+        }
+      }
+  }
+
+}


### PR DESCRIPTION
Given a dataset with a nD Cartesian domain set, take the right n domain variables to make a nested Function.

For example: `CurryRight(2)` on `(x, y, z) -> a` results in `x -> (y, z) -> a`, where `a` can be any type since it is not modified.

This improves on the `Curry` operation (effectively CurryLeft) which could use similar refactoring. Or just use this if we can compute the number of right variables from the model. Another case where it would help to construct operations with the model.

For more background on why this is called "curry", see https://en.wikipedia.org/wiki/Currying.