### PR TITLE
Add a compiler option to modify operations

### DIFF
--- a/core/src/main/scala/latis/dataset/WrappedDataset.scala
+++ b/core/src/main/scala/latis/dataset/WrappedDataset.scala
@@ -1,0 +1,66 @@
+package latis.dataset
+
+import cats.effect.IO
+import cats.syntax.all.*
+import fs2.*
+
+import latis.data.*
+import latis.metadata.Metadata
+import latis.model.*
+import latis.ops.*
+import latis.util.Identifier
+
+/**
+ * Wrap a Dataset with the ability to modify Operations
+ * 
+ * This manages the operations applied to it then optimizes
+ * their application, possibly adding additional operations,
+ * before applying them to the wrapped dataset. This can be
+ * used to apply specific operations while front-loading those
+ * (e.g. user time selections) that can be pushed down by the 
+ * wrapped dataset. Note that any operations that the wrapped 
+ * dataset already has (e.g. by a fdml processing instruction) 
+ * cannot be modified.
+ * 
+ * Note: This would not be needed if we could copy AdaptedDataset, 
+ * but we don't currently have access to the Adapter.
+ */
+case class WrappedDataset private (
+  metadata: Metadata,
+  dataset: Dataset,
+  operations: List[UnaryOperation] = List.empty,
+  mungeOperations: List[UnaryOperation] => List[UnaryOperation]
+) extends Dataset {
+
+  override def model: DataType = {
+    mungeOperations(operations)
+      .foldM(dataset.model)((mod, op) => op.applyToModel(mod))
+      .fold(throw _, identity)
+  }
+
+  override def samples: Stream[IO, Sample] = {
+    // Modify operations then add to wrapped dataset
+    // to give it a change to push down
+    val ops = mungeOperations(operations)
+    dataset.withOperations(ops).samples
+  }
+
+  override def withOperation(op: UnaryOperation): Dataset =
+    //TODO: validate op with model
+    WrappedDataset(metadata, dataset, operations :+ op, mungeOperations)
+
+  override def unsafeForce(): MemoizedDataset = ???
+}
+
+object WrappedDataset {
+  def wrap(
+    dataset: Dataset,
+    mungeOperations: List[UnaryOperation] => List[UnaryOperation],
+    id: Option[Identifier]
+  ): WrappedDataset = {
+    //TODO: pass additional metadata?
+    val md = id.map(Metadata.apply)
+      .getOrElse(dataset.metadata)
+    WrappedDataset(md, dataset, List.empty, mungeOperations)
+  }
+}


### PR DESCRIPTION
This seems like a simple yet powerful way to construct an AdaptedDataset with a function to munge operations to best fit the needs of the Adapter. For example, I often want to enforce that a particular operation is applied (e.g. telemetry conversions), but that would show up as the first operation preventing pushing down user operations (like time selections) to the Adapter. This allows me to have special logic about doing time selections before this specific operation.

This seemed like a handy alternative to a generic query optimizer, for now.