### PR TITLE
Add support for infinite bounds

### DIFF
--- a/core/src/main/scala/latis/util/Bounds.scala
+++ b/core/src/main/scala/latis/util/Bounds.scala
@@ -1,18 +1,34 @@
 package latis.util
 
+import cats.*
+
 /**
  * [[Bounds]] represent the lower and upper extents of a coverage.
  *
- * Note that "lower" and "upper" bounds are compared based on an
- * Ordering, not necessarily the usual numeric ordering.
+ * Note that "lower" and "upper" bounds are compared based on a
+ * PartialOrder, not necessarily the usual lexical ordering.
  */
 sealed trait Bounds[T] {
 
   /** Is the given value covered by this [[Bounds]] */
-  def contains(value: T): Boolean
+  def contains(value: T)(using ord: PartialOrder[T]): Boolean = this match {
+    case NonEmptyBounds(l, u) => l.boundsLower(value) && u.boundsUpper(value)
+    case PointBounds(v)       => ord.eqv(v, value)
+    case _: EmptyBounds[T]    => false
+  }
 
-  /** Does this [[Bounds]] have a zero coverage */
-  def isEmpty: Boolean
+  /** Does this [[Bounds]] have no coverage */
+  def isEmpty: Boolean = this match {
+    case _: EmptyBounds[t] => true
+    case _ => false
+  }
+
+  /** Is this [[Bounds]] without an infinite extent */
+  def isFinite: Boolean = this match {
+    case NonEmptyBounds(_: InfiniteBound[T], _) => false
+    case NonEmptyBounds(_, _: InfiniteBound[T]) => false
+    case _ => true
+  }
 
   /**
    * Replaces the lower bound if the given value further constrains it.
@@ -31,120 +47,184 @@ sealed trait Bounds[T] {
 
 /**
  * [[NonEmptyBounds]] represent a coverage with an upper [[Bound]]
- * that is greater than the lower [[Bound]].
+ * that is "greater than" the lower [[Bound]] based on the ordering.
  */
-case class NonEmptyBounds[T] private[util] (lower: Bound[T], upper: Bound[T])
-  (using ord: Ordering[T]) extends Bounds[T] {
-
-  def contains(value: T): Boolean =
-    lower.boundsLower(value) && upper.boundsUpper(value)
-
-  def isEmpty: Boolean = false
+final case class NonEmptyBounds[T: PartialOrder] private[util] (
+  lower: Bound[T], upper: Bound[T]
+) extends Bounds[T] {
 
   def constrainLower(value: T): Bounds[T] = {
     if (lower.boundsLower(value)) {
       if (upper.boundsUpper(value))
-        NonEmptyBounds(lower.updated(value), upper)
-      else Bounds.empty
+        lower match {
+          case _: ClosedBound[T]   => NonEmptyBounds(ClosedBound(value), upper)
+          case _: OpenBound[T]     => NonEmptyBounds(OpenBound(value), upper)
+          // Note, a lower infinite bound will be replaced by a closed bound
+          case _: InfiniteBound[T] => NonEmptyBounds(ClosedBound(value), upper)
+        }
+      else Bounds.empty //value exceeds upper bound
     }
+    else if (isNaN(value)) Bounds.empty
     else this
   }
 
   def constrainUpper(value: T): Bounds[T] = {
     if (upper.boundsUpper(value)) {
       if (lower.boundsLower(value))
-        NonEmptyBounds(lower, upper.updated(value))
-      else Bounds.empty
+        upper match {
+          case _: ClosedBound[T]   => NonEmptyBounds(lower, ClosedBound(value))
+          case _: OpenBound[T]     => NonEmptyBounds(lower, OpenBound(value))
+          // Note, an upper infinite bound will be replaced by an open bound
+          case _: InfiniteBound[T] => NonEmptyBounds(lower, OpenBound(value))
+        }
+      else Bounds.empty //value exceeds lower bound
     }
+    else if (isNaN(value)) Bounds.empty
     else this
   }
 
   override def toString: String = (lower, upper) match {
-    case (ClosedBound(l), ClosedBound(u)) => s"[$l,$u]"
-    case (ClosedBound(l), OpenBound(u))   => s"[$l,$u)"
-    case (OpenBound(l), ClosedBound(u))   => s"($l,$u]"
-    case (OpenBound(l), OpenBound(u))     => s"($l,$u)"
+    case (ClosedBound(l),  ClosedBound(u))   => s"[$l,$u]"
+    case (ClosedBound(l),  OpenBound(u))     => s"[$l,$u)"
+    case (OpenBound(l),    ClosedBound(u))   => s"($l,$u]"
+    case (OpenBound(l),    OpenBound(u))     => s"($l,$u)"
+    case (InfiniteBound(), ClosedBound(u))   => s"(-inf,$u]"
+    case (InfiniteBound(), OpenBound(u))     => s"(-inf,$u)"
+    case (ClosedBound(l),  InfiniteBound())  => s"[$l,inf)"
+    case (OpenBound(l),    InfiniteBound())  => s"($l,inf)"
+    case (InfiniteBound(), InfiniteBound())  => s"(-inf,inf)"
   }
 }
 
 /** [[Bounds]] that contain a single value */
-case class PointBounds[T](point: T) extends Bounds[T] {
-  def contains(value: T): Boolean = point == value
-  def isEmpty: Boolean = false
+final case class PointBounds[T] private[util] (point: T)
+  (using ord: PartialOrder[T]) extends Bounds[T] {
   def constrainLower(value: T): Bounds[T] =
-    if (point == value) this else Bounds.empty
+    if (ord.eqv(point, value)) this else Bounds.empty
   def constrainUpper(value: T): Bounds[T] =
-    if (point == value) this else Bounds.empty
+    if (ord.eqv(point, value)) this else Bounds.empty
   override def toString: String = s"[$point]"
 }
 
 /** [[Bounds]] that cover nothing */
-class EmptyBounds[T] extends Bounds[T] {
-  def contains(value: T): Boolean = false
-  def isEmpty: Boolean = true
+final case class EmptyBounds[T: PartialOrder] private[util] ()
+  extends Bounds[T] {
   def constrainLower(value: T): Bounds[T] = Bounds.empty
   def constrainUpper(value: T): Bounds[T] = Bounds.empty
   override def toString: String = "0"
 }
 
+//==== Companion object ====//
+
 object Bounds {
 
-  def empty[T]: Bounds[T] = new EmptyBounds
+  def empty[T: PartialOrder]: Bounds[T] = new EmptyBounds
 
   /**
-   * Constructs [[Bounds]] with an inclusive lower bound and
-   * exclusive upper bound.
+   * Constructs [[Bounds]] with the given lower and upper bounds.
+   *
+   * If [[inclusive]] is true, both bounds will be inclusive. If false,
+   * the lower bound will be inclusive and the upper bound exclusive.
    *
    * If either bound is a NaN, this will return an empty [[Bounds]].
    */
-  def of[T](lower: T, upper: T)(using ord: Ordering[T]): Bounds[T] =
-    //Need special handling for NaN
+  def of[T](lower: T, upper: T, inclusive: Boolean = false)
+    (using ord: PartialOrder[T]): Bounds[T] =
     (lower, upper) match {
-      case (l: Double, u: Double) if (l.isNaN || u.isNaN) => Bounds.empty
-      case (l: Float, u: Float)   if (l.isNaN || u.isNaN) => Bounds.empty
-      case (l, u) if (ord.lt(lower, upper)) =>
-        NonEmptyBounds(ClosedBound(lower), OpenBound(upper))
+      case (l, u) if (isNaN(l) || isNaN(u)) => Bounds.empty
+      case (l, u) if (isInf(l) && isInf(u)) => Bounds.unbounded
+      case (l, u) if (ord.eqv(l, u)) =>
+        if (inclusive) PointBounds(l) else Bounds.empty
+      case (l, u) if isInf(l) =>
+        val up = if (inclusive) ClosedBound(u) else OpenBound(u)
+        NonEmptyBounds(InfiniteBound(), up)
+      case (l, u) if (isInf(u)) =>
+        NonEmptyBounds(ClosedBound(l), InfiniteBound())
+      case (l, u) if (ord.lt(l, u)) =>
+        val up = if (inclusive) ClosedBound(u) else OpenBound(u)
+        NonEmptyBounds(ClosedBound(l), up)
       case _ => Bounds.empty
     }
 
-  /**
-   * Constructs [[Bounds]] with inclusive lower and upper bounds.
-   */
-  def inclusive[T](lower: T, upper: T)(using ord: Ordering[T]): Bounds[T] = {
-    if (ord.lt(lower, upper))
-      NonEmptyBounds(ClosedBound(lower), ClosedBound(upper))
-    else if (lower == upper) PointBounds(lower)
-    else Bounds.empty
+  /** Constructs [[Bounds]] with inclusive lower and upper bounds. */
+  def inclusive[T: PartialOrder](lower: T, upper: T): Bounds[T] =
+    of(lower, upper, true)
+
+  /** Constructs infinite bounds */
+  def unbounded[T: PartialOrder]: Bounds[T] =
+    NonEmptyBounds(InfiniteBound(), InfiniteBound())
+
+  /** Constructs bounds with closed lower bound and infinite upper bound */
+  def closedLower[T: PartialOrder](value: T): Bounds[T] =
+    if (isNaN(value))      Bounds.empty
+    else if (isInf(value)) Bounds.unbounded
+    else NonEmptyBounds(ClosedBound(value), InfiniteBound())
+
+  /** Constructs bounds with open lower bound and infinite upper bound */
+  def openLower[T: PartialOrder](value: T): Bounds[T] =
+    if (isNaN(value))      Bounds.empty
+    else if (isInf(value)) Bounds.unbounded
+    else NonEmptyBounds(OpenBound(value), InfiniteBound())
+
+  /** Constructs bounds with infinite lower bound and closed upper bound */
+  def closedUpper[T: PartialOrder](value: T): Bounds[T] =
+    if (isNaN(value))      Bounds.empty
+    else if (isInf(value)) Bounds.unbounded
+    else NonEmptyBounds(InfiniteBound(), ClosedBound(value))
+
+  /** Constructs bounds with infinite lower bound and open upper bound */
+  def openUpper[T: PartialOrder](value: T): Bounds[T] = {
+    if (isNaN(value))      Bounds.empty
+    else if (isInf(value)) Bounds.unbounded
+    else NonEmptyBounds(InfiniteBound(), OpenBound(value))
   }
+
+  /** Constructs a PointBound with the given value */
+  def at[T: PartialOrder](value: T): Bounds[T] = PointBounds(value)
 }
 
+//==== Bound ====/
 
 /**
  * [[Bound]] defines a boundary (lower or upper) of a coverage.
  */
 sealed trait Bound[T] {
-  /** Returns the bounding value */
-  def value: T
   /** Does this bound the given value on the lower side */
   def boundsLower(value: T): Boolean
   /** Does this bound the given value on the upper side */
   def boundsUpper(value: T): Boolean
-  /** Returns a new Bound with the updated value */
-  def updated(value: T): Bound[T]
 }
 
 /** Defines a [[Bound]] that is inclusive. */
-final case class ClosedBound[T](val value: T)
-(using ord: Ordering[T]) extends Bound[T] {
-  def boundsLower(v: T): Boolean = ord.lteq(value, v)
-  def boundsUpper(v: T): Boolean = ord.gteq(value, v)
-  def updated(v: T): Bound[T] = ClosedBound[T](v)
+final case class ClosedBound[T] private[util] (private val value: T)
+(using ord: PartialOrder[T]) extends Bound[T] {
+  def boundsLower(v: T): Boolean = ord.lteqv(value, v)
+  def boundsUpper(v: T): Boolean = ord.gteqv(value, v)
 }
 
 /** Defines a [[Bound]] that is exclusive. */
-final case class OpenBound[T](val value: T)
-(using ord: Ordering[T]) extends Bound[T] {
+final case class OpenBound[T] private[util] (private val value: T)
+(using ord: PartialOrder[T]) extends Bound[T] {
   def boundsLower(v: T): Boolean = ord.lt(value, v)
   def boundsUpper(v: T): Boolean = ord.gt(value, v)
-  def updated(v: T): Bound[T] = OpenBound[T](v)
+}
+
+/** Defines a [[Bound]] that does not constrain. */
+final case class InfiniteBound[T] private[util] () extends Bound[T] {
+  def boundsLower(v: T): Boolean = ! isNaN(v)
+  def boundsUpper(v: T): Boolean = ! isNaN(v)
+}
+
+//==== Utility methods ====//
+
+private def isNaN(v: Any): Boolean = v match {
+  case v: Double => v.isNaN
+  case v: Float  => v.isNaN
+  case _ => false
+}
+
+private def isInf(v: Any): Boolean = v match {
+  case v: Double => v.isInfinite
+  case v: Float  => v.isInfinite
+  case _ => false
 }

--- a/core/src/test/scala/latis/util/BoundsSuite.scala
+++ b/core/src/test/scala/latis/util/BoundsSuite.scala
@@ -24,7 +24,7 @@ class BoundsSuite extends FunSuite {
     assert(bounds.contains(-1))
   }
 
-  test("does not contain upper bound") {
+  test("default bounds does not contain upper bound") {
     assert(!bounds.contains(2))
   }
 
@@ -37,29 +37,39 @@ class BoundsSuite extends FunSuite {
   }
 
   test("point contains") {
-    assert(Bounds.inclusive(0, 0).contains(0))
+    assert(PointBounds(0).contains(0))
   }
 
   test("point does not contain") {
-    assert(! Bounds.inclusive(0, 0).contains(1))
+    assert(! PointBounds(0).contains(1))
+  }
+
+  test("equal inclusive bounds contains") {
+    assert(Bounds.of(0, 0, true).contains(0))
+  }
+
+  test("equal exclusive bounds does not contain") {
+    assert(! Bounds.of(0, 0).contains(0))
   }
 
   test("empty if equal and not inclusive") {
     assert(Bounds.of(0, 0).isEmpty)
   }
 
-  test("invalid if NaN") {
+  test("empty if NaN") {
     assert(Bounds.of(Double.NaN, 0d).isEmpty)
     assert(Bounds.of(0d, Double.NaN).isEmpty)
     assert(Bounds.of(Double.NaN, Double.NaN).isEmpty)
   }
 
   test("infinite bounds") {
-    val infBounds = Bounds.of(Double.NegativeInfinity, Double.PositiveInfinity)
-    assert(infBounds.contains(0))
+    val infBounds = Bounds.unbounded[Double]
+    assert(infBounds.contains(0.0))
     assert(infBounds.contains(Double.NegativeInfinity))
-    assert(!infBounds.contains(Double.PositiveInfinity))
+    assert(infBounds.contains(Double.PositiveInfinity))
     assert(!infBounds.contains(Double.NaN))
+    assert(infBounds.constrainLower(1.0).contains(1.0)) //inclusive
+    assert(! infBounds.constrainUpper(1.0).contains(1.0)) //exclusive
   }
 
   test("string bounds") {
@@ -78,7 +88,7 @@ class BoundsSuite extends FunSuite {
       case NonEmptyBounds(ClosedBound(l), OpenBound(u)) =>
         assert(l == -1D)
         assert(u == 2D)
-      case _ => fail("Expected bounds [)")
+      case _ => fail("unexpected bounds")
     }
   }
 
@@ -119,7 +129,15 @@ class BoundsSuite extends FunSuite {
   }
 
   test("Bound equality") {
-    assert(bounds == Bounds.of(-1, 2))
+    assertEquals(bounds, Bounds.of(-1.0, 2.0))
+  }
+
+  test("empty Bounds equality") {
+    assertEquals(Bounds.empty[Int], Bounds.empty[Int])
+  }
+
+  test("unbounded Bounds equality") {
+    assertEquals(Bounds.unbounded[Int], Bounds.unbounded[Int])
   }
 
   test("to string") {


### PR DESCRIPTION
This also uses cats `PartialOrder` instead of scala's total `Ordering`.