### PR TITLE
Fix OnChange bug

### DIFF
--- a/core/src/main/scala/latis/ops/OnChange.scala
+++ b/core/src/main/scala/latis/ops/OnChange.scala
@@ -48,7 +48,7 @@ class OnChange private (variableID: Identifier) extends StreamOperation {
             } else {
               // Unchanged, make sure to keep last sample to preserve coverage
               tail.pull.peek1.flatMap {
-                case Some(_) => go(curr, tail)
+                case Some((_, tail)) => go(curr, tail)
                 case None    => Pull.output1(curr) >> Pull.done
               }
             }


### PR DESCRIPTION
The issue was reusing the stream that was peeked upon rather than using the stream returned after peeking.

In the cases where this bug was observable, peeking ran the effect that produced the next chunk of data. Because we used the original stream to continue the iteration, the next uncons ran this effect again. Depending on the nature of the effect, strange things might happen.

By using the stream returned after peeking, the effect that produces the chunk is run once and when we uncons we get the chunk without running the effect again.