### PR TITLE
Operation to convert yyyyDDD integer to string

### DIFF
--- a/core/src/main/scala/latis/ops/TimeToString.scala
+++ b/core/src/main/scala/latis/ops/TimeToString.scala
@@ -1,0 +1,48 @@
+package latis.ops
+
+import cats.syntax.all.* 
+
+import latis.data.*
+import latis.data.Data.*
+import latis.model.*
+import latis.util.Identifier
+import latis.util.LatisException
+
+case class TimeToString(id: Identifier) extends MapOperation {
+  def mapFunction(model: DataType): Sample => Sample = {
+    case Sample(domain, RangeData(time)) =>
+      val newtime = time match {
+        case Integer(t) =>
+          val timestring: String = t.toString
+          StringValue(timestring)
+        case _ => 
+          throw LatisException("Invalid range type for TimeToString")
+      }
+      Sample(domain, Seq(newtime))
+  }
+
+  override def applyToModel(model: DataType): Either[LatisException, DataType] = {
+    Either.catchOnly[LatisException](model.map {
+      case s: Scalar if (s.id == id) =>
+        val md = s.metadata + ("type", StringValueType.toString) + ("units", "yyyyDDD")
+
+        Scalar.fromMetadata(md) match {
+          case Left(err) => 
+            println(err)
+            throw LatisException("Error updating scalar with new metadata")
+          case Right(d) => d
+        }
+      case dt => dt
+    })
+  }
+}
+
+object TimeToString {
+  def builder: OperationBuilder = (args: List[String]) => fromArgs(args)
+
+  def fromArgs(args: List[String]): Either[LatisException, TimeToString] = args match {
+    case arg :: Nil =>
+      Either.fromOption(Identifier.fromString(arg), LatisException(s"'$arg' is not a valid identifier")).map(TimeToString(_))
+    case _ => Left(LatisException("TimeToString requires one argument"))
+  }
+}

--- a/core/src/test/scala/latis/ops/TimeToStringSuite.scala
+++ b/core/src/test/scala/latis/ops/TimeToStringSuite.scala
@@ -1,0 +1,49 @@
+package latis.ops
+
+import munit.CatsEffectSuite
+
+import latis.data.*
+import latis.dataset.MemoizedDataset
+import latis.metadata.Metadata
+import latis.model.*
+import latis.util.Identifier.*
+
+class TimeToStringSuite extends CatsEffectSuite {
+
+  def mockDataset: MemoizedDataset = {
+    val metadata: Metadata = Metadata(id"MockDataset") + ("title" -> "Mock Dataset")
+    val model: DataType = {
+      Scalar.fromMetadata(Metadata(id"time") + ("type" -> "int") + ("units" -> "days since 1975")).fold(fail("Failed to construct model", _), identity)
+    }
+    
+    val data: MemoizedFunction = SeqFunction(
+      Seq(
+        Sample(DomainData(), RangeData(1955001)),
+        Sample(DomainData(), RangeData(2004322)),
+        Sample(DomainData(), RangeData(2026102)),
+        Sample(DomainData(), RangeData(2025120))
+      )
+    )
+    new MemoizedDataset(metadata, model, data)
+  }
+
+  test("convert a time int to a string") {
+    val ds = mockDataset.withOperation(TimeToString(id"time"))
+
+    ds.model match {
+      case s: Scalar =>
+        assertEquals(s.units, Option("yyyyDDD"))
+        assertEquals(s.valueType, StringValueType)
+      case _ => fail("unexpected model")
+    }
+
+    ds.samples.compile.toList.assertEquals(
+      List(
+        Sample(List(), List("1955001")),
+        Sample(List(), List("2004322")),
+        Sample(List(), List("2026102")),
+        Sample(List(), List("2025120"))
+      )
+    )
+  }
+}


### PR DESCRIPTION
Extends a `mapOperation` to convert a time integer to a string, given the id of the time value. The operation converts the integer to a string and updates the type and the units of the scalar to be `StringValueType` and "yyyyDDD".

For testing I created a mock dataset composed of `Sample(DomainData(), RangeData(<intTime>)`, and checked that the integer was converted to a string and the units and type of the model's scalars were updated appropriately.