### PR TITLE
Change dap2 service API and dsl to use CountAggregation2

### DIFF
--- a/core/src/main/scala/latis/dsl/package.scala
+++ b/core/src/main/scala/latis/dsl/package.scala
@@ -57,7 +57,7 @@ package object dsl {
     def take(n: Int): Dataset                      = dataset.withOperation(Take(n))
     def takeRight(n: Int): Dataset                 = dataset.withOperation(TakeRight(n))
     def transpose(): Dataset                       = dataset.withOperation(Transpose())
-    def count(): Dataset                           = dataset.withOperation(CountAggregation())
+    def count(): Dataset                           = dataset.withOperation(CountAggregation2())
     def countBy(id: Identifier, ids: Identifier*): Dataset =
       dataset.withOperation(new CountBy(NonEmptyList.of(id, ids *)))
 

--- a/core/src/main/scala/latis/ops/Aggregation2.scala
+++ b/core/src/main/scala/latis/ops/Aggregation2.scala
@@ -17,14 +17,15 @@ import latis.util.LatisException
  * aggregating the results of a Group Operation.
  */
 trait Aggregation2 extends StreamOperation { self =>
-  //TODO: replace Aggregation with this
+  //TODO: replace Aggregation with this (https://github.com/latis-data/latis3/issues/886)
+  //TODO: ensure aggregated Data is memoized
+  //TODO: be mindful of chunk sizes
 
   /** Define the function to combine samples */
   def aggregateFunction(model: DataType): Stream[IO, Sample] => IO[Data]
 
   /** Aggregate Samples and pack into a single Sample */
   override def pipe(model: DataType): Pipe[IO, Sample, Sample] =
-    //TODO: be mindful of chunking
     val aggF = aggregateFunction(model)
     samples => Stream.eval(
       aggF(samples).map(d => Sample(DomainData(), RangeData(d)))

--- a/core/src/main/scala/latis/ops/OperationRegistry.scala
+++ b/core/src/main/scala/latis/ops/OperationRegistry.scala
@@ -17,7 +17,7 @@ object OperationRegistry {
     val ops = List(
       "contains"        -> Contains.builder,
       "convertTime"     -> ConvertTime.builder,
-      "count"           -> CountAggregation.builder,
+      "count"           -> CountAggregation2.builder,
       "countBy"         -> CountBy.builder,
       "curry"           -> Curry.builder,
       "curryRight"      -> CurryRight.builder,


### PR DESCRIPTION
The `count()` function in the LaTIS dap2 service interface, which has used `CountAggregation`, has been an order of magnitude slower than `CountAggregation2` in some cases. The latter uses an effectful Stream which better aligns with our current paradigm. 

This changes the `OperationRegistry` and `dsl` to point `count()` to `CountAggregation2`. We'll take on the bigger replacement of `Aggregation` in  #886.