### PR TITLE
Avoid slow identifier validity checks during catalog rendering

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
@@ -20,7 +20,11 @@ object JsonCatalogEncoder {
         case (id, cat) => encode(cat, Some(id)) 
       }
       dss  <- catalog.datasets.compile.toList.map { dss =>
-        dss.sortBy(_.id.get).map(datasetToJson) // Note: Datasets are expected to have an id
+        // NOTE: Datasets are expected to have an identifier. Getting
+        // the identifier using the 'id' method is slow because we
+        // check that they are valid. Here we assume they are valid
+        // and just sort by the stored strings.
+        dss.sortBy(_.metadata.unsafeGet("id")).map(datasetToJson)
       }
     } yield {
       val fields = List(
@@ -33,7 +37,9 @@ object JsonCatalogEncoder {
 
   /** Provides a JSON representation of a Dataset in a catalog. */
   private def datasetToJson(dataset: Dataset): Json = {
-    val id = dataset.id.map(_.asString).getOrElse("unknown")
+    // NOTE: Getting identifier via metadata to avoid slow valid
+    // identifier check.
+    val id = dataset.metadata.unsafeGet("id")
     Json.obj(
       "identifier" -> id.asJson,
       "title"      -> dataset.metadata.getProperty("title", id).asJson


### PR DESCRIPTION
The JSON catalog is sorted by dataset identifier. Getting the identifier via the `id` method is slow because we check whether the identifier is valid every time, and this check is slow.

Instead, we can just get the identifier as a string from the metadata and avoid the slow validity check. This is probably fine, because presumably we wouldn't actually have datasets with invalid identifiers.

The previous version would return a 500 if we had an invalid identifier or no `id` property in the metadata (`.id.get` would throw). This version would also throw if there was no `id` property in the metadata (`.unsafeGet` would throw), but an invalid identifier would be included in the catalog. I think this is acceptable for now because we are unlikely to have any in the first place (would be nice to know for sure) and at most this would be confusing to users because there would be datasets in the catalog that can't be reached.