### PR TITLE
Add option to limit depth of nested catalogs in the JSON response

### DIFF
--- a/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/Dap2Service.scala
@@ -17,6 +17,7 @@ import org.http4s.circe.*
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Accept
 import org.http4s.scalatags.scalatagsEncoder
+import org.http4s.Query
 import org.typelevel.ci.*
 
 import latis.catalog.Catalog
@@ -45,7 +46,7 @@ class Dap2Service(catalog: Catalog, operationRegistry: OperationRegistry)
 
   /** Handles GET requests for a Catalog or Dataset. */
   private def handleGetRequest(path: Path, query: String, headers: Headers): IO[Response[IO]] = {
-    if (path.isEmpty) catalogResponse(catalog, headers)
+    if (path.isEmpty) catalogResponse(catalog, query, headers)
     else parsePath(path) match {
       case (Some(id), ext) => catalog.findDataset(id).flatMap {
         case Some(ds) =>
@@ -53,7 +54,7 @@ class Dap2Service(catalog: Catalog, operationRegistry: OperationRegistry)
           if (path.endsWithSlash) NotFound(s"Resource not found: $path")
           else datasetResponse(ds, ext, query)
         case None     => catalog.findCatalog(id).flatMap {
-          case Some(cat) => catalogResponse(cat, headers)
+          case Some(cat) => catalogResponse(cat, query, headers)
           case None      => NotFound(s"Resource not found: $path")
         }
       }
@@ -95,17 +96,26 @@ class Dap2Service(catalog: Catalog, operationRegistry: OperationRegistry)
    * If both match or there is no Accept header, JSON will be used over HTML. If none match,
    * this will respond with a NotAcceptable (406).
    */
-  private def catalogResponse(catalog: Catalog, headers: Headers): IO[Response[IO]] =
+  private def catalogResponse(
+    catalog: Catalog,
+    query: String,
+    headers: Headers
+  ): IO[Response[IO]] = {
+    val depth = Query.unsafeFromString(query).params.get("depth")
+      .flatMap(_.toIntOption)
     headers.get[Accept] match {
       case Some(accept) =>
         accept.values.map(_.mediaRange).map { mr =>
-          if (MediaType.application.json.satisfies(mr)) JsonCatalogEncoder.encode(catalog).flatMap(Ok(_)).some
-          else if (MediaType.text.html.satisfies(mr)) HtmlCatalogEncoder.encode(catalog).flatMap(Ok(_)).some
+          if (MediaType.application.json.satisfies(mr))
+            JsonCatalogEncoder.encode(catalog, depth = depth).flatMap(Ok(_)).some
+          else if (MediaType.text.html.satisfies(mr))
+            HtmlCatalogEncoder.encode(catalog).flatMap(Ok(_)).some
           else None
         }.toList.unite.headOption //take first nonNone response
          .getOrElse(NotAcceptable("A catalogs is available only as JSON or HTML."))
       case None => JsonCatalogEncoder.encode(catalog).flatMap(Ok(_))
     }
+  }
 
   /** Provides a response for a Dataset request. */
   private def datasetResponse(

--- a/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
+++ b/dap2-service/src/main/scala/latis/service/dap2/JsonCatalogEncoder.scala
@@ -9,15 +9,33 @@ import io.circe.syntax.*
 import latis.catalog.Catalog
 import latis.dataset.Dataset
 import latis.util.Identifier
+import latis.util.Identifier.*
 
 object JsonCatalogEncoder {
 
-  /** Provides a JSON representation of a Catalog for a dap2 response. */
-  def encode(catalog: Catalog, id: Option[Identifier] = None): IO[Json] =
-    for {
+  /**
+   * Provides a JSON representation of a Catalog for a dap2 response.
+   *
+   * This method may be called recursively as the catalog is traversed.
+   * An optional depth will limit how far the recursion will proceed.
+   * A depth of 0 will result in an empty JSON object.
+   *
+   * @param catalog The Catalog to be encoded
+   * @param id Optional identifier fot the given catalog
+   */
+  def encode(
+    catalog: Catalog,
+    id: Option[Identifier] = None,
+    depth: Option[Int] = None
+  ): IO[Json] = {
+    if (depth.contains(0)) {
+      val json = id.map(id => Json.obj("identifier" -> id.asString.asJson))
+        .getOrElse(Json.obj())
+      IO.pure(json)
+    } else for {
       subs <- catalog.catalogs
-      cats <- subs.toList.sortBy(_._1).traverse { 
-        case (id, cat) => encode(cat, Some(id)) 
+      cats <- subs.toList.sortBy(_._1).traverse {
+        case (id, cat) => encode(cat, Some(id), depth.map(_ - 1))
       }
       dss  <- catalog.datasets.compile.toList.map { dss =>
         // NOTE: Datasets are expected to have an identifier. Getting
@@ -34,6 +52,7 @@ object JsonCatalogEncoder {
       ).unite //keep only fields that are defined
       Json.obj(fields *)
     }
+  }
 
   /** Provides a JSON representation of a Dataset in a catalog. */
   private def datasetToJson(dataset: Dataset): Json = {

--- a/dap2-service/src/test/scala/latis/service/dap2/JsonCatalogEncoderSuite.scala
+++ b/dap2-service/src/test/scala/latis/service/dap2/JsonCatalogEncoderSuite.scala
@@ -19,6 +19,12 @@ class JsonCatalogEncoderSuite extends CatsEffectSuite {
       .addCatalog(id"cat1", Catalog(ds1))
   }
 
+  private lazy val nestedCatalog: Catalog = {
+    Catalog()
+      .addCatalog(id"a1", Catalog().addCatalog(id"b1", catalog))
+      .addCatalog(id"a2", Catalog().addCatalog(id"b2", catalog))
+  }
+
   test("json catalog with ordering") {
     val expected =
       """{
@@ -53,13 +59,33 @@ class JsonCatalogEncoderSuite extends CatsEffectSuite {
       assertEquals(json.toString, expected)
     }
   }
-  
+
   test("dataset ordering") {
     val cat = Catalog(ds1, ds0)
     JsonCatalogEncoder.encode(cat).map { json =>
       json.hcursor.downField("dataset").downArray.downField("identifier").as[String].map { id =>
         assertEquals(id, "ds0")
       }
+    }
+  }
+
+  test("empty catalog with 0 depth") {
+    JsonCatalogEncoder.encode(nestedCatalog, depth = Some(0)).map { json =>
+      val empty = json.asObject.map(obj => obj.isEmpty)
+      assert(empty.contains(true))
+    }
+  }
+
+  test("catalog depth of 3") {
+    JsonCatalogEncoder.encode(nestedCatalog, depth = Some(3)).map { json =>
+      val cat1 = json.hcursor
+        .downField("catalog")
+        .downArray.downField("catalog")
+        .downArray.downField("catalog")
+      val id = cat1.downArray.downField("identifier").as[String]
+      assert(id.contains("cat1"))
+      assert(cat1.downArray.downField("dataset").failed)
+      assert(cat1.downArray.downField("catalog").failed)
     }
   }
 


### PR DESCRIPTION
This adds the option to add a `depth` query parameter when requesting any level of a dap2 catalog. A depth of 0 will result in an empty JSON object. (We may want to add the top level catalog identifier but can't yet given the design of `Catalog`.) A depth of 1 will show the datasets in the requested catalog and just the identifiers for any subcatalogs. And so on. The depth is optional so the existing behavior won't change without it.

This behavior could also be impacted by #659.

I didn't add this for the HTML output since involves manual drilling down.
